### PR TITLE
feat(admin): user management API + audit log (FR-002 PR4)

### DIFF
--- a/server/src/db/database.ts
+++ b/server/src/db/database.ts
@@ -153,6 +153,9 @@ async function runMigrations(): Promise<void> {
   if (currentVersion < 3) {
     await migrateV3();
   }
+  if (currentVersion < 4) {
+    await migrateV4();
+  }
 }
 
 /**
@@ -244,6 +247,35 @@ async function migrateV3(): Promise<void> {
 
     await conn.query('INSERT IGNORE INTO schema_version (version) VALUES (3)');
     console.log('[db] Migration v3 complete');
+  } finally {
+    conn.release();
+  }
+}
+
+/**
+ * Migration v4: audit_log table for tracking sensitive actions.
+ */
+async function migrateV4(): Promise<void> {
+  console.log('[db] Running migration v4: audit_log table');
+
+  const conn = await getPool().getConnection();
+  try {
+    await conn.query(`CREATE TABLE IF NOT EXISTS audit_log (
+      id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+      user_id VARCHAR(36),
+      action VARCHAR(100) NOT NULL,
+      target_type VARCHAR(50),
+      target_id VARCHAR(36),
+      details JSON,
+      ip_address VARCHAR(45),
+      created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      INDEX idx_audit_user (user_id),
+      INDEX idx_audit_action (action),
+      INDEX idx_audit_created (created_at)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`);
+
+    await conn.query('INSERT IGNORE INTO schema_version (version) VALUES (4)');
+    console.log('[db] Migration v4 complete');
   } finally {
     conn.release();
   }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,6 +14,7 @@ import sharesRoutes from './routes/shares.js';
 import cacheRoutes from './routes/cache.js';
 import migrateRoutes from './routes/migrate.js';
 import monitoringRoutes from './routes/monitoring.js';
+import adminRoutes from './routes/admin.js';
 
 const app = express();
 const PORT = parseInt(process.env.PORT || '3002', 10);
@@ -46,6 +47,7 @@ app.use('/api/shares', sharesRoutes);
 app.use('/api/cache', cacheRoutes);
 app.use('/api/migrate', migrateRoutes);
 app.use('/api/monitoring', monitoringRoutes);
+app.use('/api/admin', adminRoutes);
 
 // Graceful shutdown
 async function shutdown() {

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1,0 +1,415 @@
+/**
+ * Admin routes: user management, session management, audit log, stats.
+ * All endpoints require admin role.
+ */
+
+import { Router } from 'express';
+import { query, queryOne, execute, transaction, connQuery, connQueryOne, connExecute } from '../db/database.js';
+import { requireAuth } from '../middleware/auth.js';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { requireRole } from '../middleware/rbac.js';
+import { revokeAllUserSessions } from '../utils/sessions.js';
+import { logAudit } from '../utils/audit.js';
+
+const router = Router();
+
+// All admin routes require auth + admin role
+router.use(requireAuth);
+router.use(requireRole('admin'));
+
+/**
+ * GET /api/admin/users
+ * Paginated list of all users.
+ */
+router.get('/users', async (req, res) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page as string) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 20));
+    const offset = (page - 1) * limit;
+
+    const countRow = await queryOne<{ total: number }>('SELECT COUNT(*) as total FROM users');
+    const total = countRow?.total || 0;
+
+    const users = await query<{
+      id: string; email: string; display_name: string; role: string;
+      auth_provider: string; is_active: number; email_verified: number;
+      last_login: string | null; created_at: string;
+    }>(
+      `SELECT id, email, display_name, role, auth_provider, is_active, email_verified, last_login, created_at
+       FROM users ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+      [limit, offset],
+    );
+
+    res.json({
+      users: users.map(u => ({
+        id: u.id,
+        email: u.email,
+        displayName: u.display_name,
+        role: u.role,
+        authProvider: u.auth_provider,
+        isActive: !!u.is_active,
+        emailVerified: !!u.email_verified,
+        lastLogin: u.last_login,
+        createdAt: u.created_at,
+      })),
+      pagination: { page, limit, total, pages: Math.ceil(total / limit) },
+    });
+  } catch (err) {
+    console.error('Admin list users error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/admin/users/:id
+ * User detail with resource counts.
+ */
+router.get('/users/:id', async (req, res) => {
+  try {
+    const user = await queryOne<{
+      id: string; email: string; display_name: string; role: string;
+      auth_provider: string; external_id: string | null; idp_id: string | null;
+      siret: string | null; organizational_unit: string | null;
+      is_active: number; email_verified: number; last_login: string | null; created_at: string;
+    }>(
+      `SELECT id, email, display_name, role, auth_provider, external_id, idp_id, siret,
+       organizational_unit, is_active, email_verified, last_login, created_at
+       FROM users WHERE id = ?`,
+      [req.params.id],
+    );
+
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    // Count resources
+    const [sources, connections, favorites, dashboards] = await Promise.all([
+      queryOne<{ count: number }>('SELECT COUNT(*) as count FROM sources WHERE owner_id = ?', [user.id]),
+      queryOne<{ count: number }>('SELECT COUNT(*) as count FROM connections WHERE owner_id = ?', [user.id]),
+      queryOne<{ count: number }>('SELECT COUNT(*) as count FROM favorites WHERE owner_id = ?', [user.id]),
+      queryOne<{ count: number }>('SELECT COUNT(*) as count FROM dashboards WHERE owner_id = ?', [user.id]),
+    ]);
+
+    res.json({
+      user: {
+        id: user.id,
+        email: user.email,
+        displayName: user.display_name,
+        role: user.role,
+        authProvider: user.auth_provider,
+        externalId: user.external_id,
+        idpId: user.idp_id,
+        siret: user.siret,
+        organizationalUnit: user.organizational_unit,
+        isActive: !!user.is_active,
+        emailVerified: !!user.email_verified,
+        lastLogin: user.last_login,
+        createdAt: user.created_at,
+      },
+      resources: {
+        sources: sources?.count || 0,
+        connections: connections?.count || 0,
+        favorites: favorites?.count || 0,
+        dashboards: dashboards?.count || 0,
+      },
+    });
+  } catch (err) {
+    console.error('Admin get user error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * PUT /api/admin/users/:id/role
+ * Change a user's role.
+ */
+router.put('/users/:id/role', async (req, res) => {
+  try {
+    const authReq = req as AuthenticatedRequest;
+    const { role } = req.body;
+    const targetId = req.params.id;
+
+    if (!['admin', 'editor', 'viewer'].includes(role)) {
+      res.status(400).json({ error: 'Invalid role. Must be admin, editor, or viewer' });
+      return;
+    }
+
+    // Cannot change own role
+    if (targetId === authReq.user!.userId) {
+      res.status(400).json({ error: 'Cannot change your own role' });
+      return;
+    }
+
+    const target = await queryOne<{ id: string; role: string }>(
+      'SELECT id, role FROM users WHERE id = ?', [targetId],
+    );
+    if (!target) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    // If demoting from admin, ensure at least 1 admin remains
+    if (target.role === 'admin' && role !== 'admin') {
+      const adminCount = await queryOne<{ count: number }>(
+        'SELECT COUNT(*) as count FROM users WHERE role = ? AND is_active = TRUE',
+        ['admin'],
+      );
+      if ((adminCount?.count || 0) <= 1) {
+        res.status(400).json({ error: 'Cannot remove the last admin' });
+        return;
+      }
+    }
+
+    await execute('UPDATE users SET role = ?, updated_at = NOW() WHERE id = ?', [role, targetId]);
+    await logAudit(req, 'role_change', 'user', targetId, { from: target.role, to: role });
+
+    res.json({ ok: true, role });
+  } catch (err) {
+    console.error('Admin change role error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * PUT /api/admin/users/:id/status
+ * Activate or deactivate a user.
+ */
+router.put('/users/:id/status', async (req, res) => {
+  try {
+    const authReq = req as AuthenticatedRequest;
+    const { active } = req.body;
+    const targetId = req.params.id;
+
+    if (typeof active !== 'boolean') {
+      res.status(400).json({ error: 'active must be a boolean' });
+      return;
+    }
+
+    // Cannot deactivate yourself
+    if (targetId === authReq.user!.userId && !active) {
+      res.status(400).json({ error: 'Cannot deactivate your own account' });
+      return;
+    }
+
+    const target = await queryOne<{ id: string; role: string }>(
+      'SELECT id, role FROM users WHERE id = ?', [targetId],
+    );
+    if (!target) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    // If deactivating an admin, ensure at least 1 active admin remains
+    if (!active && target.role === 'admin') {
+      const adminCount = await queryOne<{ count: number }>(
+        'SELECT COUNT(*) as count FROM users WHERE role = ? AND is_active = TRUE',
+        ['admin'],
+      );
+      if ((adminCount?.count || 0) <= 1) {
+        res.status(400).json({ error: 'Cannot deactivate the last admin' });
+        return;
+      }
+    }
+
+    await execute('UPDATE users SET is_active = ?, updated_at = NOW() WHERE id = ?', [active, targetId]);
+    await logAudit(req, active ? 'user_activate' : 'user_deactivate', 'user', targetId);
+
+    // Revoke all sessions when deactivating
+    if (!active) {
+      await revokeAllUserSessions(targetId);
+    }
+
+    res.json({ ok: true, active });
+  } catch (err) {
+    console.error('Admin change status error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * DELETE /api/admin/users/:id
+ * Delete a user and cascade (resources, shares, group_members).
+ */
+router.delete('/users/:id', async (req, res) => {
+  try {
+    const authReq = req as AuthenticatedRequest;
+    const targetId = req.params.id;
+
+    // Cannot delete yourself
+    if (targetId === authReq.user!.userId) {
+      res.status(400).json({ error: 'Cannot delete your own account' });
+      return;
+    }
+
+    const target = await queryOne<{ id: string; role: string; email: string }>(
+      'SELECT id, role, email FROM users WHERE id = ?', [targetId],
+    );
+    if (!target) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+
+    // Cannot delete the last admin
+    if (target.role === 'admin') {
+      const adminCount = await queryOne<{ count: number }>(
+        'SELECT COUNT(*) as count FROM users WHERE role = ? AND is_active = TRUE',
+        ['admin'],
+      );
+      if ((adminCount?.count || 0) <= 1) {
+        res.status(400).json({ error: 'Cannot delete the last admin' });
+        return;
+      }
+    }
+
+    // Cascade delete in transaction
+    await transaction(async (conn) => {
+      // Delete shares granted by or targeting this user
+      await connExecute(conn, 'DELETE FROM shares WHERE granted_by = ? OR (target_type = ? AND target_id = ?)',
+        [targetId, 'user', targetId]);
+      // Delete resources
+      for (const table of ['sources', 'connections', 'favorites', 'dashboards']) {
+        await connExecute(conn, `DELETE FROM ${table} WHERE owner_id = ?`, [targetId]);
+      }
+      // Delete group memberships
+      await connExecute(conn, 'DELETE FROM group_members WHERE user_id = ?', [targetId]);
+      // Delete sessions
+      await connExecute(conn, 'DELETE FROM sessions WHERE user_id = ?', [targetId]);
+      // Delete user
+      await connExecute(conn, 'DELETE FROM users WHERE id = ?', [targetId]);
+    });
+
+    await logAudit(req, 'user_delete', 'user', targetId, { email: target.email });
+    res.json({ ok: true });
+  } catch (err) {
+    console.error('Admin delete user error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/admin/users/:id/sessions
+ * List active sessions for a user.
+ */
+router.get('/users/:id/sessions', async (req, res) => {
+  try {
+    const sessions = await query<{
+      id: string; auth_provider: string; ip_address: string | null;
+      user_agent: string | null; created_at: string; expires_at: string; revoked_at: string | null;
+    }>(
+      `SELECT id, auth_provider, ip_address, user_agent, created_at, expires_at, revoked_at
+       FROM sessions WHERE user_id = ? ORDER BY created_at DESC LIMIT 50`,
+      [req.params.id],
+    );
+
+    res.json(sessions.map(s => ({
+      id: s.id,
+      authProvider: s.auth_provider,
+      ipAddress: s.ip_address,
+      userAgent: s.user_agent,
+      createdAt: s.created_at,
+      expiresAt: s.expires_at,
+      revokedAt: s.revoked_at,
+      isActive: !s.revoked_at && new Date(s.expires_at) > new Date(),
+    })));
+  } catch (err) {
+    console.error('Admin list sessions error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * DELETE /api/admin/users/:id/sessions
+ * Revoke all active sessions for a user.
+ */
+router.delete('/users/:id/sessions', async (req, res) => {
+  try {
+    const count = await revokeAllUserSessions(req.params.id);
+    await logAudit(req, 'sessions_revoke_all', 'user', req.params.id, { count });
+    res.json({ ok: true, revoked: count });
+  } catch (err) {
+    console.error('Admin revoke sessions error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/admin/audit
+ * Paginated audit log with optional filters.
+ */
+router.get('/audit', async (req, res) => {
+  try {
+    const page = Math.max(1, parseInt(req.query.page as string) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit as string) || 50));
+    const offset = (page - 1) * limit;
+    const action = req.query.action as string | undefined;
+    const userId = req.query.user_id as string | undefined;
+
+    let where = '1=1';
+    const params: unknown[] = [];
+    if (action) { where += ' AND action = ?'; params.push(action); }
+    if (userId) { where += ' AND user_id = ?'; params.push(userId); }
+
+    const countRow = await queryOne<{ total: number }>(
+      `SELECT COUNT(*) as total FROM audit_log WHERE ${where}`, params,
+    );
+    const total = countRow?.total || 0;
+
+    const logs = await query<{
+      id: number; user_id: string | null; action: string; target_type: string | null;
+      target_id: string | null; details: string | null; ip_address: string | null; created_at: string;
+    }>(
+      `SELECT id, user_id, action, target_type, target_id, details, ip_address, created_at
+       FROM audit_log WHERE ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+      [...params, limit, offset],
+    );
+
+    res.json({
+      logs: logs.map(l => ({
+        id: l.id,
+        userId: l.user_id,
+        action: l.action,
+        targetType: l.target_type,
+        targetId: l.target_id,
+        details: l.details ? JSON.parse(l.details) : null,
+        ipAddress: l.ip_address,
+        createdAt: l.created_at,
+      })),
+      pagination: { page, limit, total, pages: Math.ceil(total / limit) },
+    });
+  } catch (err) {
+    console.error('Admin audit log error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+/**
+ * GET /api/admin/stats
+ * Global statistics.
+ */
+router.get('/stats', async (req, res) => {
+  try {
+    const [byRole, byProvider, total, active] = await Promise.all([
+      query<{ role: string; count: number }>(
+        'SELECT role, COUNT(*) as count FROM users GROUP BY role',
+      ),
+      query<{ auth_provider: string; count: number }>(
+        'SELECT auth_provider, COUNT(*) as count FROM users GROUP BY auth_provider',
+      ),
+      queryOne<{ count: number }>('SELECT COUNT(*) as count FROM users'),
+      queryOne<{ count: number }>('SELECT COUNT(*) as count FROM users WHERE is_active = TRUE'),
+    ]);
+
+    res.json({
+      totalUsers: total?.count || 0,
+      activeUsers: active?.count || 0,
+      byRole: Object.fromEntries(byRole.map(r => [r.role, r.count])),
+      byProvider: Object.fromEntries(byProvider.map(p => [p.auth_provider, p.count])),
+    });
+  } catch (err) {
+    console.error('Admin stats error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/server/src/utils/audit.ts
+++ b/server/src/utils/audit.ts
@@ -1,0 +1,29 @@
+/**
+ * Audit log helper — records sensitive actions for traceability.
+ */
+
+import { execute } from '../db/database.js';
+import type { Request } from 'express';
+import type { AuthenticatedRequest } from '../middleware/auth.js';
+
+export async function logAudit(
+  req: Request,
+  action: string,
+  targetType?: string,
+  targetId?: string,
+  details?: Record<string, unknown>,
+): Promise<void> {
+  const authReq = req as AuthenticatedRequest;
+  const userId = authReq.user?.userId || null;
+  const ip = req.ip || req.socket?.remoteAddress || null;
+  try {
+    await execute(
+      `INSERT INTO audit_log (user_id, action, target_type, target_id, details, ip_address)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [userId, action, targetType || null, targetId || null, details ? JSON.stringify(details) : null, ip],
+    );
+  } catch (err) {
+    // Best-effort logging — don't break the request
+    console.error('[audit] Failed to log:', action, err);
+  }
+}

--- a/tests/server/admin.test.ts
+++ b/tests/server/admin.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Server tests for admin routes (/api/admin).
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import type { Express } from 'express';
+import { createTestApp, closeTestApp, authCookie } from './test-helpers.js';
+import { execute, queryOne } from '../../server/src/db/database.js';
+
+// Mock mailer
+vi.mock('../../server/src/utils/mailer.js', () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+  sendWelcomeEmail: vi.fn().mockResolvedValue(undefined),
+  setTransporter: vi.fn(),
+}));
+
+const VALID_PASSWORD = 'Password1';
+
+/** Extract cookie from register response. */
+function extractCookie(res: request.Response): string {
+  const cookies = res.headers['set-cookie'];
+  if (!cookies) return '';
+  const raw = Array.isArray(cookies) ? cookies[0] : cookies;
+  return raw.split(';')[0];
+}
+
+/** Register admin (first user) and return cookie. */
+async function registerAdmin(app: Express, email = 'admin@example.com'): Promise<string> {
+  const res = await request(app)
+    .post('/api/auth/register')
+    .send({ email, password: VALID_PASSWORD, displayName: 'Admin' });
+  return extractCookie(res);
+}
+
+/** Register a non-admin user, verify in DB, return { id, cookie }. */
+async function registerVerifiedUser(app: Express, email: string, displayName?: string) {
+  await request(app)
+    .post('/api/auth/register')
+    .send({ email, password: VALID_PASSWORD, displayName: displayName || email.split('@')[0] });
+
+  await execute('UPDATE users SET email_verified = TRUE, verification_token_hash = NULL WHERE email = ?', [email]);
+  const user = await queryOne<{ id: string; role: string }>('SELECT id, role FROM users WHERE email = ?', [email]);
+  const cookie = authCookie({ userId: user!.id, email, role: user!.role });
+  return { id: user!.id, email, role: user!.role, cookie };
+}
+
+let app: Express;
+
+beforeEach(async () => {
+  app = await createTestApp();
+  vi.clearAllMocks();
+});
+
+afterAll(async () => {
+  await closeTestApp();
+});
+
+describe('GET /api/admin/users', () => {
+  it('returns paginated user list for admin', async () => {
+    const adminCookie = await registerAdmin(app);
+    await registerVerifiedUser(app, 'user1@example.com');
+    await registerVerifiedUser(app, 'user2@example.com');
+
+    const res = await request(app)
+      .get('/api/admin/users')
+      .set('Cookie', adminCookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.users).toHaveLength(3);
+    expect(res.body.pagination.total).toBe(3);
+  });
+
+  it('rejects non-admin', async () => {
+    await registerAdmin(app);
+    const editor = await registerVerifiedUser(app, 'editor@example.com');
+
+    const res = await request(app)
+      .get('/api/admin/users')
+      .set('Cookie', editor.cookie);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('GET /api/admin/users/:id', () => {
+  it('returns user detail with resource counts', async () => {
+    const adminCookie = await registerAdmin(app);
+    const user = await registerVerifiedUser(app, 'detail@example.com', 'Detail');
+
+    const res = await request(app)
+      .get(`/api/admin/users/${user.id}`)
+      .set('Cookie', adminCookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.email).toBe('detail@example.com');
+    expect(res.body.user.displayName).toBe('Detail');
+    expect(res.body.resources).toEqual({
+      sources: 0, connections: 0, favorites: 0, dashboards: 0,
+    });
+  });
+
+  it('returns 404 for unknown user', async () => {
+    const adminCookie = await registerAdmin(app);
+
+    const res = await request(app)
+      .get('/api/admin/users/nonexistent')
+      .set('Cookie', adminCookie);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('PUT /api/admin/users/:id/role', () => {
+  it('changes user role', async () => {
+    const adminCookie = await registerAdmin(app);
+    const user = await registerVerifiedUser(app, 'role-target@example.com');
+
+    const res = await request(app)
+      .put(`/api/admin/users/${user.id}/role`)
+      .set('Cookie', adminCookie)
+      .send({ role: 'viewer' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.role).toBe('viewer');
+
+    // Verify in DB
+    const updated = await queryOne<{ role: string }>('SELECT role FROM users WHERE id = ?', [user.id]);
+    expect(updated?.role).toBe('viewer');
+  });
+
+  it('cannot change own role', async () => {
+    const adminCookie = await registerAdmin(app);
+    const admin = await queryOne<{ id: string }>('SELECT id FROM users WHERE email = ?', ['admin@example.com']);
+
+    const res = await request(app)
+      .put(`/api/admin/users/${admin!.id}/role`)
+      .set('Cookie', adminCookie)
+      .send({ role: 'editor' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/own role/i);
+  });
+
+  it('cannot remove last admin', async () => {
+    const adminCookie = await registerAdmin(app);
+    // Create a second admin
+    const user = await registerVerifiedUser(app, 'admin2@example.com');
+    await execute('UPDATE users SET role = ? WHERE id = ?', ['admin', user.id]);
+
+    // Demote user (ok, still 1 admin left)
+    const res1 = await request(app)
+      .put(`/api/admin/users/${user.id}/role`)
+      .set('Cookie', adminCookie)
+      .send({ role: 'editor' });
+    expect(res1.status).toBe(200);
+
+    // Now there's only 1 admin — cannot demote self (blocked by own-role check)
+    // But let's try to demote via another admin scenario
+    // Re-promote user, then try to demote the original admin
+    await execute('UPDATE users SET role = ? WHERE id = ?', ['admin', user.id]);
+    const admin = await queryOne<{ id: string }>('SELECT id FROM users WHERE email = ?', ['admin@example.com']);
+
+    // User is now admin, use their cookie
+    const user2Cookie = authCookie({ userId: user.id, email: 'admin2@example.com', role: 'admin' });
+    const res2 = await request(app)
+      .put(`/api/admin/users/${admin!.id}/role`)
+      .set('Cookie', user2Cookie)
+      .send({ role: 'editor' });
+    // This should succeed (2 admins, demoting 1 leaves 1)
+    expect(res2.status).toBe(200);
+  });
+});
+
+describe('PUT /api/admin/users/:id/status', () => {
+  it('deactivates a user', async () => {
+    const adminCookie = await registerAdmin(app);
+    const user = await registerVerifiedUser(app, 'deactivate@example.com');
+
+    const res = await request(app)
+      .put(`/api/admin/users/${user.id}/status`)
+      .set('Cookie', adminCookie)
+      .send({ active: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body.active).toBe(false);
+
+    // User should not be able to log in
+    const loginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'deactivate@example.com', password: VALID_PASSWORD });
+    expect(loginRes.status).toBe(403);
+  });
+
+  it('reactivates a user', async () => {
+    const adminCookie = await registerAdmin(app);
+    const user = await registerVerifiedUser(app, 'reactivate@example.com');
+    await execute('UPDATE users SET is_active = FALSE WHERE id = ?', [user.id]);
+
+    const res = await request(app)
+      .put(`/api/admin/users/${user.id}/status`)
+      .set('Cookie', adminCookie)
+      .send({ active: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.active).toBe(true);
+  });
+
+  it('cannot deactivate yourself', async () => {
+    const adminCookie = await registerAdmin(app);
+    const admin = await queryOne<{ id: string }>('SELECT id FROM users WHERE email = ?', ['admin@example.com']);
+
+    const res = await request(app)
+      .put(`/api/admin/users/${admin!.id}/status`)
+      .set('Cookie', adminCookie)
+      .send({ active: false });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/own account/i);
+  });
+});
+
+describe('DELETE /api/admin/users/:id', () => {
+  it('deletes a user and their resources', async () => {
+    const adminCookie = await registerAdmin(app);
+    const user = await registerVerifiedUser(app, 'delete-me@example.com');
+
+    // Create a source for the user
+    await request(app)
+      .post('/api/sources')
+      .set('Cookie', user.cookie)
+      .send({ name: 'Doomed', type: 'csv', config_json: {}, data_json: [] });
+
+    const res = await request(app)
+      .delete(`/api/admin/users/${user.id}`)
+      .set('Cookie', adminCookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    // User should be gone
+    const gone = await queryOne<{ id: string }>('SELECT id FROM users WHERE id = ?', [user.id]);
+    expect(gone).toBeUndefined();
+  });
+
+  it('cannot delete yourself', async () => {
+    const adminCookie = await registerAdmin(app);
+    const admin = await queryOne<{ id: string }>('SELECT id FROM users WHERE email = ?', ['admin@example.com']);
+
+    const res = await request(app)
+      .delete(`/api/admin/users/${admin!.id}`)
+      .set('Cookie', adminCookie);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/own account/i);
+  });
+});
+
+describe('GET /api/admin/audit', () => {
+  it('returns audit log entries', async () => {
+    const adminCookie = await registerAdmin(app);
+    const user = await registerVerifiedUser(app, 'audited@example.com');
+
+    // Trigger an audit action (change role)
+    await request(app)
+      .put(`/api/admin/users/${user.id}/role`)
+      .set('Cookie', adminCookie)
+      .send({ role: 'viewer' });
+
+    const res = await request(app)
+      .get('/api/admin/audit')
+      .set('Cookie', adminCookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.logs.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.logs[0].action).toBe('role_change');
+  });
+});
+
+describe('GET /api/admin/stats', () => {
+  it('returns user statistics', async () => {
+    const adminCookie = await registerAdmin(app);
+    await registerVerifiedUser(app, 'stat1@example.com');
+    await registerVerifiedUser(app, 'stat2@example.com');
+
+    const res = await request(app)
+      .get('/api/admin/stats')
+      .set('Cookie', adminCookie);
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalUsers).toBe(3);
+    expect(res.body.activeUsers).toBe(3);
+    expect(res.body.byRole.admin).toBe(1);
+    expect(res.body.byRole.editor).toBe(2);
+    expect(res.body.byProvider.local).toBe(3);
+  });
+});

--- a/tests/server/test-helpers.ts
+++ b/tests/server/test-helpers.ts
@@ -29,6 +29,7 @@ import sharesRoutes from '../../server/src/routes/shares.js';
 import cacheRoutes from '../../server/src/routes/cache.js';
 import migrateRoutes from '../../server/src/routes/migrate.js';
 import monitoringRoutes from '../../server/src/routes/monitoring.js';
+import adminRoutes from '../../server/src/routes/admin.js';
 import type { Express } from 'express';
 
 // Set test env defaults
@@ -46,6 +47,7 @@ let initialized = false;
  * Tables in reverse FK order for truncation.
  */
 const TABLES_TO_TRUNCATE = [
+  'audit_log',
   'sessions',
   'data_cache',
   'monitoring',
@@ -80,6 +82,7 @@ export async function createTestApp(): Promise<Express> {
   await execute('INSERT IGNORE INTO schema_version (version) VALUES (1)');
   await execute('INSERT IGNORE INTO schema_version (version) VALUES (2)');
   await execute('INSERT IGNORE INTO schema_version (version) VALUES (3)');
+  await execute('INSERT IGNORE INTO schema_version (version) VALUES (4)');
 
   const app = express();
   app.use(express.json({ limit: '10mb' }));
@@ -96,6 +99,7 @@ export async function createTestApp(): Promise<Express> {
   app.use('/api/cache', cacheRoutes);
   app.use('/api/migrate', migrateRoutes);
   app.use('/api/monitoring', monitoringRoutes);
+  app.use('/api/admin', adminRoutes);
 
   return app;
 }


### PR DESCRIPTION
## Summary

Quatrieme PR de [FR-002](https://github.com/bmatge/dsfr-data/issues/12) — API d'administration des utilisateurs + audit log.

### 9 endpoints admin (tous derriere `requireRole('admin')`)

| Methode | Endpoint | Description |
|---------|----------|-------------|
| GET | `/api/admin/users` | Liste paginee (email, role, provider, last_login, is_active) |
| GET | `/api/admin/users/:id` | Detail + resource counts (sources, connections, favorites, dashboards) |
| PUT | `/api/admin/users/:id/role` | Changer le role |
| PUT | `/api/admin/users/:id/status` | Activer/desactiver (revoque les sessions) |
| DELETE | `/api/admin/users/:id` | Supprimer + cascade (resources, shares, groups, sessions) |
| GET | `/api/admin/users/:id/sessions` | Sessions actives/revoquees |
| DELETE | `/api/admin/users/:id/sessions` | Revoquer toutes les sessions |
| GET | `/api/admin/audit` | Journal d'audit pagine + filtres (action, user_id) |
| GET | `/api/admin/stats` | Stats (total, actifs, par role, par provider) |

### Protections admin
- Un admin ne peut pas changer son propre role
- Un admin ne peut pas se desactiver lui-meme
- Un admin ne peut pas se supprimer lui-meme
- Il doit toujours rester au moins 1 admin actif
- Toute modification est tracee dans `audit_log`

## Test plan

- [x] 83/83 tests passent (14 nouveaux tests admin)
- [ ] Tester les endpoints admin en deploiement

**Depends on** : PR #15 (PR 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)