### PR TITLE
fix: route adapter fetches through proxy and fix CSP blocking API calls

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -184,6 +184,47 @@ server {
         proxy_set_header Referer "";
     }
 
+    # Proxy pour INSEE Melodi API (contourne CORS)
+    location /insee-proxy/ {
+        # Répondre directement aux OPTIONS
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept' always;
+            add_header 'Access-Control-Max-Age' 86400 always;
+            add_header 'Content-Type' 'text/plain charset=UTF-8' always;
+            add_header 'Content-Length' 0 always;
+            return 204;
+        }
+
+        # Masquer les headers CORS de l'upstream pour éviter les doublons
+        proxy_hide_header 'Access-Control-Allow-Origin';
+        proxy_hide_header 'Access-Control-Allow-Methods';
+        proxy_hide_header 'Access-Control-Allow-Headers';
+
+        # CORS headers pour les vraies requêtes
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept' always;
+        add_header 'Access-Control-Max-Age' 86400 always;
+
+        proxy_pass https://api.insee.fr/;
+        proxy_ssl_server_name on;
+        proxy_set_header Host api.insee.fr;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Supprimer origin/referer pour éviter le rejet CORS de l'upstream
+        proxy_set_header Origin '';
+        proxy_set_header Referer '';
+
+        # Cache GET 60s
+        proxy_cache api_cache;
+        proxy_cache_methods GET;
+        proxy_cache_valid 200 60s;
+    }
+
     # Proxy pour Tabular API data.gouv.fr (contourne CORS)
     location /tabular-proxy/ {
         # Répondre directement aux OPTIONS
@@ -224,6 +265,47 @@ server {
         proxy_cache api_cache;
         proxy_cache_methods GET;
         proxy_cache_valid 200 60s;
+    }
+
+    # Proxy CORS generique pour dsfr-data-source use-proxy
+    # Le client envoie un header X-Target-URL avec l'URL de l'API cible
+    location /cors-proxy {
+        # Preflight CORS
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, X-Target-URL' always;
+            add_header 'Access-Control-Max-Age' 86400 always;
+            return 204;
+        }
+
+        # Resolver pour les noms de domaine dynamiques
+        resolver 8.8.8.8 1.1.1.1 valid=30s;
+
+        # Lire l'URL cible depuis le header X-Target-URL
+        set $target_url $http_x_target_url;
+
+        # Masquer les headers CORS upstream
+        proxy_hide_header 'Access-Control-Allow-Origin';
+        proxy_hide_header 'Access-Control-Allow-Methods';
+        proxy_hide_header 'Access-Control-Allow-Headers';
+
+        # CORS headers
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, X-Target-URL' always;
+
+        proxy_pass $target_url;
+        proxy_ssl_server_name on;
+        proxy_set_header Host $proxy_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Ne pas forwarder les headers internes
+        proxy_set_header X-Target-URL "";
+        proxy_set_header Origin "";
+        proxy_set_header Referer "";
     }
 
     # Beacon de tracking des widgets deployes
@@ -284,5 +366,5 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' cdn.jsdelivr.net 'unsafe-inline'; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; img-src 'self' data: blob:; connect-src 'self' *.opendatasoft.com albert.api.etalab.gouv.fr api.openai.com api.anthropic.com generativelanguage.googleapis.com api.mistral.ai;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' cdn.jsdelivr.net 'unsafe-inline'; style-src 'self' 'unsafe-inline' cdn.jsdelivr.net; font-src 'self' cdn.jsdelivr.net; img-src 'self' data: blob: *; connect-src *;" always;
 }

--- a/packages/shared/src/api/proxy-config.ts
+++ b/packages/shared/src/api/proxy-config.ts
@@ -10,6 +10,7 @@ export interface ProxyConfig {
     gristGouv: string;
     albert: string;
     tabular: string;
+    insee: string;
     corsProxy: string;
   };
 }
@@ -46,6 +47,7 @@ export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
     gristGouv: '/grist-gouv-proxy',
     albert: '/albert-proxy',
     tabular: '/tabular-proxy',
+    insee: '/insee-proxy',
     corsProxy: '/cors-proxy',
   }
 };

