### PR TITLE
fix: table editor ID mismatch, unlimited chart series, a11y default

### DIFF
--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -981,6 +981,7 @@ ce tableau en format DSFR Chart (tableaux imbriques x/y).
 | label-field | String | \`""\` | selon type | Chemin vers les labels dans les donnees |
 | value-field | String | \`""\` | oui (sauf gauge) | Chemin vers les valeurs |
 | value-field-2 | String | \`""\` | non | 2e serie de valeurs (bar-line) |
+| value-fields | String | \`""\` | non | Series supplementaires separees par virgules (ex: \`"budget,score"\`) |
 | name | String | \`""\` | non | Noms des series en JSON : \`'["Serie 1","Serie 2"]'\` |
 | selected-palette | String | \`"categorical"\` | non | Palette : categorical, sequentialAscending, sequentialDescending, divergentAscending, divergentDescending, neutral, default |
 | unit-tooltip | String | \`""\` | non | Unite dans les info-bulles : %, EUR, etc. |
@@ -1620,12 +1621,12 @@ Guide pour choisir le type de visualisation adapte aux donnees.
 - **Quand** : comparer des categories (5-15 ideal)
 - **Champs** : label-field (categories), value-field (valeurs)
 - **Options** : \`horizontal\` (barres horizontales), \`stacked\` (empile)
-- **Supporte** : value-field-2 pour 2e serie, highlight-index
+- **Supporte** : value-field-2 ou value-fields pour N series, highlight-index
 
 ### Lignes (line)
 - **Quand** : evolution temporelle, tendances
 - **Champs** : label-field (dates/temps), value-field (valeurs)
-- **Supporte** : value-field-2 pour comparaison, x-min/x-max/y-min/y-max
+- **Supporte** : value-field-2 ou value-fields pour comparaison, x-min/x-max/y-min/y-max
 
 ### Combine barres + ligne (bar-line)
 - **Quand** : comparer 2 metriques differentes (ex: CA en barres + objectif en ligne)
@@ -1640,7 +1641,7 @@ Guide pour choisir le type de visualisation adapte aux donnees.
 ### Radar
 - **Quand** : profils multicriteres, comparaison de dimensions
 - **Champs** : label-field (criteres), value-field (scores)
-- **Supporte** : value-field-2 pour comparer 2 profils
+- **Supporte** : value-field-2 ou value-fields pour comparer plusieurs profils
 
 ### Nuage de points (scatter)
 - **Quand** : correlation entre deux variables numeriques
@@ -1665,7 +1666,9 @@ Guide pour choisir le type de visualisation adapte aux donnees.
 - **Champs** : code-field (code region), value-field
 
 ### Series multiples (bar, line, bar-line, radar)
-Utiliser value-field-2 pour une seconde serie. Definir les noms avec \`name='["Serie 1","Serie 2"]'\`.`,
+Utiliser \`value-field-2\` pour une seconde serie, ou \`value-fields\` pour plusieurs series supplementaires (separees par virgules).
+Definir les noms avec \`name='["Serie 1","Serie 2","Serie 3"]'\`.
+Exemple multi-series : \`value-field="ca" value-fields="budget,objectif" name='["CA","Budget","Objectif"]'\``,
   },
 
   dsfrColors: {

--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -322,15 +322,12 @@
           </div>
         </div>
 
-        <!-- Champs optionnels (affiches conditionnellement) -->
-        <div class="fr-select-group fr-select-group--sm fr-mt-1w" id="value-field-2-group" style="display: none;">
-          <label class="fr-label" for="value-field-2">
-            Serie 2 (optionnel)
-            <span class="fr-hint-text">Second champ pour comparaison</span>
-          </label>
-          <select class="fr-select" id="value-field-2">
-            <option value="">— Aucune (serie unique) —</option>
-          </select>
+        <!-- Series supplementaires (affiches conditionnellement) -->
+        <div id="extra-series-group" style="display: none;">
+          <div id="extra-series-container"></div>
+          <button type="button" class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-mt-1w" id="add-series-btn">
+            <i class="ri-add-line"></i> Ajouter une serie
+          </button>
         </div>
 
         <div class="fr-select-group fr-select-group--sm fr-mt-1w" id="code-field-group" style="display: none;">
@@ -519,14 +516,14 @@
       </div>
 
       <!-- Option accessibilite -->
-      <div class="config-section" id="section-a11y" style="display: none;">
+      <div class="config-section" id="section-a11y">
         <div class="fr-checkbox-group fr-checkbox-group--sm">
-          <input type="checkbox" id="a11y-toggle">
+          <input type="checkbox" id="a11y-toggle" checked>
           <label class="fr-label" for="a11y-toggle">
             <i class="ri-accessibility-line fr-mr-1w" aria-hidden="true"></i>Ajouter accessibilite
           </label>
         </div>
-        <div id="a11y-options" style="display: none; margin-left: 1.5rem; margin-top: 0.5rem;">
+        <div id="a11y-options" style="display: block; margin-left: 1.5rem; margin-top: 0.5rem;">
           <div class="fr-checkbox-group fr-checkbox-group--sm fr-mb-1w">
             <input type="checkbox" id="a11y-table" checked>
             <label class="fr-label" for="a11y-table">Tableau de donnees</label>

--- a/apps/builder/src/main.ts
+++ b/apps/builder/src/main.ts
@@ -27,6 +27,7 @@ import type { ChartType } from './state.js';
 import { setupDatalistListeners } from './ui/datalist-config.js';
 import { setupNormalizeListeners, updateMiddlewareSections } from './ui/normalize-config.js';
 import { setupFacetsListeners } from './ui/facets-config.js';
+import { addExtraSeries } from './ui/extra-series.js';
 
 // Expose functions called from inline onclick in HTML
 (window as any).toggleSection = toggleSection;
@@ -173,6 +174,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       state.queryAggregate = (e.target as HTMLInputElement).value;
     });
   }
+
+  // Extra series "add" button
+  const addSeriesBtn = document.getElementById('add-series-btn');
+  if (addSeriesBtn) addSeriesBtn.addEventListener('click', addExtraSeries);
 
   // Datalist config listeners
   setupDatalistListeners();

