### PR TITLE
feat(auth): revocable sessions (FR-002 PR3)

### DIFF
--- a/server/src/db/database.ts
+++ b/server/src/db/database.ts
@@ -150,6 +150,9 @@ async function runMigrations(): Promise<void> {
   if (currentVersion < 2) {
     await migrateV2();
   }
+  if (currentVersion < 3) {
+    await migrateV3();
+  }
 }
 
 /**
@@ -210,6 +213,37 @@ async function migrateV2(): Promise<void> {
   } catch (err) {
     await conn.rollback();
     throw err;
+  } finally {
+    conn.release();
+  }
+}
+
+/**
+ * Migration v3: sessions table for JWT revocation tracking.
+ */
+async function migrateV3(): Promise<void> {
+  console.log('[db] Running migration v3: sessions table');
+
+  const conn = await getPool().getConnection();
+  try {
+    await conn.query(`CREATE TABLE IF NOT EXISTS sessions (
+      id VARCHAR(36) NOT NULL PRIMARY KEY,
+      user_id VARCHAR(36) NOT NULL,
+      token_hash VARCHAR(64) NOT NULL,
+      auth_provider ENUM('local', 'proconnect') NOT NULL,
+      ip_address VARCHAR(45),
+      user_agent VARCHAR(500),
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      expires_at TIMESTAMP NOT NULL,
+      revoked_at TIMESTAMP NULL,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+      INDEX idx_sessions_user (user_id),
+      INDEX idx_sessions_token (token_hash),
+      INDEX idx_sessions_expires (expires_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`);
+
+    await conn.query('INSERT IGNORE INTO schema_version (version) VALUES (3)');
+    console.log('[db] Migration v3 complete');
   } finally {
     conn.release();
   }

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -7,6 +7,7 @@
 import type { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 import { queryOne } from '../db/database.js';
+import { isSessionValid } from '../utils/sessions.js';
 
 export interface JwtPayload {
   userId: string;
@@ -51,6 +52,9 @@ export async function authMiddleware(req: Request, _res: Response, next: NextFun
       [payload.userId],
     );
     if (!user || !user.is_active) {
+      authReq.user = null;
+    } else if (!(await isSessionValid(token))) {
+      // Session revoked
       authReq.user = null;
     } else {
       authReq.user = payload;

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -12,6 +12,7 @@ import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { authLimiter } from '../middleware/rate-limit.js';
 import { isValidEmail, isStrongPassword } from '../utils/validation.js';
 import { sendVerificationEmail } from '../utils/mailer.js';
+import { createSession, revokeSession } from '../utils/sessions.js';
 
 const router = Router();
 const SALT_ROUNDS = 10;
@@ -84,6 +85,7 @@ router.post('/register', authLimiter, async (req, res) => {
 
       const token = createToken({ userId: id, email, role });
       setAuthCookie(res, token);
+      await createSession(id, token, 'local', req);
 
       res.status(201).json({
         user: { id, email, displayName: name, role },
@@ -162,6 +164,7 @@ router.get('/verify-email', async (req, res) => {
     // Log in
     const jwt = createToken({ userId: user.id, email: user.email, role: user.role });
     setAuthCookie(res, jwt);
+    await createSession(user.id, jwt, 'local', req);
 
     res.redirect('/');
   } catch (err) {
@@ -280,6 +283,7 @@ router.post('/login', authLimiter, async (req, res) => {
 
     const token = createToken({ userId: user.id, email: user.email, role: user.role });
     setAuthCookie(res, token);
+    await createSession(user.id, token, 'local', req);
     await execute('UPDATE users SET last_login = NOW() WHERE id = ?', [user.id]);
 
     res.json({
@@ -298,9 +302,17 @@ router.post('/login', authLimiter, async (req, res) => {
 
 /**
  * POST /api/auth/logout
- * Clear the auth cookie.
+ * Clear the auth cookie and revoke the session.
  */
-router.post('/logout', (_req, res) => {
+router.post('/logout', async (req, res) => {
+  const token = req.cookies?.['gw-auth-token'];
+  if (token) {
+    try {
+      await revokeSession(token);
+    } catch {
+      // Best-effort revocation
+    }
+  }
   clearAuthCookie(res);
   res.json({ ok: true });
 });

--- a/server/src/utils/sessions.ts
+++ b/server/src/utils/sessions.ts
@@ -1,0 +1,74 @@
+/**
+ * Session management: create, verify, and revoke JWT sessions.
+ * Sessions are stored in DB with a SHA-256 hash of the JWT token.
+ */
+
+import crypto from 'node:crypto';
+import { v4 as uuidv4 } from 'uuid';
+import { queryOne, execute } from '../db/database.js';
+import type { Request } from 'express';
+
+/** Hash a JWT token with SHA-256 for DB storage. */
+export function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+/**
+ * Create a session record in the database.
+ * Called after successful login/register/verify-email.
+ */
+export async function createSession(
+  userId: string,
+  token: string,
+  authProvider: 'local' | 'proconnect',
+  req: Request,
+): Promise<string> {
+  const id = uuidv4();
+  const tokenHash = hashToken(token);
+  const ip = req.ip || req.socket?.remoteAddress || null;
+  const userAgent = req.headers['user-agent']?.substring(0, 500) || null;
+  // 7 days expiry (matching JWT)
+  await execute(
+    `INSERT INTO sessions (id, user_id, token_hash, auth_provider, ip_address, user_agent, expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, DATE_ADD(NOW(), INTERVAL 7 DAY))`,
+    [id, userId, tokenHash, authProvider, ip, userAgent],
+  );
+  return id;
+}
+
+/**
+ * Check if a session is valid (exists and not revoked).
+ */
+export async function isSessionValid(token: string): Promise<boolean> {
+  const tokenHash = hashToken(token);
+  const session = await queryOne<{ revoked_at: string | null; expires_at: string }>(
+    'SELECT revoked_at, expires_at FROM sessions WHERE token_hash = ?',
+    [tokenHash],
+  );
+  if (!session) return true; // No session record = legacy token (pre-sessions), allow
+  if (session.revoked_at) return false;
+  if (new Date(session.expires_at) < new Date()) return false;
+  return true;
+}
+
+/**
+ * Revoke a session by token.
+ */
+export async function revokeSession(token: string): Promise<void> {
+  const tokenHash = hashToken(token);
+  await execute(
+    'UPDATE sessions SET revoked_at = NOW() WHERE token_hash = ? AND revoked_at IS NULL',
+    [tokenHash],
+  );
+}
+
+/**
+ * Revoke all active sessions for a user.
+ */
+export async function revokeAllUserSessions(userId: string): Promise<number> {
+  const result = await execute(
+    'UPDATE sessions SET revoked_at = NOW() WHERE user_id = ? AND revoked_at IS NULL',
+    [userId],
+  );
+  return result.affectedRows;
+}

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -366,6 +366,7 @@ describe('POST /api/auth/logout', () => {
 
   beforeEach(async () => {
     app = await createTestApp();
+    vi.clearAllMocks();
   });
 
   it('clears cookie', async () => {
@@ -378,6 +379,28 @@ describe('POST /api/auth/logout', () => {
     expect(cookies).toBeDefined();
     const raw = Array.isArray(cookies) ? cookies[0] : cookies;
     expect(raw).toMatch(/gw-auth-token=/);
+  });
+
+  it('revokes session so token cannot be reused', async () => {
+    // Login as admin
+    const cookie = await registerAdmin(app, 'logout-test@example.com');
+
+    // Verify we can access /me
+    const meRes = await request(app)
+      .get('/api/auth/me')
+      .set('Cookie', cookie);
+    expect(meRes.status).toBe(200);
+
+    // Logout
+    await request(app)
+      .post('/api/auth/logout')
+      .set('Cookie', cookie);
+
+    // Try to reuse the same token — should be rejected (session revoked)
+    const afterLogout = await request(app)
+      .get('/api/auth/me')
+      .set('Cookie', cookie);
+    expect(afterLogout.status).toBe(401);
   });
 });
 

--- a/tests/server/test-helpers.ts
+++ b/tests/server/test-helpers.ts
@@ -46,6 +46,7 @@ let initialized = false;
  * Tables in reverse FK order for truncation.
  */
 const TABLES_TO_TRUNCATE = [
+  'sessions',
   'data_cache',
   'monitoring',
   'shares',
@@ -78,6 +79,7 @@ export async function createTestApp(): Promise<Express> {
   // Re-insert schema_version
   await execute('INSERT IGNORE INTO schema_version (version) VALUES (1)');
   await execute('INSERT IGNORE INTO schema_version (version) VALUES (2)');
+  await execute('INSERT IGNORE INTO schema_version (version) VALUES (3)');
 
   const app = express();
   app.use(express.json({ limit: '10mb' }));


### PR DESCRIPTION
## Summary

Troisieme PR de [FR-002](https://github.com/bmatge/dsfr-data/issues/12) — sessions revocables.

- **Table `sessions`** (migration v3) : `id`, `user_id`, `token_hash` (SHA-256), `auth_provider`, `ip_address`, `user_agent`, `expires_at`, `revoked_at`
- **Enregistrement** : session creee a chaque login, register (admin), verify-email
- **Verification** : `authMiddleware` verifie que la session n'est pas revoquee
- **Logout** : revoque la session en DB — le token ne peut plus etre reutilise
- **Retrocompatibilite** : les tokens sans session (anterieurs a cette PR) sont acceptes
- **`revokeAllUserSessions()`** : helper expose pour l'admin (utilise dans PR 4)

## Test plan

- [x] 69/69 tests passent (1 nouveau : logout revoque la session)
- [ ] Verifier que le logout invalide bien le token en production

**Depends on** : PR #14 (PR 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)