--- a/packages/shared/src/api/proxy.ts
+++ b/packages/shared/src/api/proxy.ts
@@ -54,6 +54,10 @@ export function getProxiedUrl(url: string): string {
     return url.replace('https://albert.api.etalab.gouv.fr', `${config.baseUrl}${config.endpoints.albert}`);
   }
 
+  if (url.includes('api.insee.fr')) {
+    return url.replace('https://api.insee.fr', `${config.baseUrl}${config.endpoints.insee}`);
+  }
+
   return url;
 }
 

--- a/proxy/nginx/nginx.conf
+++ b/proxy/nginx/nginx.conf
@@ -193,6 +193,47 @@ http {
         }
 
         # =================================================================
+        # Proxy : INSEE Melodi API (api.insee.fr)
+        # =================================================================
+        location /insee-proxy/ {
+            # -- Preflight OPTIONS ----------------------------------------
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' '*' always;
+                add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+                add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept' always;
+                add_header 'Access-Control-Max-Age' 86400 always;
+                add_header 'Content-Type' 'text/plain; charset=UTF-8' always;
+                add_header 'Content-Length' 0 always;
+                return 204;
+            }
+
+            # Masquer les headers CORS de l'upstream pour eviter les doublons
+            proxy_hide_header 'Access-Control-Allow-Origin';
+            proxy_hide_header 'Access-Control-Allow-Methods';
+            proxy_hide_header 'Access-Control-Allow-Headers';
+
+            # -- CORS pour les requetes normales --------------------------
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Origin, Content-Type, Accept' always;
+            add_header 'Access-Control-Max-Age' 86400 always;
+
+            # -- Proxy vers l'upstream ------------------------------------
+            proxy_pass https://api.insee.fr/;
+            proxy_ssl_server_name on;
+            proxy_set_header Host api.insee.fr;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_set_header Origin '';
+            proxy_set_header Referer '';
+
+            proxy_no_cache 1;
+            proxy_cache_bypass 1;
+        }
+
+        # =================================================================
         # Proxy : Tabular API data.gouv.fr (tabular-api.data.gouv.fr)
         # =================================================================
         location /tabular-proxy/ {
@@ -228,6 +269,44 @@ http {
 
             proxy_no_cache 1;
             proxy_cache_bypass 1;
+        }
+
+        # =================================================================
+        # Proxy CORS generique (X-Target-URL header pattern)
+        # =================================================================
+        location /cors-proxy {
+            # -- Preflight OPTIONS ----------------------------------------
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' '*' always;
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
+                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, X-Target-URL' always;
+                add_header 'Access-Control-Max-Age' 86400 always;
+                return 204;
+            }
+
+            # Lire l'URL cible depuis le header X-Target-URL
+            set $target_url $http_x_target_url;
+
+            # Masquer les headers CORS upstream
+            proxy_hide_header 'Access-Control-Allow-Origin';
+            proxy_hide_header 'Access-Control-Allow-Methods';
+            proxy_hide_header 'Access-Control-Allow-Headers';
+
+            # CORS headers
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, X-Target-URL' always;
+
+            proxy_pass $target_url;
+            proxy_ssl_server_name on;
+            proxy_set_header Host $proxy_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_set_header X-Target-URL "";
+            proxy_set_header Origin "";
+            proxy_set_header Referer "";
         }
 
         # -----------------------------------------------------------------

--- a/src/adapters/grist-adapter.ts
+++ b/src/adapters/grist-adapter.ts
@@ -26,7 +26,7 @@ import type {
 } from './api-adapter.js';
 import type { QueryAggregate } from '../components/dsfr-data-query.js';
 import type { ProviderConfig } from '@dsfr-data/shared';
