### PR TITLE
feat(auth): email verification enrollment via SMTP (FR-002 PR2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,17 @@ APP_DOMAIN=chartsbuilder.matge.com
 # ENCRYPTION_KEY=
 
 # ---------------------------------------------------------------------------
+# SMTP - Envoi d'emails (mode serveur uniquement)
+# ---------------------------------------------------------------------------
+# Serveur SMTP pour l'envoi d'emails (verification, bienvenue).
+# Par defaut, utilise le conteneur docker-mailserver sur ecosystem-network.
+# Pas d'authentification requise depuis le reseau Docker interne.
+# SMTP_HOST=mailserver
+# SMTP_PORT=25
+# SMTP_FROM=noreply@ecosysteme.matge.com
+# APP_URL=https://chartsbuilder.matge.com
+
+# ---------------------------------------------------------------------------
 # Albert IA - Configuration serveur par defaut (Builder IA)
 # ---------------------------------------------------------------------------
 # Si ces variables sont definies, le Builder IA fonctionne sans que l'utilisateur

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -42,6 +42,10 @@ services:
       - DB_USER=${DB_USER:-dsfr_data}
       - DB_PASSWORD=${DB_PASSWORD}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      - SMTP_HOST=${SMTP_HOST:-mailserver}
+      - SMTP_PORT=${SMTP_PORT:-25}
+      - SMTP_FROM=${SMTP_FROM:-noreply@ecosysteme.matge.com}
+      - APP_URL=${APP_URL:-https://chartsbuilder.matge.com}
       - IA_DEFAULT_TOKEN=${IA_DEFAULT_TOKEN:-}
       - IA_DEFAULT_API_URL=${IA_DEFAULT_API_URL:-https://albert.api.etalab.gouv.fr/v1/chat/completions}
       - IA_DEFAULT_MODEL=${IA_DEFAULT_MODEL:-albert-large}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2364,6 +2364,16 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/nodemailer": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/parse5": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
@@ -5926,6 +5936,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nodemailer": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
+      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -8714,6 +8733,7 @@
         "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.11.0",
+        "nodemailer": "^8.0.4",
         "uuid": "^11.0.0"
       },
       "devDependencies": {
@@ -8723,6 +8743,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/jsonwebtoken": "^9.0.7",
+        "@types/nodemailer": "^7.0.11",
         "@types/supertest": "^6.0.2",
         "@types/uuid": "^10.0.0",
         "better-sqlite3": "^11.7.0",

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.11.0",
+    "nodemailer": "^8.0.4",
     "uuid": "^11.0.0"
   },
   "devDependencies": {
@@ -27,6 +28,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/jsonwebtoken": "^9.0.7",
+    "@types/nodemailer": "^7.0.11",
     "@types/supertest": "^6.0.2",
     "@types/uuid": "^10.0.0",
     "better-sqlite3": "^11.7.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
-import { initDatabase, closeDatabase } from './db/database.js';
+import { initDatabase, closeDatabase, execute } from './db/database.js';
 import { authMiddleware } from './middleware/auth.js';
 import authRoutes from './routes/auth.js';
 import sourcesRoutes from './routes/sources.js';
@@ -58,6 +58,20 @@ process.on('SIGINT', shutdown);
 // Start server after database initialization
 async function start() {
   await initDatabase();
+
+  // Cleanup expired unverified accounts (older than 7 days)
+  try {
+    const result = await execute(
+      `DELETE FROM users WHERE email_verified = FALSE AND verification_expires IS NOT NULL
+       AND verification_expires < DATE_SUB(NOW(), INTERVAL 7 DAY)`,
+    );
+    if (result.affectedRows > 0) {
+      console.log(`[server] Cleaned up ${result.affectedRows} expired unverified account(s)`);
+    }
+  } catch (err) {
+    console.error('[server] Failed to cleanup expired accounts:', err);
+  }
+
   app.listen(PORT, () => {
     console.log(`[server] dsfr-data API listening on port ${PORT}`);
   });

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -1,8 +1,9 @@
 /**
- * Authentication routes: register, login, logout, me.
+ * Authentication routes: register, login, logout, me, email verification.
  */
 
 import { Router } from 'express';
+import crypto from 'node:crypto';
 import bcrypt from 'bcrypt';
 import { v4 as uuidv4 } from 'uuid';
 import { query, queryOne, execute } from '../db/database.js';
@@ -10,13 +11,24 @@ import { createToken, setAuthCookie, clearAuthCookie, requireAuth } from '../mid
 import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { authLimiter } from '../middleware/rate-limit.js';
 import { isValidEmail, isStrongPassword } from '../utils/validation.js';
+import { sendVerificationEmail } from '../utils/mailer.js';
 
 const router = Router();
 const SALT_ROUNDS = 10;
+const VERIFICATION_TOKEN_BYTES = 32;
+const VERIFICATION_EXPIRY_HOURS = 24;
+const RESEND_MAX = 3; // max resend per hour per email
+
+/** Hash a verification token with SHA-256 for safe DB storage. */
+function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
 
 /**
  * POST /api/auth/register
  * Create a new user account.
+ * First user (admin): auto-verified, logged in immediately.
+ * Other users: verification email sent, must click link to activate.
  */
 router.post('/register', authLimiter, async (req, res) => {
   try {
@@ -38,50 +50,183 @@ router.post('/register', authLimiter, async (req, res) => {
       return;
     }
 
-    // Check if email already exists
-    const existing = await queryOne<{ id: string }>('SELECT id FROM users WHERE email = ?', [email]);
+    // Check if email already exists (active accounts only — allow re-register if previous expired)
+    const existing = await queryOne<{ id: string; email_verified: number }>(
+      'SELECT id, email_verified FROM users WHERE email = ?',
+      [email],
+    );
     if (existing) {
-      res.status(409).json({ error: 'Email already registered' });
-      return;
+      if (existing.email_verified) {
+        res.status(409).json({ error: 'Email already registered' });
+        return;
+      }
+      // Unverified account exists — delete it so user can re-register
+      await execute('DELETE FROM users WHERE id = ?', [existing.id]);
     }
 
     const id = uuidv4();
     const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
+    const name = displayName || email.split('@')[0];
 
     // First user becomes admin (with email auto-verified)
     const countRow = await queryOne<{ count: number }>('SELECT COUNT(*) as count FROM users');
     const isFirstUser = countRow?.count === 0;
     const role = isFirstUser ? 'admin' : 'editor';
 
-    await execute(
-      `INSERT INTO users (id, email, password_hash, display_name, role, email_verified)
-       VALUES (?, ?, ?, ?, ?, ?)`,
-      [id, email, passwordHash, displayName || email.split('@')[0], role, isFirstUser ? 1 : 0],
-    );
-
     if (isFirstUser) {
       // Admin: skip email verification, log in immediately
-      const token = createToken({ userId: id, email, role });
-      setAuthCookie(res, token);
+      await execute(
+        `INSERT INTO users (id, email, password_hash, display_name, role, email_verified)
+         VALUES (?, ?, ?, ?, ?, TRUE)`,
+        [id, email, passwordHash, name, role],
+      );
       await execute('UPDATE users SET last_login = NOW() WHERE id = ?', [id]);
 
+      const token = createToken({ userId: id, email, role });
+      setAuthCookie(res, token);
+
       res.status(201).json({
-        user: { id, email, displayName: displayName || email.split('@')[0], role },
+        user: { id, email, displayName: name, role },
       });
     } else {
-      // Regular user: email verification required (handled in PR 2)
-      // For now, auto-verify and log in (will be gated behind email flow in PR 2)
-      await execute('UPDATE users SET email_verified = TRUE WHERE id = ?', [id]);
-      const token = createToken({ userId: id, email, role });
-      setAuthCookie(res, token);
-      await execute('UPDATE users SET last_login = NOW() WHERE id = ?', [id]);
+      // Regular user: generate verification token, send email
+      const verificationToken = crypto.randomBytes(VERIFICATION_TOKEN_BYTES).toString('hex');
+      const tokenHash = hashToken(verificationToken);
+
+      await execute(
+        `INSERT INTO users (id, email, password_hash, display_name, role, email_verified, verification_token_hash, verification_expires)
+         VALUES (?, ?, ?, ?, ?, FALSE, ?, DATE_ADD(NOW(), INTERVAL ? HOUR))`,
+        [id, email, passwordHash, name, role, tokenHash, VERIFICATION_EXPIRY_HOURS],
+      );
+
+      // Send verification email (best-effort — if SMTP fails, user can resend)
+      try {
+        await sendVerificationEmail(email, verificationToken);
+      } catch (err) {
+        console.error('Failed to send verification email:', err);
+        // Don't fail registration — user can resend later
+      }
 
       res.status(201).json({
-        user: { id, email, displayName: displayName || email.split('@')[0], role },
+        message: 'Verification email sent',
+        email,
       });
     }
   } catch (err) {
     console.error('Register error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/auth/verify-email?token=xxx
+ * Verify the email token, activate the account, log in, redirect to /.
+ */
+router.get('/verify-email', async (req, res) => {
+  try {
+    const token = req.query.token as string;
+    if (!token) {
+      res.redirect('/?error=invalid_token');
+      return;
+    }
+
+    const tokenHash = hashToken(token);
+
+    const user = await queryOne<{
+      id: string; email: string; role: string; verification_expires: string;
+    }>(
+      `SELECT id, email, role, verification_expires FROM users
+       WHERE verification_token_hash = ? AND email_verified = FALSE`,
+      [tokenHash],
+    );
+
+    if (!user) {
+      res.redirect('/?error=invalid_token');
+      return;
+    }
+
+    // Check expiry
+    const expires = new Date(user.verification_expires);
+    if (expires < new Date()) {
+      res.redirect('/?error=token_expired');
+      return;
+    }
+
+    // Activate account
+    await execute(
+      `UPDATE users SET email_verified = TRUE, verification_token_hash = NULL,
+       verification_expires = NULL, last_login = NOW() WHERE id = ?`,
+      [user.id],
+    );
+
+    // Log in
+    const jwt = createToken({ userId: user.id, email: user.email, role: user.role });
+    setAuthCookie(res, jwt);
+
+    res.redirect('/');
+  } catch (err) {
+    console.error('Verify email error:', err);
+    res.redirect('/?error=server_error');
+  }
+});
+
+/**
+ * POST /api/auth/resend-verification
+ * Resend the verification email for an unverified account.
+ * Rate limited: max 3 per hour per email.
+ * Always returns 200 to avoid leaking account existence.
+ */
+router.post('/resend-verification', authLimiter, async (req, res) => {
+  try {
+    const { email } = req.body;
+    if (!email) {
+      res.json({ message: 'If an account exists, a verification email has been sent' });
+      return;
+    }
+
+    const user = await queryOne<{ id: string; verification_expires: string }>(
+      `SELECT id, verification_expires FROM users
+       WHERE email = ? AND email_verified = FALSE AND is_active = TRUE AND auth_provider = 'local'`,
+      [email],
+    );
+
+    if (!user) {
+      // Don't leak whether the account exists
+      res.json({ message: 'If an account exists, a verification email has been sent' });
+      return;
+    }
+
+    // Rate limit: check how many times verification was regenerated in the last hour
+    // We use verification_expires as a proxy — if it was recently set, reject
+    if (user.verification_expires) {
+      const expires = new Date(user.verification_expires);
+      const hoursUntilExpiry = (expires.getTime() - Date.now()) / (1000 * 60 * 60);
+      // If token was generated less than 20 minutes ago (24h - 20min = 23.67h remaining), throttle
+      if (hoursUntilExpiry > (VERIFICATION_EXPIRY_HOURS - 1 / RESEND_MAX)) {
+        res.json({ message: 'If an account exists, a verification email has been sent' });
+        return;
+      }
+    }
+
+    // Generate new token
+    const verificationToken = crypto.randomBytes(VERIFICATION_TOKEN_BYTES).toString('hex');
+    const tokenHash = hashToken(verificationToken);
+
+    await execute(
+      `UPDATE users SET verification_token_hash = ?,
+       verification_expires = DATE_ADD(NOW(), INTERVAL ? HOUR) WHERE id = ?`,
+      [tokenHash, VERIFICATION_EXPIRY_HOURS, user.id],
+    );
+
+    try {
+      await sendVerificationEmail(email, verificationToken);
+    } catch (err) {
+      console.error('Failed to resend verification email:', err);
+    }
+
+    res.json({ message: 'If an account exists, a verification email has been sent' });
+  } catch (err) {
+    console.error('Resend verification error:', err);
     res.status(500).json({ error: 'Internal server error' });
   }
 });

--- a/server/src/utils/mailer.ts
+++ b/server/src/utils/mailer.ts
@@ -1,0 +1,78 @@
+/**
+ * Email sending utilities via SMTP.
+ * Uses docker-mailserver on ecosystem-network (port 25, no auth).
+ */
+
+import nodemailer from 'nodemailer';
+import type { Transporter } from 'nodemailer';
+
+let transporter: Transporter | null = null;
+
+const FROM = () => process.env.SMTP_FROM || 'noreply@ecosysteme.matge.com';
+const APP_URL = () => process.env.APP_URL || 'https://chartsbuilder.matge.com';
+
+/**
+ * Get or create the nodemailer transporter.
+ * Lazy-initialized to allow env vars to be set before first use.
+ */
+function getTransporter(): Transporter {
+  if (!transporter) {
+    transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST || 'mailserver',
+      port: parseInt(process.env.SMTP_PORT || '25', 10),
+      secure: false,
+      tls: { rejectUnauthorized: false },
+      // No auth — internal Docker network
+    });
+  }
+  return transporter;
+}
+
+/**
+ * Send a verification email with a one-time token link.
+ * The user must click the link to activate their account.
+ */
+export async function sendVerificationEmail(email: string, token: string): Promise<void> {
+  const verifyUrl = `${APP_URL()}/api/auth/verify-email?token=${token}`;
+  await getTransporter().sendMail({
+    from: `"DSFR Data" <${FROM()}>`,
+    to: email,
+    subject: 'Confirmez votre adresse email — DSFR Data',
+    html: `
+      <p>Bonjour,</p>
+      <p>Vous avez cree un compte sur <strong>DSFR Data</strong>.</p>
+      <p>Cliquez sur le lien ci-dessous pour confirmer votre adresse email et activer votre compte :</p>
+      <p><a href="${verifyUrl}">${verifyUrl}</a></p>
+      <p>Ce lien expire dans <strong>24 heures</strong>.</p>
+      <p>Si vous n'etes pas a l'origine de cette inscription, ignorez cet email.</p>
+    `,
+    text: `Confirmez votre email en visitant : ${verifyUrl}\n\nCe lien expire dans 24 heures.`,
+  });
+}
+
+/**
+ * Send a welcome email for ProConnect users (first login).
+ * Non-blocking: failure does not prevent login.
+ */
+export async function sendWelcomeEmail(email: string, displayName: string): Promise<void> {
+  const appUrl = APP_URL();
+  await getTransporter().sendMail({
+    from: `"DSFR Data" <${FROM()}>`,
+    to: email,
+    subject: 'Bienvenue sur DSFR Data',
+    html: `
+      <p>Bonjour ${displayName},</p>
+      <p>Votre compte a ete cree sur <a href="${appUrl}">DSFR Data</a> via ProConnect.</p>
+      <p>Vous disposez du role <strong>editeur</strong> et pouvez creer des visualisations de donnees.</p>
+      <p>Si vous n'etes pas a l'origine de cette connexion, contactez l'administrateur.</p>
+    `,
+    text: `Bonjour ${displayName},\n\nVotre compte a ete cree sur DSFR Data (${appUrl}) via ProConnect.\nRole : editeur.`,
+  });
+}
+
+/**
+ * Override the transporter (for testing with a mock).
+ */
+export function setTransporter(t: Transporter | null): void {
+  transporter = t;
+}

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -2,11 +2,21 @@
  * Server tests for auth routes (/api/auth).
  */
 
-import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import request from 'supertest';
+import crypto from 'node:crypto';
 import type { Express } from 'express';
-import { createTestApp, closeTestApp, authCookie } from './test-helpers.js';
+import { createTestApp, closeTestApp } from './test-helpers.js';
 import { execute, queryOne } from '../../server/src/db/database.js';
+
+// Mock the mailer module — capture emails instead of sending
+vi.mock('../../server/src/utils/mailer.js', () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+  sendWelcomeEmail: vi.fn().mockResolvedValue(undefined),
+  setTransporter: vi.fn(),
+}));
+
+import { sendVerificationEmail } from '../../server/src/utils/mailer.js';
 
 /** Valid password that meets complexity requirements (8+ chars, upper, lower, digit). */
 const VALID_PASSWORD = 'Password1';
@@ -16,8 +26,35 @@ function extractCookie(res: request.Response): string {
   const cookies = res.headers['set-cookie'];
   if (!cookies) return '';
   const raw = Array.isArray(cookies) ? cookies[0] : cookies;
-  // Return only the key=value part (before the first semicolon)
   return raw.split(';')[0];
+}
+
+/** Register the first user (admin) and return cookie. Admin is auto-verified. */
+async function registerAdmin(app: Express, email = 'admin@example.com'): Promise<string> {
+  const res = await request(app)
+    .post('/api/auth/register')
+    .send({ email, password: VALID_PASSWORD, displayName: 'Admin' });
+  return extractCookie(res);
+}
+
+/** Register a non-admin user. Returns the response (no cookie — needs verification). */
+async function registerUser(app: Express, email: string, displayName?: string) {
+  // Ensure there's already an admin so this user is not the first
+  const count = await queryOne<{ count: number }>('SELECT COUNT(*) as count FROM users');
+  if (count?.count === 0) {
+    await registerAdmin(app);
+  }
+  return request(app)
+    .post('/api/auth/register')
+    .send({ email, password: VALID_PASSWORD, displayName: displayName || email.split('@')[0] });
+}
+
+/** Verify a user's email directly in DB (shortcut for tests that don't test verification). */
+async function verifyUserEmail(email: string): Promise<void> {
+  await execute(
+    'UPDATE users SET email_verified = TRUE, verification_token_hash = NULL, verification_expires = NULL WHERE email = ?',
+    [email],
+  );
 }
 
 describe('POST /api/auth/register', () => {
@@ -25,50 +62,42 @@ describe('POST /api/auth/register', () => {
 
   beforeEach(async () => {
     app = await createTestApp();
+    vi.clearAllMocks();
   });
 
-  it('creates a user successfully', async () => {
+  it('first user gets admin role and is auto-verified (cookie set)', async () => {
     const res = await request(app)
       .post('/api/auth/register')
-      .send({ email: 'alice@example.com', password: VALID_PASSWORD, displayName: 'Alice' });
+      .send({ email: 'first@example.com', password: VALID_PASSWORD, displayName: 'First' });
 
     expect(res.status).toBe(201);
-    expect(res.body.user).toMatchObject({
-      email: 'alice@example.com',
-      displayName: 'Alice',
-    });
-    expect(res.body.user.id).toBeDefined();
-    expect(res.body.user.role).toBeDefined();
-    // Should set an httpOnly cookie
+    expect(res.body.user).toMatchObject({ email: 'first@example.com', role: 'admin' });
+    // Admin gets a cookie (auto-verified)
     expect(res.headers['set-cookie']).toBeDefined();
+    // No verification email sent for admin
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
   });
 
-  it('first user gets admin role', async () => {
-    const res = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'first@example.com', password: VALID_PASSWORD, displayName: 'First' });
-
-    expect(res.status).toBe(201);
-    expect(res.body.user.role).toBe('admin');
-  });
-
-  it('second user gets editor role', async () => {
-    await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'first@example.com', password: VALID_PASSWORD, displayName: 'First' });
+  it('second user gets editor role and verification email (no cookie)', async () => {
+    await registerAdmin(app);
 
     const res = await request(app)
       .post('/api/auth/register')
       .send({ email: 'second@example.com', password: VALID_PASSWORD, displayName: 'Second' });
 
     expect(res.status).toBe(201);
-    expect(res.body.user.role).toBe('editor');
+    expect(res.body.message).toMatch(/verification/i);
+    expect(res.body.email).toBe('second@example.com');
+    // No cookie for unverified user
+    const cookies = res.headers['set-cookie'];
+    const hasCookie = cookies && (Array.isArray(cookies) ? cookies : [cookies]).some((c: string) => c.startsWith('gw-auth-token='));
+    expect(hasCookie).toBeFalsy();
+    // Verification email sent
+    expect(sendVerificationEmail).toHaveBeenCalledWith('second@example.com', expect.any(String));
   });
 
   it('rejects duplicate email', async () => {
-    await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'dup@example.com', password: VALID_PASSWORD, displayName: 'Dup' });
+    await registerAdmin(app, 'dup@example.com');
 
     const res = await request(app)
       .post('/api/auth/register')
@@ -76,6 +105,23 @@ describe('POST /api/auth/register', () => {
 
     expect(res.status).toBe(409);
     expect(res.body.error).toMatch(/already/i);
+  });
+
+  it('allows re-register of unverified account (replaces it)', async () => {
+    await registerAdmin(app);
+
+    // Register once (unverified)
+    await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'retry@example.com', password: VALID_PASSWORD });
+
+    // Register again with same email — should succeed (replaces unverified)
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'retry@example.com', password: VALID_PASSWORD });
+
+    expect(res.status).toBe(201);
+    expect(res.body.message).toMatch(/verification/i);
   });
 
   it('rejects short password', async () => {
@@ -124,16 +170,139 @@ describe('POST /api/auth/register', () => {
   });
 });
 
+describe('GET /api/auth/verify-email', () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    app = await createTestApp();
+    vi.clearAllMocks();
+  });
+
+  it('verifies email and logs in (redirect to /)', async () => {
+    await registerAdmin(app);
+
+    // Register a user (sends verification email)
+    await registerUser(app, 'verify@example.com');
+
+    // Get the token that was passed to sendVerificationEmail
+    const calls = vi.mocked(sendVerificationEmail).mock.calls;
+    expect(calls.length).toBe(1);
+    const token = calls[0][1];
+
+    // Verify
+    const res = await request(app)
+      .get(`/api/auth/verify-email?token=${token}`);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/');
+    expect(res.headers['set-cookie']).toBeDefined();
+
+    // Check DB: email_verified = true
+    const user = await queryOne<{ email_verified: number }>(
+      'SELECT email_verified FROM users WHERE email = ?', ['verify@example.com'],
+    );
+    expect(user?.email_verified).toBe(1);
+  });
+
+  it('rejects invalid token', async () => {
+    const res = await request(app)
+      .get('/api/auth/verify-email?token=invalidtoken123');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/?error=invalid_token');
+  });
+
+  it('rejects expired token', async () => {
+    await registerAdmin(app);
+    await registerUser(app, 'expired@example.com');
+
+    const calls = vi.mocked(sendVerificationEmail).mock.calls;
+    const token = calls[0][1];
+
+    // Expire the token in DB
+    await execute(
+      'UPDATE users SET verification_expires = DATE_SUB(NOW(), INTERVAL 1 HOUR) WHERE email = ?',
+      ['expired@example.com'],
+    );
+
+    const res = await request(app)
+      .get(`/api/auth/verify-email?token=${token}`);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/?error=token_expired');
+  });
+
+  it('rejects missing token parameter', async () => {
+    const res = await request(app)
+      .get('/api/auth/verify-email');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/?error=invalid_token');
+  });
+});
+
+describe('POST /api/auth/resend-verification', () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    app = await createTestApp();
+    vi.clearAllMocks();
+  });
+
+  it('resends verification email for unverified account', async () => {
+    await registerAdmin(app);
+    await registerUser(app, 'resend@example.com');
+
+    vi.clearAllMocks(); // Clear the initial sendVerificationEmail call
+
+    // Make the token old enough to allow resend (set expires to less than 23.67h from now)
+    await execute(
+      'UPDATE users SET verification_expires = DATE_ADD(NOW(), INTERVAL 20 HOUR) WHERE email = ?',
+      ['resend@example.com'],
+    );
+
+    const res = await request(app)
+      .post('/api/auth/resend-verification')
+      .send({ email: 'resend@example.com' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/verification/i);
+    expect(sendVerificationEmail).toHaveBeenCalledWith('resend@example.com', expect.any(String));
+  });
+
+  it('returns 200 for non-existent email (no leak)', async () => {
+    const res = await request(app)
+      .post('/api/auth/resend-verification')
+      .send({ email: 'nobody@example.com' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBeDefined();
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 for already verified email (no leak)', async () => {
+    await registerAdmin(app, 'verified@example.com');
+
+    const res = await request(app)
+      .post('/api/auth/resend-verification')
+      .send({ email: 'verified@example.com' });
+
+    expect(res.status).toBe(200);
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
+  });
+});
+
 describe('POST /api/auth/login', () => {
   let app: Express;
 
   beforeEach(async () => {
     app = await createTestApp();
+    vi.clearAllMocks();
 
-    // Seed a user for login tests
-    await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'user@example.com', password: VALID_PASSWORD, displayName: 'User' });
+    // Seed: register admin, then a verified user
+    await registerAdmin(app);
+    await registerUser(app, 'user@example.com', 'User');
+    await verifyUserEmail('user@example.com');
   });
 
   it('successful login', async () => {
@@ -168,7 +337,6 @@ describe('POST /api/auth/login', () => {
   });
 
   it('rejects disabled account', async () => {
-    // Disable the user via DB
     const user = await queryOne<{ id: string }>('SELECT id FROM users WHERE email = ?', ['user@example.com']);
     await execute('UPDATE users SET is_active = FALSE WHERE id = ?', [user!.id]);
 
@@ -181,13 +349,8 @@ describe('POST /api/auth/login', () => {
   });
 
   it('rejects unverified email', async () => {
-    // Create a second user and mark as unverified
-    await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'unverified@example.com', password: VALID_PASSWORD, displayName: 'Unverified' });
-
-    const user = await queryOne<{ id: string }>('SELECT id FROM users WHERE email = ?', ['unverified@example.com']);
-    await execute('UPDATE users SET email_verified = FALSE WHERE id = ?', [user!.id]);
+    // Create an unverified user
+    await registerUser(app, 'unverified@example.com');
 
     const res = await request(app)
       .post('/api/auth/login')
@@ -211,7 +374,6 @@ describe('POST /api/auth/logout', () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ ok: true });
-    // The set-cookie header should clear the auth cookie
     const cookies = res.headers['set-cookie'];
     expect(cookies).toBeDefined();
     const raw = Array.isArray(cookies) ? cookies[0] : cookies;
@@ -224,14 +386,11 @@ describe('GET /api/auth/me', () => {
 
   beforeEach(async () => {
     app = await createTestApp();
+    vi.clearAllMocks();
   });
 
   it('returns user info with new fields', async () => {
-    const registerRes = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'me@example.com', password: VALID_PASSWORD, displayName: 'Me' });
-
-    const cookie = extractCookie(registerRes);
+    const cookie = await registerAdmin(app, 'me@example.com');
 
     const res = await request(app)
       .get('/api/auth/me')
@@ -240,7 +399,7 @@ describe('GET /api/auth/me', () => {
     expect(res.status).toBe(200);
     expect(res.body.user).toMatchObject({
       email: 'me@example.com',
-      displayName: 'Me',
+      displayName: 'Admin',
       role: 'admin',
       authProvider: 'local',
       isActive: true,
@@ -259,13 +418,8 @@ describe('GET /api/auth/me', () => {
   });
 
   it('401 for disabled account', async () => {
-    const registerRes = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'disabled@example.com', password: VALID_PASSWORD, displayName: 'Disabled' });
+    const cookie = await registerAdmin(app, 'disabled@example.com');
 
-    const cookie = extractCookie(registerRes);
-
-    // Disable the user
     const user = await queryOne<{ id: string }>('SELECT id FROM users WHERE email = ?', ['disabled@example.com']);
     await execute('UPDATE users SET is_active = FALSE WHERE id = ?', [user!.id]);
 
@@ -273,7 +427,6 @@ describe('GET /api/auth/me', () => {
       .get('/api/auth/me')
       .set('Cookie', cookie);
 
-    // authMiddleware sets user to null when is_active = false → 401
     expect(res.status).toBe(401);
   });
 });
@@ -283,14 +436,11 @@ describe('PUT /api/auth/me', () => {
 
   beforeEach(async () => {
     app = await createTestApp();
+    vi.clearAllMocks();
   });
 
   it('updates display name', async () => {
-    const registerRes = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'update@example.com', password: VALID_PASSWORD, displayName: 'Before' });
-
-    const cookie = extractCookie(registerRes);
+    const cookie = await registerAdmin(app, 'update@example.com');
 
     const res = await request(app)
       .put('/api/auth/me')
@@ -302,13 +452,8 @@ describe('PUT /api/auth/me', () => {
   });
 
   it('updates password with strong password', async () => {
-    const registerRes = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'pwchange@example.com', password: VALID_PASSWORD, displayName: 'PW' });
+    const cookie = await registerAdmin(app, 'pwchange@example.com');
 
-    const cookie = extractCookie(registerRes);
-
-    // Update password
     const updateRes = await request(app)
       .put('/api/auth/me')
       .set('Cookie', cookie)
@@ -316,21 +461,15 @@ describe('PUT /api/auth/me', () => {
 
     expect(updateRes.status).toBe(200);
 
-    // Verify new password works for login
     const loginRes = await request(app)
       .post('/api/auth/login')
       .send({ email: 'pwchange@example.com', password: 'NewPassword2' });
 
     expect(loginRes.status).toBe(200);
-    expect(loginRes.body.user.email).toBe('pwchange@example.com');
   });
 
   it('rejects weak password update', async () => {
-    const registerRes = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'weakpw@example.com', password: VALID_PASSWORD, displayName: 'WeakPw' });
-
-    const cookie = extractCookie(registerRes);
+    const cookie = await registerAdmin(app, 'weakpw@example.com');
 
     const res = await request(app)
       .put('/api/auth/me')
@@ -346,14 +485,11 @@ describe('GET /api/auth/users', () => {
 
   beforeEach(async () => {
     app = await createTestApp();
+    vi.clearAllMocks();
   });
 
   it('finds by email', async () => {
-    const registerRes = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'searchme@example.com', password: VALID_PASSWORD, displayName: 'SearchMe' });
-
-    const cookie = extractCookie(registerRes);
+    const cookie = await registerAdmin(app, 'searchme@example.com');
 
     const res = await request(app)
       .get('/api/auth/users?q=searchme')
@@ -366,17 +502,11 @@ describe('GET /api/auth/users', () => {
   });
 
   it('excludes disabled users from search', async () => {
-    const registerRes = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'admin@example.com', password: VALID_PASSWORD, displayName: 'Admin' });
+    const cookie = await registerAdmin(app);
 
-    const cookie = extractCookie(registerRes);
-
-    // Create another user and disable it
-    await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'hidden@example.com', password: VALID_PASSWORD, displayName: 'Hidden' });
-
+    // Create and verify another user, then disable
+    await registerUser(app, 'hidden@example.com', 'Hidden');
+    await verifyUserEmail('hidden@example.com');
     const user = await queryOne<{ id: string }>('SELECT id FROM users WHERE email = ?', ['hidden@example.com']);
     await execute('UPDATE users SET is_active = FALSE WHERE id = ?', [user!.id]);
 
@@ -389,11 +519,7 @@ describe('GET /api/auth/users', () => {
   });
 
   it('returns empty for short query', async () => {
-    const registerRes = await request(app)
-      .post('/api/auth/register')
-      .send({ email: 'test@example.com', password: VALID_PASSWORD, displayName: 'Test' });
-
-    const cookie = extractCookie(registerRes);
+    const cookie = await registerAdmin(app, 'test@example.com');
 
     const res = await request(app)
       .get('/api/auth/users?q=a')

--- a/tests/server/cache.test.ts
+++ b/tests/server/cache.test.ts
@@ -2,10 +2,17 @@
  * Server tests for cache routes (/api/cache).
  */
 
-import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import request from 'supertest';
 import type { Express } from 'express';
 import { createTestApp, closeTestApp } from './test-helpers.js';
+
+// Mock mailer
+vi.mock('../../server/src/utils/mailer.js', () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+  sendWelcomeEmail: vi.fn().mockResolvedValue(undefined),
+  setTransporter: vi.fn(),
+}));
 
 /** Extract the set-cookie header value to use in subsequent requests. */
 function extractCookie(res: request.Response): string {

--- a/tests/server/migrate.test.ts
+++ b/tests/server/migrate.test.ts
@@ -2,10 +2,17 @@
  * Server tests for migration route (/api/migrate).
  */
 
-import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import request from 'supertest';
 import type { Express } from 'express';
 import { createTestApp, closeTestApp } from './test-helpers.js';
+
+// Mock mailer
+vi.mock('../../server/src/utils/mailer.js', () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+  sendWelcomeEmail: vi.fn().mockResolvedValue(undefined),
+  setTransporter: vi.fn(),
+}));
 
 /** Extract the set-cookie header value to use in subsequent requests. */
 function extractCookie(res: request.Response): string {

--- a/tests/server/rbac.test.ts
+++ b/tests/server/rbac.test.ts
@@ -3,14 +3,22 @@
  * Tests user-to-user sharing, group sharing, and global sharing flows.
  */
 
-import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import request from 'supertest';
-import { createTestApp, closeTestApp } from './test-helpers.js';
+import { createTestApp, closeTestApp, authCookie } from './test-helpers.js';
+import { execute, queryOne } from '../../server/src/db/database.js';
 import type { Express } from 'express';
+
+// Mock mailer
+vi.mock('../../server/src/utils/mailer.js', () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+  sendWelcomeEmail: vi.fn().mockResolvedValue(undefined),
+  setTransporter: vi.fn(),
+}));
 
 let app: Express;
 
-/** Register a user and return { userId, cookies } */
+/** Register a user and return { userId, cookies }. Auto-verifies non-admin users. */
 async function registerUser(
   app: Express,
   email: string,
@@ -21,8 +29,18 @@ async function registerUser(
     .post('/api/auth/register')
     .send({ email, password, displayName });
   expect(res.status).toBe(201);
-  const cookies = res.headers['set-cookie'] as unknown as string[];
-  return { userId: res.body.user.id, cookies };
+
+  if (res.body.user) {
+    // Admin: already verified
+    const cookies = res.headers['set-cookie'] as unknown as string[];
+    return { userId: res.body.user.id, cookies };
+  }
+
+  // Non-admin: verify in DB and build cookie
+  await execute('UPDATE users SET email_verified = TRUE, verification_token_hash = NULL WHERE email = ?', [email]);
+  const user = await queryOne<{ id: string; role: string }>('SELECT id, role FROM users WHERE email = ?', [email]);
+  const cookie = authCookie({ userId: user!.id, email, role: user!.role });
+  return { userId: user!.id, cookies: [cookie] };
 }
 
 /** Create a source owned by the authenticated user, return source id */

--- a/tests/server/sources.test.ts
+++ b/tests/server/sources.test.ts
@@ -2,14 +2,22 @@
  * Server tests for the sources CRUD routes.
  */
 
-import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import request from 'supertest';
 import { createTestApp, closeTestApp, authCookie } from './test-helpers.js';
+import { execute, queryOne } from '../../server/src/db/database.js';
 import type { Express } from 'express';
+
+// Mock mailer
+vi.mock('../../server/src/utils/mailer.js', () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+  sendWelcomeEmail: vi.fn().mockResolvedValue(undefined),
+  setTransporter: vi.fn(),
+}));
 
 let app: Express;
 
-/** Register a user via the API and return { id, email, cookie }. */
+/** Register a user via the API and return { id, email, cookie }. Auto-verifies non-admin users. */
 async function registerUser(
   email: string,
   password = 'Password1',
@@ -18,10 +26,20 @@ async function registerUser(
   const res = await request(app)
     .post('/api/auth/register')
     .send({ email, password, displayName });
-  const userId = res.body.user.id as string;
-  const role = res.body.user.role as string;
-  const cookie = authCookie({ userId, email, role });
-  return { id: userId, email, role, cookie };
+
+  if (res.body.user) {
+    // Admin: already verified and logged in
+    const userId = res.body.user.id as string;
+    const role = res.body.user.role as string;
+    const cookie = authCookie({ userId, email, role });
+    return { id: userId, email, role, cookie };
+  }
+
+  // Non-admin: verify email in DB, then build cookie from DB
+  await execute('UPDATE users SET email_verified = TRUE, verification_token_hash = NULL WHERE email = ?', [email]);
+  const user = await queryOne<{ id: string; role: string }>('SELECT id, role FROM users WHERE email = ?', [email]);
+  const cookie = authCookie({ userId: user!.id, email, role: user!.role });
+  return { id: user!.id, email, role: user!.role, cookie };
 }
 
 /** Helper to create a source for a user. */

--- a/tests/server/test-helpers.ts
+++ b/tests/server/test-helpers.ts
@@ -67,16 +67,17 @@ export async function createTestApp(): Promise<Express> {
   if (!initialized) {
     await initDatabase();
     initialized = true;
-  } else {
-    // Truncate all tables for clean state (disable FK checks temporarily)
-    await execute('SET FOREIGN_KEY_CHECKS = 0');
-    for (const table of TABLES_TO_TRUNCATE) {
-      await execute(`TRUNCATE TABLE ${table}`);
-    }
-    await execute('SET FOREIGN_KEY_CHECKS = 1');
-    // Re-insert schema_version
-    await execute('INSERT IGNORE INTO schema_version (version) VALUES (1)');
   }
+
+  // Truncate all tables for clean state (disable FK checks temporarily)
+  await execute('SET FOREIGN_KEY_CHECKS = 0');
+  for (const table of TABLES_TO_TRUNCATE) {
+    await execute(`TRUNCATE TABLE ${table}`);
+  }
+  await execute('SET FOREIGN_KEY_CHECKS = 1');
+  // Re-insert schema_version
+  await execute('INSERT IGNORE INTO schema_version (version) VALUES (1)');
+  await execute('INSERT IGNORE INTO schema_version (version) VALUES (2)');
 
   const app = express();
   app.use(express.json({ limit: '10mb' }));


### PR DESCRIPTION
## Summary

Deuxieme PR de [FR-002](https://github.com/bmatge/dsfr-data/issues/12) — verification d'email a l'inscription via SMTP.

- **Module mailer** (`nodemailer`) : envoie via `mailserver` sur `ecosystem-network` (port 25, DKIM, pas d'auth)
- **Register modifie** : les non-admins recoivent un email de verification au lieu d'un JWT. Token opaque 32 bytes, stocke en SHA-256, expire 24h
- **Premier user (admin)** : exempt de la verification, connecte immediatement
- **`GET /verify-email?token=xxx`** : verifie le token, active le compte, pose le JWT, redirect `/`
- **`POST /resend-verification`** : renvoie l'email (throttle 20 min entre envois). Retourne toujours 200 (pas de leak d'existence)
- **Re-inscription** : un compte non verifie peut etre remplace par une nouvelle inscription avec le meme email
- **Cleanup au demarrage** : supprime les comptes non verifies expires depuis > 7 jours
- **`sendWelcomeEmail()`** : prepare pour PR 6 (ProConnect, email de bienvenue fire-and-forget)

## Fichiers cles

| Fichier | Description |
|---------|-------------|
| `server/src/utils/mailer.ts` | Transport SMTP, `sendVerificationEmail()`, `sendWelcomeEmail()`, `setTransporter()` pour tests |
| `server/src/routes/auth.ts` | Register, verify-email, resend-verification |
| `server/src/index.ts` | Cleanup des comptes expires au demarrage |
| `docker-compose.db.yml` | +SMTP_HOST, SMTP_PORT, SMTP_FROM, APP_URL |
| `.env.example` | Documentation SMTP |

## Test plan

- [x] 68/68 tests serveur passent (31 auth dont 7 nouveaux)
- [x] Mailer mocke dans tous les fichiers de test
- [ ] Test en deploiement : verifier que l'email arrive via `mailserver` sur ecosystem-network
- [ ] Verifier le lien de verification en navigateur (redirect + cookie)

**Depends on** : PR #13 (PR 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)