--- a/apps/builder/src/sources-fields.ts
+++ b/apps/builder/src/sources-fields.ts
@@ -11,15 +11,13 @@ import { state } from './state.js';
 export function populateFieldSelects(): void {
   const labelSelect = document.getElementById('label-field') as HTMLSelectElement | null;
   const valueSelect = document.getElementById('value-field') as HTMLSelectElement | null;
-  const valueSelect2 = document.getElementById('value-field-2') as HTMLSelectElement | null;
   const codeSelect = document.getElementById('code-field') as HTMLSelectElement | null;
 
-  if (!labelSelect || !valueSelect || !valueSelect2 || !codeSelect) return;
+  if (!labelSelect || !valueSelect || !codeSelect) return;
 
   // Clear
   labelSelect.innerHTML = '<option value="">\u2014 S\u00e9lectionner \u2014</option>';
   valueSelect.innerHTML = '<option value="">\u2014 S\u00e9lectionner \u2014</option>';
-  valueSelect2.innerHTML = '<option value="">\u2014 Aucune (s\u00e9rie unique) \u2014</option>';
   codeSelect.innerHTML = '<option value="">\u2014 S\u00e9lectionner \u2014</option>';
 
   state.fields.forEach(field => {
@@ -36,14 +34,6 @@ export function populateFieldSelects(): void {
     optionValue.value = field.name;
     optionValue.textContent = displayText;
     valueSelect.appendChild(optionValue);
-
-    // Only add numeric fields to serie 2
-    if (field.type === 'number') {
-      const optionValue2 = document.createElement('option');
-      optionValue2.value = field.name;
-      optionValue2.textContent = displayText;
-      valueSelect2.appendChild(optionValue2);
-    }
 
     // Add string/number fields to code select (department codes can be strings like "2A" or numbers)
     if (field.type === 'string' || field.type === 'number') {
@@ -87,4 +77,35 @@ export function populateFieldSelects(): void {
   if (stringField) labelSelect.value = stringField.name;
   if (numberField) valueSelect.value = numberField.name;
   if (codeField) codeSelect.value = codeField.name;
+
+  // Re-populate existing extra series selects
+  refreshExtraSeriesSelects();
+}
+
+/**
+ * Build options HTML for an extra series field select.
+ */
+export function buildSeriesFieldOptions(): string {
+  let html = '<option value="">\u2014 S\u00e9lectionner \u2014</option>';
+  state.fields.forEach(field => {
+    const displayText = field.displayName
+      ? `${field.displayName} (${field.type})`
+      : `${field.name} (${field.type})`;
+    html += `<option value="${field.name}">${displayText}</option>`;
+  });
+  return html;
+}
+
+/**
+ * Refresh all extra series field selects with current fields.
+ */
+export function refreshExtraSeriesSelects(): void {
+  const container = document.getElementById('extra-series-container');
+  if (!container) return;
+  const selects = container.querySelectorAll<HTMLSelectElement>('.extra-series-field');
+  selects.forEach(select => {
+    const currentValue = select.value;
+    select.innerHTML = buildSeriesFieldOptions();
+    if (currentValue) select.value = currentValue;
+  });
 }

--- a/apps/builder/src/sources.ts
+++ b/apps/builder/src/sources.ts
@@ -10,6 +10,7 @@ import { selectChartType } from './ui/chart-type-selector.js';
 import { populateFieldSelects } from './sources-fields.js';
 import { generateCodeForLocalData } from './ui/code-generator.js';
 import { updateMiddlewareSections, autoEnableNormalizeForGrist } from './ui/normalize-config.js';
+import { restoreExtraSeriesFromState } from './ui/extra-series.js';
 
 /**
  * Load saved sources from localStorage and populate the dropdown.
@@ -227,11 +228,7 @@ export function loadFieldsFromLocalData(): void {
     if (generationModeSection) generationModeSection.style.display = 'none';
   }
 
-  // Show/hide accessibility option (available for dynamic sources)
-  const a11ySection = document.getElementById('section-a11y') as HTMLElement | null;
-  if (a11ySection) {
-    a11ySection.style.display = (source?.type === 'grist' || source?.type === 'api') ? 'block' : 'none';
-  }
+  // Accessibility option is always visible (works for all source types)
   updateMiddlewareSections();
 
   showDataPreviewButton();
@@ -389,17 +386,18 @@ export function loadFavoriteState(): void {
       setTimeout(() => {
         const labelSelect = document.getElementById('label-field') as HTMLSelectElement | null;
         const valueSelect = document.getElementById('value-field') as HTMLSelectElement | null;
-        const valueSelect2 = document.getElementById('value-field-2') as HTMLSelectElement | null;
         const codeSelect = document.getElementById('code-field') as HTMLSelectElement | null;
         const aggSelect = document.getElementById('aggregation') as HTMLSelectElement | null;
         const sortSelect = document.getElementById('sort-order') as HTMLSelectElement | null;
 
         if (state.labelField && labelSelect) labelSelect.value = state.labelField;
         if (state.valueField && valueSelect) valueSelect.value = state.valueField;
-        if (state.valueField2 && valueSelect2) valueSelect2.value = state.valueField2;
         if (state.codeField && codeSelect) codeSelect.value = state.codeField;
         if (state.aggregation && aggSelect) aggSelect.value = state.aggregation;
         if (state.sortOrder && sortSelect) sortSelect.value = state.sortOrder;
+
+        // Restore extra series (migrates old valueField2 if needed)
+        restoreExtraSeriesFromState();
       }, 0);
     }
 

--- a/apps/builder/src/state.ts
+++ b/apps/builder/src/state.ts
@@ -86,6 +86,12 @@ export interface Field {
 // Source is imported from @dsfr-data/shared (unified interface)
 export type { Source } from '@dsfr-data/shared';
 
+/** An extra data series configuration */
+export interface ExtraSeries {
+  field: string;
+  label: string;
+}
+
 /** A single data record (aggregated result) */
 export interface DataRecord {
   [key: string]: unknown;
@@ -115,6 +121,7 @@ export interface BuilderState {
   labelField: string;
   valueField: string;
   valueField2: string;
+  extraSeries: ExtraSeries[];
   codeField: string;
   aggregation: AggregationType;
   sortOrder: SortOrder;
@@ -156,6 +163,7 @@ export const state: BuilderState = {
   labelField: '',
   valueField: '',
   valueField2: '',
+  extraSeries: [],
   codeField: '',
   aggregation: 'avg',
   sortOrder: 'desc',
@@ -194,7 +202,7 @@ export const state: BuilderState = {
     sort: 'count',
     hideEmpty: false,
   },
-  a11yEnabled: false,
+  a11yEnabled: true,
   a11yTable: true,
   a11yDownload: true,
   a11yDescription: '',

--- a/apps/builder/src/ui/chart-renderer.ts
+++ b/apps/builder/src/ui/chart-renderer.ts
@@ -206,9 +206,6 @@ export function renderChart(): void {
 
   const labels = state.data.map(d => (d[state.labelField] as string) || 'N/A');
   const values = state.data.map(d => Math.round(((d.value as number) || 0) * 100) / 100);
-  const values2 = state.valueField2
-    ? state.data.map(d => Math.round(((d.value2 as number) || 0) * 100) / 100)
-    : null;
 
   // Determine chart type for Chart.js
   let chartType: string = state.chartType;
@@ -270,17 +267,21 @@ export function renderChart(): void {
     fill: state.chartType !== 'line',
   }];
 
-  // Add second series if defined
-  if (values2 && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType)) {
+  // Add extra series if defined
+  const activeExtraSeries = state.extraSeries.filter(s => s.field && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType));
+  const extraColors = ['#E1000F', '#18753C', '#D64D00', '#0063CB', '#6E445A', '#009081', '#C08C36'];
+  activeExtraSeries.forEach((s, i) => {
+    const seriesValues = state.data.map(d => Math.round(((d[`value${i + 2}`] as number) || 0) * 100) / 100);
+    const seriesColor = extraColors[i % extraColors.length];
     datasets.push({
-      label: state.valueField2,
-      data: values2,
-      backgroundColor: state.color2,
-      borderColor: state.color2,
+      label: s.label || s.field,
+      data: seriesValues,
+      backgroundColor: seriesColor,
+      borderColor: seriesColor,
       borderWidth: state.chartType === 'line' ? 2 : 1,
       fill: false,
     });
-  }
+  });
 
   state.chartInstance = new (ChartJS())(canvas, {
     type: chartType,

--- a/apps/builder/src/ui/chart-type-selector.ts
+++ b/apps/builder/src/ui/chart-type-selector.ts
@@ -81,12 +81,13 @@ export function selectChartType(type: ChartType): void {
 
   // Types that support multiple series: bar, horizontalBar, line, radar
   const supportsMultiSeries = ['bar', 'horizontalBar', 'line', 'radar'].includes(type);
-  const valueField2Group = document.getElementById('value-field-2-group') as HTMLElement | null;
-  if (valueField2Group) valueField2Group.style.display = supportsMultiSeries ? 'block' : 'none';
+  const extraSeriesGroup = document.getElementById('extra-series-group') as HTMLElement | null;
+  if (extraSeriesGroup) extraSeriesGroup.style.display = supportsMultiSeries ? 'block' : 'none';
   if (!supportsMultiSeries) {
     state.valueField2 = '';
-    const vf2Select = document.getElementById('value-field-2') as HTMLSelectElement | null;
-    if (vf2Select) vf2Select.value = '';
+    state.extraSeries = [];
+    const container = document.getElementById('extra-series-container');
+    if (container) container.innerHTML = '';
   }
 
   // Map chart needs code field for department codes

--- a/apps/builder/src/ui/code-generator.ts
+++ b/apps/builder/src/ui/code-generator.ts
@@ -372,14 +372,14 @@ export async function generateChart(): Promise<void> {
   // Get current values from form
   const labelField = document.getElementById('label-field') as HTMLSelectElement | null;
   const valueField = document.getElementById('value-field') as HTMLSelectElement | null;
-  const valueField2 = document.getElementById('value-field-2') as HTMLSelectElement | null;
   const codeField = document.getElementById('code-field') as HTMLSelectElement | null;
   const aggregation = document.getElementById('aggregation') as HTMLSelectElement | null;
   const sortOrder = document.getElementById('sort-order') as HTMLSelectElement | null;
 
   if (labelField) state.labelField = labelField.value;
   if (valueField) state.valueField = valueField.value;
-  state.valueField2 = valueField2?.value || '';
+  // Sync valueField2 from extraSeries for backward compat
+  state.valueField2 = state.extraSeries.length > 0 ? state.extraSeries[0].field : '';
   state.codeField = codeField?.value || '';
   if (aggregation) state.aggregation = aggregation.value as typeof state.aggregation;
   if (sortOrder) state.sortOrder = sortOrder.value as typeof state.sortOrder;
@@ -444,11 +444,12 @@ export async function generateChart(): Promise<void> {
     ? 'count(*) as value'
     : `${state.aggregation}(${state.valueField}) as value`;
 
-  // Handle second series if defined
-  const hasSecondSeries = state.valueField2 && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType);
-  const valueExpression2 = hasSecondSeries
-    ? `, ${state.aggregation}(${state.valueField2}) as value2`
-    : '';
+  // Handle extra series if defined
+  const activeExtraSeries = state.extraSeries.filter(s => s.field && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType));
+  let extraValueExpressions = '';
+  activeExtraSeries.forEach((s, i) => {
+    extraValueExpressions += `, ${state.aggregation}(${s.field}) as value${i + 2}`;
+  });
 
   let params: URLSearchParams;
   if (isSingleValue) {
@@ -467,7 +468,7 @@ export async function generateChart(): Promise<void> {
   } else {
     // Chart: group by label field — limit=200 to fetch all categories
     params = new URLSearchParams({
-      select: `${state.labelField}, ${valueExpression}${valueExpression2}`,
+      select: `${state.labelField}, ${valueExpression}${extraValueExpressions}`,
       group_by: state.labelField,
       order_by: `value ${state.sortOrder}`,
       limit: '200',
@@ -536,12 +537,12 @@ export function generateChartFromLocalData(): void {
   }
 
   // Aggregate local data
-  const aggregated: Record<string, { values: number[]; values2: number[]; count: number }> = {};
+  const aggregated: Record<string, { values: number[]; extraValues: number[][]; count: number }> = {};
 
   // For maps, aggregate by codeField; for other charts, by labelField
   const isMap = state.chartType === 'map';
   const groupField = isMap ? state.codeField : state.labelField;
-  const hasSecondSeries = state.valueField2 && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType);
+  const activeExtraSeries = state.extraSeries.filter(s => s.field && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType));
 
   // Apply advanced mode filter to local data
   let filteredLocal = state.localData || [];
@@ -560,12 +561,12 @@ export function generateChartFromLocalData(): void {
       const value = toNumber(record[state.valueField]);
 
       if (!aggregated[groupKey]) {
-        aggregated[groupKey] = { values: [], values2: [], count: 0 };
+        aggregated[groupKey] = { values: [], extraValues: activeExtraSeries.map(() => []), count: 0 };
       }
       aggregated[groupKey].values.push(value);
-      if (hasSecondSeries) {
-        aggregated[groupKey].values2.push(toNumber(record[state.valueField2]));
-      }
+      activeExtraSeries.forEach((s, i) => {
+        aggregated[groupKey].extraValues[i].push(toNumber(record[s.field]));
+      });
       aggregated[groupKey].count++;
     });
   }
@@ -593,10 +594,12 @@ export function generateChartFromLocalData(): void {
       result[state.labelField] = groupKey;
     }
 
-    // Second series
-    if (hasSecondSeries && data.values2.length > 0) {
-      result.value2 = applyAgg(data.values2, data.count);
-    }
+    // Extra series
+    activeExtraSeries.forEach((_, i) => {
+      if (data.extraValues[i].length > 0) {
+        result[`value${i + 2}`] = applyAgg(data.extraValues[i], data.count);
+      }
+    });
 
     return result;
   });
@@ -817,17 +820,19 @@ datalist.onSourceData(data);
   const labels = state.data.map(d => (d[state.labelField] as string) || 'N/A');
   const values = state.data.map(d => Math.round(((d.value as number) || 0) * 100) / 100);
 
-  const hasSecondSeries = state.valueField2 && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType);
-  const values2 = hasSecondSeries
-    ? state.data.map(d => Math.round(((d.value2 as number) || 0) * 100) / 100)
-    : null;
+  const activeExtraSeries = state.extraSeries.filter(s => s.field && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType));
+  const allSeriesValues: number[][] = [values];
+  const allSeriesNames: string[] = [state.valueField];
+
+  activeExtraSeries.forEach((s, i) => {
+    allSeriesValues.push(state.data.map(d => Math.round(((d[`value${i + 2}`] as number) || 0) * 100) / 100));
+    allSeriesNames.push(s.label || s.field);
+  });
 
   const dsfrTag = DSFR_TAG_MAP[state.chartType] || 'bar-chart';
   const x = JSON.stringify([labels]);
-  const y = values2 ? JSON.stringify([values, values2]) : JSON.stringify([values]);
-  const seriesNames = values2
-    ? JSON.stringify([state.valueField, state.valueField2])
-    : JSON.stringify([state.valueField]);
+  const y = allSeriesValues.length > 1 ? JSON.stringify(allSeriesValues) : JSON.stringify([values]);
+  const seriesNames = JSON.stringify(allSeriesNames);
 
   // Build extra attributes
   const extraAttrs: string[] = [];
@@ -868,7 +873,7 @@ export function generateOdsQueryCode(
   odsInfo: { baseUrl: string; datasetId: string },
   labelFieldPath: string,
   valueFieldPath: string
-): { queryElement: string; chartSource: string; labelField: string; valueField: string; valueField2: string } {
+): { queryElement: string; chartSource: string; labelField: string; valueField: string; valueField2: string; extraValueFields: string[] } {
   // --- dsfr-data-source attributes (fetch + server-side processing) ---
   const srcAttrs: string[] = [];
   srcAttrs.push('api-type="opendatasoft"');
@@ -887,7 +892,8 @@ export function generateOdsQueryCode(
   let selectParts: string[] = [];
   if (groupByField) selectParts.push(groupByField);
 
-  const hasSecondSeries = state.valueField2 && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType);
+  const activeExtraSeries = state.extraSeries.filter(s => s.field && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType));
+  const extraValueFields: string[] = [];
 
   if (state.advancedMode && state.queryAggregate) {
     // Advanced mode: parse custom aggregation expressions
@@ -913,12 +919,13 @@ export function generateOdsQueryCode(
       selectParts.push(`${state.aggregation}(${valueFieldPath}) as ${alias}`);
       resultValueField = alias;
 
-      // Add second series aggregation
-      if (hasSecondSeries) {
-        const alias2 = `${state.valueField2}__${state.aggregation}`;
-        selectParts.push(`${state.aggregation}(${state.valueField2}) as ${alias2}`);
-        resultValueField2 = alias2;
-      }
+      // Add extra series aggregations
+      activeExtraSeries.forEach(s => {
+        const aliasN = `${s.field}__${state.aggregation}`;
+        selectParts.push(`${state.aggregation}(${s.field}) as ${aliasN}`);
+        extraValueFields.push(aliasN);
+      });
+      if (extraValueFields.length > 0) resultValueField2 = extraValueFields[0];
     }
   }
   srcAttrs.push(`select="${escapeHtml(selectParts.join(', '))}"`);
@@ -953,6 +960,7 @@ export function generateOdsQueryCode(
     labelField: groupByField,
     valueField: resultValueField,
     valueField2: resultValueField2,
+    extraValueFields,
   };
 }
 
@@ -964,7 +972,7 @@ export function generateTabularQueryCode(
   tabularInfo: { baseUrl: string; resourceId: string },
   labelFieldPath: string,
   valueFieldPath: string
-): { queryElement: string; chartSource: string; labelField: string; valueField: string; valueField2: string } {
+): { queryElement: string; chartSource: string; labelField: string; valueField: string; valueField2: string; extraValueFields: string[] } {
   // --- dsfr-data-source attributes (fetch + auto-pagination) ---
   const srcAttrs: string[] = [];
   srcAttrs.push('api-type="tabular"');
@@ -986,7 +994,8 @@ export function generateTabularQueryCode(
   let resultValueField2 = '';
   let aggregateExpr: string;
 
-  const hasSecondSeries = state.valueField2 && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType);
+  const activeExtraSeries = state.extraSeries.filter(s => s.field && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType));
+  const extraValueFields: string[] = [];
 
   if (state.advancedMode && state.queryAggregate) {
     aggregateExpr = state.queryAggregate;
@@ -997,12 +1006,13 @@ export function generateTabularQueryCode(
     aggregateExpr = `${valueFieldPath}:${state.aggregation}`;
     resultValueField = `${valueFieldPath}__${state.aggregation}`;
 
-    if (hasSecondSeries) {
-      const vf2Info = state.fields.find(f => f.name === state.valueField2);
-      const valueField2Path = vf2Info?.fullPath || state.valueField2;
-      aggregateExpr += `, ${valueField2Path}:${state.aggregation}`;
-      resultValueField2 = `${valueField2Path}__${state.aggregation}`;
-    }
+    activeExtraSeries.forEach(s => {
+      const info = state.fields.find(f => f.name === s.field);
+      const path = info?.fullPath || s.field;
+      aggregateExpr += `, ${path}:${state.aggregation}`;
+      extraValueFields.push(`${path}__${state.aggregation}`);
+    });
+    if (extraValueFields.length > 0) resultValueField2 = extraValueFields[0];
   }
   qAttrs.push(`aggregate="${escapeHtml(aggregateExpr)}"`);
 
@@ -1034,6 +1044,7 @@ export function generateTabularQueryCode(
     labelField: groupByField,
     valueField: resultValueField,
     valueField2: resultValueField2,
+    extraValueFields,
   };
 }
 
@@ -1046,7 +1057,7 @@ export function generateDsfrDataQueryCode(
   sourceId: string,
   labelFieldPath: string,
   valueFieldPath: string
-): { queryElement: string; chartSource: string; labelField: string; valueField: string; valueField2: string } {
+): { queryElement: string; chartSource: string; labelField: string; valueField: string; valueField2: string; extraValueFields: string[] } {
   const attrs: string[] = [];
   attrs.push(`source="${sourceId}"`);
 
@@ -1067,10 +1078,8 @@ export function generateDsfrDataQueryCode(
   let resultValueField: string;
   let resultValueField2 = '';
 
-  const hasSecondSeries = state.valueField2 && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType);
-  // Resolve valueField2 path for dynamic mode
-  const vf2Info = state.fields.find(f => f.name === state.valueField2);
-  const valueField2Path = vf2Info?.fullPath || state.valueField2;
+  const activeExtraSeries = state.extraSeries.filter(s => s.field && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType));
+  const extraValueFields: string[] = [];
 
   if (state.advancedMode && state.queryAggregate) {
     aggregateExpr = state.queryAggregate;
@@ -1080,11 +1089,14 @@ export function generateDsfrDataQueryCode(
     resultValueField = sortField;
   } else {
     aggregateExpr = `${valueFieldPath}:${state.aggregation}`;
-    // Add second series aggregation
-    if (hasSecondSeries) {
-      aggregateExpr += `, ${valueField2Path}:${state.aggregation}`;
-      resultValueField2 = `${valueField2Path}__${state.aggregation}`;
-    }
+    // Add extra series aggregations
+    activeExtraSeries.forEach(s => {
+      const info = state.fields.find(f => f.name === s.field);
+      const path = info?.fullPath || s.field;
+      aggregateExpr += `, ${path}:${state.aggregation}`;
+      extraValueFields.push(`${path}__${state.aggregation}`);
+    });
+    if (extraValueFields.length > 0) resultValueField2 = extraValueFields[0];
     sortField = `${valueFieldPath}__${state.aggregation}`;
     resultValueField = sortField;
   }
@@ -1112,6 +1124,7 @@ export function generateDsfrDataQueryCode(
     labelField: groupByField,
     valueField: resultValueField,
     valueField2: resultValueField2,
+    extraValueFields,
   };
 }
 
@@ -1202,7 +1215,7 @@ ${middlewareHtml}
     : labelFieldPath;
 
   // Generate dsfr-data-query for aggregation, sorting, filtering
-  const { queryElement, chartSource, labelField: queryLabelField, valueField: queryValueField, valueField2: queryValueField2 } =
+  const { queryElement, chartSource, labelField: queryLabelField, valueField: queryValueField, valueField2: queryValueField2, extraValueFields: queryExtraVFs } =
     generateDsfrDataQueryCode(querySourceId, groupByPath, valueFieldPath);
 
   // Map palette
@@ -1213,8 +1226,19 @@ ${middlewareHtml}
   // Map-specific attributes
   const codeFieldAttr = isMap && state.codeField ? `\n    code-field="${state.codeField}"` : '';
 
-  // Second series attribute
-  const valueField2Attr = queryValueField2 ? `\n    value-field-2="${queryValueField2}"` : '';
+  // Extra series attributes
+  const extraVFs = queryExtraVFs;
+  let extraFieldsAttr = '';
+  let nameAttr = `name="${escapeHtml(state.title || state.valueField)}"`;
+
+  if (extraVFs && extraVFs.length > 0) {
+    extraFieldsAttr = `\n    value-fields="${extraVFs.join(',')}"`;
+    // Build series names from labels
+    const seriesNames = [state.valueField, ...state.extraSeries.filter(s => s.field).map(s => s.label || s.field)];
+    nameAttr = `name='${escapeSingleQuotes(JSON.stringify(seriesNames))}'`;
+  } else if (queryValueField2) {
+    extraFieldsAttr = `\n    value-field-2="${queryValueField2}"`;
+  }
 
   const code = `<!-- Graphique dynamique genere avec dsfr-data Builder -->
 <!-- Source : ${escapeHtml(source.name)} (chargement dynamique depuis ${gristHost}) -->
@@ -1247,8 +1271,8 @@ ${middlewareHtml}${queryElement}
     source="${chartSource}"
     type="${state.chartType === 'horizontalBar' ? 'bar' : state.chartType === 'doughnut' ? 'pie' : state.chartType}"${dsfrChartAttrs()}${codeFieldAttr}
     label-field="${queryLabelField}"
-    value-field="${queryValueField}"${valueField2Attr}
-    name="${escapeHtml(state.title || state.valueField)}"
+    value-field="${queryValueField}"${extraFieldsAttr}
+    ${nameAttr}
     selected-palette="${palette}">
   </dsfr-data-chart>${generateA11yElement(chartSource, 'chart')}
 </div>`;
@@ -1466,13 +1490,12 @@ ${middlewareHtml}
   let queryLabelField: string;
   let queryValueField: string;
   let queryValueField2 = '';
+  let queryExtraVFs: string[] = [];
   let sourceElement: string;
   let middlewareHtml = '';
   let facetsHtml = '';
 
   if (provider.id === 'opendatasoft' && resourceIds?.datasetId) {
-    // ODS source: use dsfr-data-source + dsfr-data-query for
-    // server-side aggregation and automatic pagination (limit > 100)
     const odsInfo = { baseUrl: apiBaseUrl, datasetId: resourceIds.datasetId };
     const result = generateOdsQueryCode(odsInfo, groupByPath, valueFieldPath);
     queryElement = result.queryElement;
@@ -1480,13 +1503,11 @@ ${middlewareHtml}
     queryLabelField = result.labelField;
     queryValueField = result.valueField;
     queryValueField2 = result.valueField2 || '';
+    queryExtraVFs = result.extraValueFields;
     sourceElement = '';
-    // Facets after ODS query (filters aggregated results)
     const facets = generateFacetsElement(chartSource);
     if (facets.element) { facetsHtml = facets.element; chartSource = facets.finalSourceId; }
   } else if (provider.id === 'tabular' && resourceIds?.resourceId) {
-    // Tabular source: use dsfr-data-source + dsfr-data-query for
-    // automatic pagination (up to 50K records) and client-side aggregation
     const tabularInfo = { baseUrl: apiBaseUrl, resourceId: resourceIds.resourceId };
     const result = generateTabularQueryCode(tabularInfo, groupByPath, valueFieldPath);
     queryElement = result.queryElement;
@@ -1494,12 +1515,11 @@ ${middlewareHtml}
     queryLabelField = result.labelField;
     queryValueField = result.valueField;
     queryValueField2 = result.valueField2 || '';
+    queryExtraVFs = result.extraValueFields;
     sourceElement = '';
-    // Facets after Tabular query (filters aggregated results)
     const facets = generateFacetsElement(chartSource);
     if (facets.element) { facetsHtml = facets.element; chartSource = facets.finalSourceId; }
   } else {
-    // Non-ODS/Tabular source: use dsfr-data-source + dsfr-data-query (generic, client-side)
     const mw = generateMiddlewareElements('chart-data');
     middlewareHtml = mw.elements;
     const result = generateDsfrDataQueryCode(mw.finalSourceId, groupByPath, valueFieldPath);
@@ -1508,6 +1528,7 @@ ${middlewareHtml}
     queryLabelField = result.labelField;
     queryValueField = result.valueField;
     queryValueField2 = result.valueField2 || '';
+    queryExtraVFs = result.extraValueFields;
     sourceElement = `
   <!-- Source de donnees API -->
   <dsfr-data-source
@@ -1524,8 +1545,17 @@ ${middlewareHtml}
   // Map-specific attributes
   const codeFieldAttr = isMap && state.codeField ? `\n    code-field="${state.codeField}"` : '';
 
-  // Second series attribute
-  const valueField2Attr = queryValueField2 ? `\n    value-field-2="${queryValueField2}"` : '';
+  // Extra series attributes
+  let extraFieldsAttr = '';
+  let nameAttr = `name="${escapeHtml(state.title || state.valueField)}"`;
+
+  if (queryExtraVFs.length > 0) {
+    extraFieldsAttr = `\n    value-fields="${queryExtraVFs.join(',')}"`;
+    const seriesNames = [state.valueField, ...state.extraSeries.filter(s => s.field).map(s => s.label || s.field)];
+    nameAttr = `name='${escapeSingleQuotes(JSON.stringify(seriesNames))}'`;
+  } else if (queryValueField2) {
+    extraFieldsAttr = `\n    value-field-2="${queryValueField2}"`;
+  }
 
   const code = `<!-- Graphique dynamique genere avec dsfr-data Builder -->
 <!-- Source : ${escapeHtml(source.name)} (chargement dynamique) -->
@@ -1550,8 +1580,8 @@ ${sourceElement}${middlewareHtml}${queryElement}${facetsHtml}
     source="${chartSource}"
     type="${state.chartType === 'horizontalBar' ? 'bar' : state.chartType === 'doughnut' ? 'pie' : state.chartType}"${dsfrChartAttrs()}${codeFieldAttr}
     label-field="${queryLabelField}"
-    value-field="${queryValueField}"${valueField2Attr}
-    name="${escapeHtml(state.title || state.valueField)}"
+    value-field="${queryValueField}"${extraFieldsAttr}
+    ${nameAttr}
     selected-palette="${palette}">
   </dsfr-data-chart>${generateA11yElement(chartSource, 'chart')}
 </div>`;
@@ -1818,16 +1848,24 @@ loadMap();
   }
 
   // Build DSFR Chart type and extra attributes
-  const hasSecondSeries = state.valueField2 && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType);
+  const activeExtraSeriesCode = state.extraSeries.filter(s => s.field && ['bar', 'horizontalBar', 'line', 'radar'].includes(state.chartType));
   const dsfrTag = DSFR_TAG_MAP[state.chartType] || 'bar-chart';
 
   const extraAttrs: string[] = [];
   if (state.chartType === 'horizontalBar') extraAttrs.push('horizontal');
   if (state.chartType === 'pie') extraAttrs.push('fill');
 
-  const seriesNames = hasSecondSeries
-    ? JSON.stringify([state.valueField, state.valueField2])
+  const seriesNames = activeExtraSeriesCode.length > 0
+    ? JSON.stringify([state.valueField, ...activeExtraSeriesCode.map(s => s.label || s.field)])
     : JSON.stringify([state.valueField]);
+
+  // Generate extra series extraction code
+  const extraSeriesExtractCode = activeExtraSeriesCode.map((_, i) =>
+    `\n  const values${i + 2} = data.map(d => Math.round((d.value${i + 2} || 0) * 100) / 100);`
+  ).join('');
+  const allValuesArrayCode = activeExtraSeriesCode.length > 0
+    ? `JSON.stringify([values, ${activeExtraSeriesCode.map((_, i) => `values${i + 2}`).join(', ')}])`
+    : 'JSON.stringify([values])';
 
   const code = `<!-- Graphique genere avec dsfr-data Builder -->
 
@@ -1853,10 +1891,9 @@ async function loadChart() {
   const data = await fetchAllODS(API_URL);
 
   const labels = data.map(d => d['${state.labelField}'] || 'N/A');
-  const values = data.map(d => Math.round((d.value || 0) * 100) / 100);${hasSecondSeries ? `
-  const values2 = data.map(d => Math.round((d.value2 || 0) * 100) / 100);` : ''}
+  const values = data.map(d => Math.round((d.value || 0) * 100) / 100);${extraSeriesExtractCode}
 
-  const y = ${hasSecondSeries ? 'JSON.stringify([values, values2])' : 'JSON.stringify([values])'};
+  const y = ${allValuesArrayCode};
 
   var el = document.createElement('${dsfrTag}');
   el.setAttribute('x', JSON.stringify([labels]));

--- a/apps/builder/src/ui/extra-series.ts
+++ b/apps/builder/src/ui/extra-series.ts
@@ -1,0 +1,155 @@
+/**
+ * Extra series management for multi-series charts.
+ * Handles adding, removing, and rendering extra series field selectors.
+ */
+
+import { state } from '../state.js';
+import { buildSeriesFieldOptions } from '../sources-fields.js';
+
+let seriesCounter = 0;
+
+/**
+ * Add a new extra series to the UI and state.
+ */
+export function addExtraSeries(): void {
+  seriesCounter++;
+  const index = state.extraSeries.length;
+  state.extraSeries.push({ field: '', label: '' });
+
+  const container = document.getElementById('extra-series-container');
+  if (!container) return;
+
+  const row = document.createElement('div');
+  row.className = 'extra-series-row fr-mt-1w';
+  row.dataset.seriesIndex = String(index);
+  row.style.cssText = 'display: flex; gap: 0.5rem; align-items: flex-end;';
+
+  row.innerHTML = `
+    <div class="fr-select-group fr-select-group--sm" style="flex: 1; margin-bottom: 0;">
+      <label class="fr-label" for="extra-series-field-${seriesCounter}">
+        Serie ${index + 2}
+        <span class="fr-hint-text">Champ numerique</span>
+      </label>
+      <select class="fr-select extra-series-field" id="extra-series-field-${seriesCounter}">
+        ${buildSeriesFieldOptions()}
+      </select>
+    </div>
+    <div class="fr-input-group fr-input-group--sm" style="flex: 1; margin-bottom: 0;">
+      <label class="fr-label" for="extra-series-label-${seriesCounter}">
+        Libelle
+        <span class="fr-hint-text">Nom affiche (vide = nom du champ)</span>
+      </label>
+      <input type="text" class="fr-input fr-input--sm extra-series-label" id="extra-series-label-${seriesCounter}" placeholder="Nom de la serie">
+    </div>
+    <button type="button" class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline remove-series-btn" title="Supprimer cette serie" style="margin-bottom: 2px;">
+      <i class="ri-delete-bin-line"></i>
+    </button>
+  `;
+
+  // Event listeners
+  const fieldSelect = row.querySelector('.extra-series-field') as HTMLSelectElement;
+  const labelInput = row.querySelector('.extra-series-label') as HTMLInputElement;
+  const removeBtn = row.querySelector('.remove-series-btn') as HTMLButtonElement;
+
+  fieldSelect.addEventListener('change', () => {
+    const idx = getRowIndex(row);
+    if (idx >= 0 && idx < state.extraSeries.length) {
+      state.extraSeries[idx].field = fieldSelect.value;
+      syncValueField2();
+    }
+  });
+
+  labelInput.addEventListener('input', () => {
+    const idx = getRowIndex(row);
+    if (idx >= 0 && idx < state.extraSeries.length) {
+      state.extraSeries[idx].label = labelInput.value;
+    }
+  });
+
+  removeBtn.addEventListener('click', () => {
+    removeExtraSeries(row);
+  });
+
+  container.appendChild(row);
+}
+
+/**
+ * Remove an extra series row from the UI and state.
+ */
+function removeExtraSeries(row: HTMLElement): void {
+  const idx = getRowIndex(row);
+  if (idx >= 0 && idx < state.extraSeries.length) {
+    state.extraSeries.splice(idx, 1);
+  }
+  row.remove();
+  renumberSeriesRows();
+  syncValueField2();
+}
+
+/**
+ * Get the current index of a row within the container.
+ */
+function getRowIndex(row: HTMLElement): number {
+  const container = document.getElementById('extra-series-container');
+  if (!container) return -1;
+  return Array.from(container.children).indexOf(row);
+}
+
+/**
+ * Renumber series labels after removal.
+ */
+function renumberSeriesRows(): void {
+  const container = document.getElementById('extra-series-container');
+  if (!container) return;
+  Array.from(container.children).forEach((row, index) => {
+    const label = row.querySelector('.fr-select-group .fr-label');
+    if (label) {
+      const hint = label.querySelector('.fr-hint-text');
+      label.childNodes[0].textContent = `Serie ${index + 2} `;
+      if (!hint) {
+        label.innerHTML = `Serie ${index + 2} <span class="fr-hint-text">Champ numerique</span>`;
+      }
+    }
+  });
+}
+
+/**
+ * Keep state.valueField2 in sync with extraSeries[0] for backward compatibility.
+ */
+function syncValueField2(): void {
+  state.valueField2 = state.extraSeries.length > 0 ? state.extraSeries[0].field : '';
+}
+
+/**
+ * Restore extra series UI from state (e.g. when loading favorites).
+ */
+export function restoreExtraSeriesFromState(): void {
+  const container = document.getElementById('extra-series-container');
+  if (!container) return;
+  container.innerHTML = '';
+  seriesCounter = 0;
+
+  // Migrate from old valueField2 if extraSeries is empty
+  if (state.extraSeries.length === 0 && state.valueField2) {
+    state.extraSeries = [{ field: state.valueField2, label: '' }];
+  }
+
+  const seriesToRestore = [...state.extraSeries];
+  state.extraSeries = [];
+
+  seriesToRestore.forEach(series => {
+    addExtraSeries();
+    const rows = container.children;
+    const lastRow = rows[rows.length - 1];
+    if (lastRow) {
+      const fieldSelect = lastRow.querySelector('.extra-series-field') as HTMLSelectElement;
+      const labelInput = lastRow.querySelector('.extra-series-label') as HTMLInputElement;
+      if (fieldSelect && series.field) fieldSelect.value = series.field;
+      if (labelInput && series.label) labelInput.value = series.label;
+      // Update state entry
+      const idx = state.extraSeries.length - 1;
+      state.extraSeries[idx] = { ...series };
+    }
+  });
+  syncValueField2();
+}

--- a/apps/sources/src/editors/table-editor.ts
+++ b/apps/sources/src/editors/table-editor.ts
@@ -9,7 +9,7 @@ import { looksLikeNumber, toNumber, toastWarning } from '@dsfr-data/shared';
 // ============================================================
 
 export function getTableEditor(): HTMLTableElement | null {
-  return document.getElementById('manual-table') as HTMLTableElement | null;
+  return document.getElementById('source-table-editor') as HTMLTableElement | null;
 }
 
 export function getColumnCount(): number {

--- a/src/components/dsfr-data-chart.ts
+++ b/src/components/dsfr-data-chart.ts
@@ -61,6 +61,10 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
   @property({ type: String, attribute: 'value-field-2' })
   valueField2 = '';
 
+  /** Champs de valeur supplementaires, separes par des virgules (ex: 'budget,score') */
+  @property({ type: String, attribute: 'value-fields' })
+  valueFields = '';
+
   /** Noms des séries (ex: '["Série 1", "Série 2"]') */
   @property({ type: String })
   name = '';
@@ -133,30 +137,43 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
 
   // --- Data processing ---
 
+  /** Parse all value field names (value-field, value-field-2, value-fields) */
+  private _getAllValueFields(): string[] {
+    const fields = [this.valueField];
+    if (this.valueFields) {
+      fields.push(...this.valueFields.split(',').map(f => f.trim()).filter(Boolean));
+    } else if (this.valueField2) {
+      fields.push(this.valueField2);
+    }
+    return fields;
+  }
+
   private _processData(): { x: string; y: string; y2?: string; yMulti?: string; labels: string[]; values: number[]; values2: number[] } {
     if (!this._data || this._data.length === 0) {
       return { x: '[[]]', y: '[[]]', labels: [], values: [], values2: [] };
     }
 
+    const allFields = this._getAllValueFields();
     const labels: string[] = [];
-    const values: number[] = [];
-    const values2: number[] = [];
+    const allSeries: number[][] = allFields.map(() => []);
 
     for (const record of this._data) {
       labels.push(String(getByPath(record, this.labelField) ?? 'N/A'));
-      values.push(Number(getByPath(record, this.valueField)) || 0);
-
-      if (this.valueField2) {
-        values2.push(Number(getByPath(record, this.valueField2)) || 0);
+      for (let i = 0; i < allFields.length; i++) {
+        allSeries[i].push(Number(getByPath(record, allFields[i])) || 0);
       }
     }
+
+    const values = allSeries[0] || [];
+    const values2 = allSeries[1] || [];
+    const hasMulti = allFields.length > 1;
 
     return {
       x: JSON.stringify([labels]),
       y: JSON.stringify([values]),
-      y2: this.valueField2 ? JSON.stringify([values2]) : undefined,
-      // Combined y with both series for multi-series charts (bar, line, radar)
-      yMulti: this.valueField2 ? JSON.stringify([values, values2]) : undefined,
+      y2: hasMulti ? JSON.stringify([values2]) : undefined,
+      // Combined y with all series for multi-series charts (bar, line, radar)
+      yMulti: hasMulti ? JSON.stringify(allSeries) : undefined,
       labels,
       values,
       values2,
@@ -207,10 +224,8 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
       if (isMap) {
         attrs['name'] = this.valueField;
       } else {
-        const names = this.valueField2
-          ? [this.valueField, this.valueField2]
-          : [this.valueField];
-        attrs['name'] = JSON.stringify(names);
+        const allFields = this._getAllValueFields();
+        attrs['name'] = JSON.stringify(allFields);
       }
     }
 

--- a/tests/apps/builder/chart-renderer.test.ts
+++ b/tests/apps/builder/chart-renderer.test.ts
@@ -18,7 +18,7 @@ describe('builder chart-renderer', () => {
     state.data = [];
     state.labelField = 'region';
     state.valueField = 'population';
-    state.valueField2 = '';
+    state.extraSeries = [];
     state.codeField = '';
     state.title = 'Test Chart';
     state.palette = 'default';
@@ -591,10 +591,10 @@ describe('builder chart-renderer', () => {
   });
 
   describe('Multi-series', () => {
-    it('should add second dataset when valueField2 is set for bar type', async () => {
+    it('should add second dataset when extraSeries is set for bar type', async () => {
       const renderChart = await loadRenderChart();
       state.chartType = 'bar';
-      state.valueField2 = 'density';
+      state.extraSeries = [{ field: 'density', label: '' }];
       state.data = [
         { region: 'IDF', value: 100, value2: 50 },
         { region: 'PACA', value: 200, value2: 75 },
@@ -610,24 +610,24 @@ describe('builder chart-renderer', () => {
       expect(config.data.datasets[1].data).toEqual([50, 75]);
     });
 
-    it('should use color2 for the second dataset', async () => {
+    it('should use first extra color for the second dataset', async () => {
       const renderChart = await loadRenderChart();
       state.chartType = 'bar';
-      state.valueField2 = 'density';
-      state.color2 = '#FF0000';
+      state.extraSeries = [{ field: 'density', label: '' }];
       state.data = [{ region: 'IDF', value: 100, value2: 50 }];
 
       renderChart();
 
       const config = MockChart.mock.calls[0][1];
-      expect(config.data.datasets[1].backgroundColor).toBe('#FF0000');
-      expect(config.data.datasets[1].borderColor).toBe('#FF0000');
+      // First extra color in the extraColors array is '#E1000F'
+      expect(config.data.datasets[1].backgroundColor).toBe('#E1000F');
+      expect(config.data.datasets[1].borderColor).toBe('#E1000F');
     });
 
     it('should add second dataset for line type', async () => {
       const renderChart = await loadRenderChart();
       state.chartType = 'line';
-      state.valueField2 = 'density';
+      state.extraSeries = [{ field: 'density', label: '' }];
       state.data = [{ region: 'IDF', value: 100, value2: 50 }];
 
       renderChart();
@@ -637,10 +637,10 @@ describe('builder chart-renderer', () => {
       expect(config.data.datasets[1].fill).toBe(false);
     });
 
-    it('should NOT add second dataset for pie type even if valueField2 is set', async () => {
+    it('should NOT add second dataset for pie type even if extraSeries is set', async () => {
       const renderChart = await loadRenderChart();
       state.chartType = 'pie';
-      state.valueField2 = 'density';
+      state.extraSeries = [{ field: 'density', label: '' }];
       state.data = [
         { region: 'IDF', value: 100, value2: 50 },
         { region: 'PACA', value: 200, value2: 75 },
@@ -655,7 +655,7 @@ describe('builder chart-renderer', () => {
     it('should show legend when multiple datasets are present', async () => {
       const renderChart = await loadRenderChart();
       state.chartType = 'bar';
-      state.valueField2 = 'density';
+      state.extraSeries = [{ field: 'density', label: '' }];
       state.data = [{ region: 'IDF', value: 100, value2: 50 }];
 
       renderChart();

--- a/tests/apps/builder/chart-type-selector.test.ts
+++ b/tests/apps/builder/chart-type-selector.test.ts
@@ -62,9 +62,9 @@ function buildDOM(): void {
       <select id="aggregation"></select>
     </div>
 
-    <!-- Multi-series value field 2 -->
-    <div id="value-field-2-group" style="display: none;">
-      <select id="value-field-2"></select>
+    <!-- Multi-series extra series -->
+    <div id="extra-series-group" style="display: none;">
+      <div id="extra-series-container"></div>
     </div>
 
     <!-- Map code field -->
@@ -79,6 +79,7 @@ function resetState(): void {
   state.chartType = 'bar';
   state.palette = 'default';
   state.valueField2 = '';
+  state.extraSeries = [];
   state.codeField = '';
 }
 
@@ -291,17 +292,17 @@ describe('selectChartType', () => {
     const noMultiSeriesTypes: ChartType[] = ['pie', 'doughnut', 'scatter', 'kpi', 'gauge', 'map', 'datalist'];
 
     for (const type of multiSeriesTypes) {
-      it(`should show value-field-2-group for ${type}`, () => {
+      it(`should show extra-series-group for ${type}`, () => {
         selectChartType(type);
-        const group = document.getElementById('value-field-2-group') as HTMLElement;
+        const group = document.getElementById('extra-series-group') as HTMLElement;
         expect(group.style.display).toBe('block');
       });
     }
 
     for (const type of noMultiSeriesTypes) {
-      it(`should hide value-field-2-group for ${type}`, () => {
+      it(`should hide extra-series-group for ${type}`, () => {
         selectChartType(type);
-        const group = document.getElementById('value-field-2-group') as HTMLElement;
+        const group = document.getElementById('extra-series-group') as HTMLElement;
         expect(group.style.display).toBe('none');
       });
     }
@@ -310,24 +311,25 @@ describe('selectChartType', () => {
   // -----------------------------------------------------------
   // 11. Resetting valueField2 when multi-series not supported
   // -----------------------------------------------------------
-  describe('valueField2 reset', () => {
-    it('should reset state.valueField2 to empty when type does not support multi-series', () => {
-      state.valueField2 = 'population';
+  describe('extraSeries reset', () => {
+    it('should reset state.extraSeries to empty when type does not support multi-series', () => {
+      state.extraSeries = [{ field: 'population', label: '' }];
       selectChartType('pie');
+      expect(state.extraSeries).toEqual([]);
       expect(state.valueField2).toBe('');
     });
 
-    it('should reset the value-field-2 select element', () => {
-      const vf2 = document.getElementById('value-field-2') as HTMLSelectElement;
-      vf2.value = 'some-field';
+    it('should clear the extra-series-container when type does not support multi-series', () => {
+      const container = document.getElementById('extra-series-container')!;
+      container.innerHTML = '<div>some series</div>';
       selectChartType('scatter');
-      expect(vf2.value).toBe('');
+      expect(container.innerHTML).toBe('');
     });
 
-    it('should not reset valueField2 when type supports multi-series', () => {
-      state.valueField2 = 'population';
+    it('should not reset extraSeries when type supports multi-series', () => {
+      state.extraSeries = [{ field: 'population', label: '' }];
       selectChartType('bar');
-      expect(state.valueField2).toBe('population');
+      expect(state.extraSeries).toEqual([{ field: 'population', label: '' }]);
     });
   });
 
@@ -424,9 +426,9 @@ describe('selectChartType', () => {
       expect(group.style.display).toBe('block');
     });
 
-    it('should hide value-field-2-group for datalist', () => {
+    it('should hide extra-series-group for datalist', () => {
       selectChartType('datalist');
-      const group = document.getElementById('value-field-2-group') as HTMLElement;
+      const group = document.getElementById('extra-series-group') as HTMLElement;
       expect(group.style.display).toBe('none');
     });
 

--- a/tests/apps/builder/code-generator.test.ts
+++ b/tests/apps/builder/code-generator.test.ts
@@ -27,6 +27,7 @@ function resetState(): void {
   state.labelField = '';
   state.valueField = '';
   state.valueField2 = '';
+  state.extraSeries = [];
   state.codeField = '';
   state.aggregation = 'avg';
   state.sortOrder = 'desc';
@@ -1124,7 +1125,7 @@ describe('generateOdsQueryCode', () => {
 
   it('should generate second series aggregation', () => {
     state.aggregation = 'sum';
-    state.valueField2 = 'budget';
+    state.extraSeries = [{ field: 'budget', label: '' }];
     state.chartType = 'bar';
     const result = generateOdsQueryCode(
       { baseUrl: 'https://ods.example.com', datasetId: 'ds1' },
@@ -1209,7 +1210,7 @@ describe('generateTabularQueryCode', () => {
 
   it('should generate second series aggregation', () => {
     state.aggregation = 'avg';
-    state.valueField2 = 'budget';
+    state.extraSeries = [{ field: 'budget', label: '' }];
     state.chartType = 'line';
     state.fields = [{ name: 'budget', fullPath: 'budget', type: 'number', sample: 100 }];
     const result = generateTabularQueryCode(
@@ -1367,13 +1368,13 @@ describe('generateDynamicCode', () => {
     expect(code).not.toContain('refresh=');
   });
 
-  it('should include second series attribute when valueField2 is set', () => {
-    state.valueField2 = 'budget';
+  it('should include second series attribute when extraSeries is set', () => {
+    state.extraSeries = [{ field: 'budget', label: '' }];
     state.fields.push({ name: 'budget', fullPath: 'fields.budget', type: 'number', sample: 500 });
     state.aggregation = 'sum';
     generateDynamicCode();
     const code = document.getElementById('generated-code')!.textContent!;
-    expect(code).toContain('value-field-2=');
+    expect(code).toContain('value-fields=');
   });
 
   it('should generate horizontalBar as type="bar" with horizontal attribute', () => {
@@ -1719,12 +1720,12 @@ describe('generateDynamicCodeForApi', () => {
     };
     state.labelField = 'region';
     state.valueField = 'population';
-    state.valueField2 = 'budget';
+    state.extraSeries = [{ field: 'budget', label: '' }];
     state.aggregation = 'sum';
     state.chartType = 'bar';
     generateDynamicCodeForApi();
     const code = document.getElementById('generated-code')!.textContent!;
-    expect(code).toContain('value-field-2=');
+    expect(code).toContain('value-fields=');
   });
 });
 
@@ -2454,11 +2455,11 @@ describe('generateCode (API fetch embedded)', () => {
     state.chartType = 'bar';
     state.labelField = 'region';
     state.valueField = 'population';
-    state.valueField2 = 'budget';
+    state.extraSeries = [{ field: 'budget', label: '' }];
     generateCode('https://api.example.com?limit=200');
     const code = document.getElementById('generated-code')!.textContent!;
     expect(code).toContain('bar-chart');
-    expect(code).toContain('value2');
+    expect(code).toContain('values2');
     // name attribute should include both series
     expect(code).toContain('population');
     expect(code).toContain('budget');
@@ -2468,10 +2469,10 @@ describe('generateCode (API fetch embedded)', () => {
     state.chartType = 'pie';
     state.labelField = 'region';
     state.valueField = 'population';
-    state.valueField2 = 'budget';
+    state.extraSeries = [{ field: 'budget', label: '' }];
     generateCode('https://api.example.com?limit=200');
     const code = document.getElementById('generated-code')!.textContent!;
-    expect(code).not.toContain('value2');
+    expect(code).not.toContain('values2');
   });
 
   it('should include subtitle when set', () => {

--- a/tests/apps/builder/sources-fields.test.ts
+++ b/tests/apps/builder/sources-fields.test.ts
@@ -10,14 +10,15 @@ describe('builder sources-fields', () => {
     state.labelField = '';
     state.valueField = '';
     state.valueField2 = '';
+    state.extraSeries = [];
     state.codeField = '';
 
     // Setup DOM with required select elements
     document.body.innerHTML = `
       <select id="label-field"></select>
       <select id="value-field"></select>
-      <select id="value-field-2"></select>
       <select id="code-field"></select>
+      <div id="extra-series-container"></div>
     `;
   });
 
@@ -33,12 +34,10 @@ describe('builder sources-fields', () => {
 
     const labelSelect = document.getElementById('label-field') as HTMLSelectElement;
     const valueSelect = document.getElementById('value-field') as HTMLSelectElement;
-    const valueSelect2 = document.getElementById('value-field-2') as HTMLSelectElement;
     const codeSelect = document.getElementById('code-field') as HTMLSelectElement;
 
     expect(labelSelect.options).toHaveLength(1);
     expect(valueSelect.options).toHaveLength(1);
-    expect(valueSelect2.options).toHaveLength(1);
     expect(codeSelect.options).toHaveLength(1);
   });
 
@@ -55,19 +54,6 @@ describe('builder sources-fields', () => {
     // +1 for the default option
     expect(labelSelect.options).toHaveLength(3);
     expect(valueSelect.options).toHaveLength(3);
-  });
-
-  it('should only add numeric fields to value-field-2', () => {
-    state.fields = [
-      { name: 'region', type: 'string', sample: 'Bretagne' },
-      { name: 'population', type: 'number', sample: 3300000 },
-      { name: 'surface', type: 'number', sample: 27208 },
-    ];
-    populateFieldSelects();
-
-    const valueSelect2 = document.getElementById('value-field-2') as HTMLSelectElement;
-    // Default option + 2 numeric fields
-    expect(valueSelect2.options).toHaveLength(3);
   });
 
   it('should add string and number fields to code-field', () => {


### PR DESCRIPTION
1. Fix manual source "tableau vide" bug: table-editor.ts used wrong ID ('manual-table' instead of 'source-table-editor')

2. Builder multi-series: replace fixed valueField2 with dynamic extraSeries array. Users can add/remove unlimited series with custom labels. New value-fields attribute on dsfr-data-chart component. Code generation updated for all source types.

3. Enable accessible chart option by default in builder

https://claude.ai/code/session_01T2YaadVWDJj1ipqa6JY3kB