-import { GRIST_CONFIG } from '@dsfr-data/shared';
+import { GRIST_CONFIG, getProxiedUrl } from '@dsfr-data/shared';
 
 /** Construit les options fetch avec headers optionnels */
 function buildFetchOptions(params: Pick<AdapterParams, 'headers'>, signal?: AbortSignal): RequestInit {
@@ -100,7 +100,7 @@ export class GristAdapter implements ApiAdapter {
     }
 
     // Mode Records (enrichi avec filter/sort/limit)
-    const url = this.buildUrl(params);
+    const url = getProxiedUrl(this.buildUrl(params));
     const response = await fetch(url, buildFetchOptions(params, signal));
     if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 
@@ -121,7 +121,7 @@ export class GristAdapter implements ApiAdapter {
     }
 
     // Mode Records pagine
-    const url = this.buildServerSideUrl(params, overlay);
+    const url = getProxiedUrl(this.buildServerSideUrl(params, overlay));
     const response = await fetch(url, buildFetchOptions(params, signal));
     if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 
@@ -223,7 +223,7 @@ export class GristAdapter implements ApiAdapter {
       }
       sql += ` GROUP BY ${col} ORDER BY cnt DESC LIMIT 200`;
 
-      const sqlUrl = this._getSqlEndpointUrl(fullParams);
+      const sqlUrl = getProxiedUrl(this._getSqlEndpointUrl(fullParams));
       try {
         const response = await fetch(sqlUrl, {
           method: 'POST',
@@ -312,7 +312,7 @@ export class GristAdapter implements ApiAdapter {
     params: AdapterParams,
     signal?: AbortSignal
   ): Promise<GristColumn[]> {
-    const url = params.baseUrl.replace(/\/records.*$/, '/columns');
+    const url = getProxiedUrl(params.baseUrl.replace(/\/records.*$/, '/columns'));
     try {
       const response = await fetch(url, buildFetchOptions(params, signal));
       if (!response.ok) return [];
@@ -341,7 +341,7 @@ export class GristAdapter implements ApiAdapter {
     params: AdapterParams,
     signal?: AbortSignal
   ): Promise<GristTable[]> {
-    const url = params.baseUrl.replace(/\/tables\/[^/]+\/records.*$/, '/tables');
+    const url = getProxiedUrl(params.baseUrl.replace(/\/tables\/[^/]+\/records.*$/, '/tables'));
     try {
       const response = await fetch(url, buildFetchOptions(params, signal));
       if (!response.ok) return [];
@@ -455,7 +455,7 @@ export class GristAdapter implements ApiAdapter {
       offset ? `OFFSET ${offset}` : '',
     ].filter(Boolean).join(' ');
 
-    const sqlUrl = this._getSqlEndpointUrl(params);
+    const sqlUrl = getProxiedUrl(this._getSqlEndpointUrl(params));
     const response = await fetch(sqlUrl, {
       method: 'POST',
       headers: {
@@ -488,7 +488,7 @@ export class GristAdapter implements ApiAdapter {
 
   /** Fetch Records mode (internal fallback) */
   private async _fetchAllRecords(params: AdapterParams, signal: AbortSignal): Promise<FetchResult> {
-    const url = this.buildUrl(params);
+    const url = getProxiedUrl(this.buildUrl(params));
     const response = await fetch(url, buildFetchOptions(params, signal));
     if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 
@@ -704,7 +704,7 @@ export class GristAdapter implements ApiAdapter {
     if (cached !== undefined) return cached;
 
     try {
-      const sqlUrl = this._getSqlEndpointUrl(params);
+      const sqlUrl = getProxiedUrl(this._getSqlEndpointUrl(params));
       const response = await fetch(sqlUrl + '?q=SELECT%201', {
         method: 'GET',
         headers: (params.headers || {}) as Record<string, string>,

--- a/src/adapters/insee-adapter.ts
+++ b/src/adapters/insee-adapter.ts
@@ -13,7 +13,7 @@ import type {
   FetchResult, ServerSideOverlay
 } from './api-adapter.js';
 import type { ProviderConfig } from '@dsfr-data/shared';
-import { INSEE_CONFIG } from '@dsfr-data/shared';
+import { INSEE_CONFIG, getProxiedUrl } from '@dsfr-data/shared';
 
 /** Default base URL for the Melodi API */
 const INSEE_BASE_URL = 'https://api.insee.fr/melodi';
@@ -72,7 +72,7 @@ export class InseeAdapter implements ApiAdapter {
       if (remaining <= 0) break;
 
       const effectivePageSize = Math.min(pageSize, remaining);
-      const url = this.buildUrl(params, effectivePageSize, page);
+      const url = getProxiedUrl(this.buildUrl(params, effectivePageSize, page));
 
       const response = await fetch(url, buildFetchOptions(params, signal));
       if (!response.ok) {
@@ -117,7 +117,7 @@ export class InseeAdapter implements ApiAdapter {
    * Fetch a single page in server-side pagination mode.
    */
   async fetchPage(params: AdapterParams, overlay: ServerSideOverlay, signal: AbortSignal): Promise<FetchResult> {
-    const url = this.buildServerSideUrl(params, overlay);
+    const url = getProxiedUrl(this.buildServerSideUrl(params, overlay));
 
     const response = await fetch(url, buildFetchOptions(params, signal));
     if (!response.ok) {

--- a/src/adapters/opendatasoft-adapter.ts
+++ b/src/adapters/opendatasoft-adapter.ts
@@ -11,7 +11,7 @@ import type {
 } from './api-adapter.js';
 import type { QueryAggregate } from '../components/dsfr-data-query.js';
 import type { ProviderConfig } from '@dsfr-data/shared';
-import { ODS_CONFIG } from '@dsfr-data/shared';
+import { ODS_CONFIG, getProxiedUrl } from '@dsfr-data/shared';
 
 /** Construit les options fetch avec headers optionnels */
 function buildFetchOptions(params: Pick<AdapterParams, 'headers'>, signal?: AbortSignal): RequestInit {
@@ -67,7 +67,7 @@ export class OpenDataSoftAdapter implements ApiAdapter {
       const remaining = requestedLimit - allResults.length;
       if (remaining <= 0) break;
 
-      const url = this.buildUrl(params, Math.min(pageSize, remaining), offset);
+      const url = getProxiedUrl(this.buildUrl(params, Math.min(pageSize, remaining), offset));
 
       const response = await fetch(url, buildFetchOptions(params, signal));
       if (!response.ok) {
@@ -111,7 +111,7 @@ export class OpenDataSoftAdapter implements ApiAdapter {
    * Fetch une seule page en mode server-side.
    */
   async fetchPage(params: AdapterParams, overlay: ServerSideOverlay, signal: AbortSignal): Promise<FetchResult> {
-    const url = this.buildServerSideUrl(params, overlay);
+    const url = getProxiedUrl(this.buildServerSideUrl(params, overlay));
 
     const response = await fetch(url, buildFetchOptions(params, signal));
     if (!response.ok) {
@@ -231,7 +231,7 @@ export class OpenDataSoftAdapter implements ApiAdapter {
       url.searchParams.set('where', where);
     }
 
-    const response = await fetch(url.toString(), buildFetchOptions(params, signal));
+    const response = await fetch(getProxiedUrl(url.toString()), buildFetchOptions(params, signal));
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }

--- a/tests/adapters/insee-adapter.test.ts
+++ b/tests/adapters/insee-adapter.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Mock getProxiedUrl to return the URL as-is (avoid proxy rewriting in tests)
+vi.mock('@dsfr-data/shared', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, getProxiedUrl: (url: string) => url };
+});
+
 // Mock fetch globally
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -92,6 +92,20 @@ export default defineConfig({
           });
         }
       },
+      // Proxy pour INSEE Melodi API
+      '/insee-proxy': {
+        target: 'https://api.insee.fr',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/insee-proxy/, ''),
+        secure: true,
+        configure: (proxy) => {
+          proxy.on('proxyReq', (proxyReq) => {
+            proxyReq.removeHeader('cookie');
+            proxyReq.removeHeader('origin');
+            proxyReq.removeHeader('referer');
+          });
+        }
+      },
       // Proxy générique pour les APIs externes (legacy, prefer /cors-proxy middleware)
       '/api-proxy': {
         target: '',


### PR DESCRIPTION
Adapters (ODS, Grist, INSEE) were fetching directly from external APIs, bypassing the proxy system. In production, CSP connect-src blocked these requests to non-whitelisted domains (api.insee.fr, ghibliapi.vercel.app, custom-domain ODS instances, etc.).

Changes:
- Add getProxiedUrl() to all adapter fetch calls (ODS, Grist, INSEE)
- Add /cors-proxy location to nginx.conf (was only in Vite dev middleware)
- Add /insee-proxy to nginx.conf, vite.config.ts, and proxy-config
- Widen CSP connect-src to allow arbitrary API connections (connect-src *)
- Update standalone proxy config (proxy/nginx/nginx.conf)

https://claude.ai/code/session_01JhvSFMdbRVooVBQ77oPFX7