### PR TITLE
feat(admin): frontend admin app (FR-002 PR5)

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="fr" data-fr-theme>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Administration - dsfr-data</title>
+  <style>@view-transition{navigation:auto}app-header:not(:defined){display:block;min-height:56px}app-footer:not(:defined){display:block;min-height:48px}</style>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.11.2/dist/dsfr.min.css" integrity="sha384-VuzA/gYnk/ZqcT5a/ravR88otj71vNPl/h1JPrKoESV33DCX6SeXIxBcRr5qYPRj" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.11.2/dist/utility/utility.min.css" integrity="sha384-YR4AxNhFVy1qsQ0Hp7Rosg06e4sj2m9dLxiYZrtqJ0boIOiDbD8XkIsIPMMkf0VL" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
+  <script type="module" src="../../dist/dsfr-data.esm.js"></script>
+  <link rel="stylesheet" href="src/styles/admin.css">
+</head>
+<body>
+  <app-header current-page="admin" base-path="../.."></app-header>
+
+  <main class="fr-pb-8w" id="main-content">
+    <div class="fr-container">
+      <h1 class="fr-mt-4w">
+        <i class="ri-admin-line"></i> Administration
+      </h1>
+      <p class="fr-text--lead" id="admin-subtitle">Gestion des utilisateurs et suivi des actions.</p>
+
+      <div id="access-denied" class="fr-alert fr-alert--error fr-mb-2w" style="display:none">
+        <p>Acces reserve aux administrateurs.</p>
+      </div>
+
+      <!-- Tabs -->
+      <div id="admin-tabs" style="display:none">
+        <nav class="fr-tabs" role="navigation" aria-label="Onglets admin">
+          <ul class="fr-tabs__list" role="tablist">
+            <li role="presentation">
+              <button id="tab-users" class="fr-tabs__tab" role="tab" aria-selected="true" aria-controls="panel-users">Utilisateurs</button>
+            </li>
+            <li role="presentation">
+              <button id="tab-audit" class="fr-tabs__tab" role="tab" aria-selected="false" aria-controls="panel-audit">Journal d'audit</button>
+            </li>
+            <li role="presentation">
+              <button id="tab-stats" class="fr-tabs__tab" role="tab" aria-selected="false" aria-controls="panel-stats">Statistiques</button>
+            </li>
+          </ul>
+        </nav>
+
+        <!-- Users panel -->
+        <div id="panel-users" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tab-users">
+          <div id="users-list">
+            <p class="admin-loading">Chargement...</p>
+          </div>
+          <div id="users-pagination" class="fr-mt-2w"></div>
+        </div>
+
+        <!-- Audit panel -->
+        <div id="panel-audit" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tab-audit">
+          <div id="audit-list">
+            <p class="admin-loading">Chargement...</p>
+          </div>
+          <div id="audit-pagination" class="fr-mt-2w"></div>
+        </div>
+
+        <!-- Stats panel -->
+        <div id="panel-stats" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tab-stats">
+          <div id="stats-content">
+            <p class="admin-loading">Chargement...</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- User detail modal -->
+      <dialog id="user-detail-modal" class="fr-modal" aria-labelledby="modal-title">
+        <div class="fr-container fr-container--fluid fr-container-md">
+          <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8">
+              <div class="fr-modal__body">
+                <div class="fr-modal__header">
+                  <button class="fr-btn--close fr-btn" title="Fermer" aria-controls="user-detail-modal" id="modal-close">Fermer</button>
+                </div>
+                <div class="fr-modal__content">
+                  <h1 id="modal-title" class="fr-modal__title">Detail utilisateur</h1>
+                  <div id="modal-body"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </dialog>
+    </div>
+  </main>
+
+  <app-footer base-path="../.."></app-footer>
+
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.11.2/dist/dsfr.module.min.js" integrity="sha384-4dK3hBJJh/bjoOulz9Q1kNO2O09lzuKiFeF5c+0VguV1RT3IiLkv+Pt98Jul84V+" crossorigin="anonymous"></script>
+  <script type="module" src="src/main.ts"></script>
+</body>
+</html>

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@dsfr-data/app-admin",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@dsfr-data/shared": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.0",
+    "vite": "^6.4.1"
+  }
+}

--- a/apps/admin/src/api.ts
+++ b/apps/admin/src/api.ts
@@ -1,0 +1,113 @@
+/**
+ * Admin API client — typed fetch wrappers for /api/admin endpoints.
+ */
+
+export interface User {
+  id: string;
+  email: string;
+  displayName: string;
+  role: 'admin' | 'editor' | 'viewer';
+  authProvider: 'local' | 'proconnect';
+  isActive: boolean;
+  emailVerified: boolean;
+  lastLogin: string | null;
+  createdAt: string;
+}
+
+export interface UserDetail extends User {
+  externalId: string | null;
+  idpId: string | null;
+  siret: string | null;
+  organizationalUnit: string | null;
+}
+
+export interface Pagination {
+  page: number;
+  limit: number;
+  total: number;
+  pages: number;
+}
+
+export interface Session {
+  id: string;
+  authProvider: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+  createdAt: string;
+  expiresAt: string;
+  revokedAt: string | null;
+  isActive: boolean;
+}
+
+export interface AuditEntry {
+  id: number;
+  userId: string | null;
+  action: string;
+  targetType: string | null;
+  targetId: string | null;
+  details: Record<string, unknown> | null;
+  ipAddress: string | null;
+  createdAt: string;
+}
+
+export interface Stats {
+  totalUsers: number;
+  activeUsers: number;
+  byRole: Record<string, number>;
+  byProvider: Record<string, number>;
+}
+
+const opts: RequestInit = { credentials: 'include' };
+
+async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`/api/admin${path}`, { ...opts, ...init });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `HTTP ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function fetchUsers(page = 1, limit = 20): Promise<{ users: User[]; pagination: Pagination }> {
+  return api(`/users?page=${page}&limit=${limit}`);
+}
+
+export async function fetchUserDetail(id: string): Promise<{ user: UserDetail; resources: Record<string, number> }> {
+  return api(`/users/${id}`);
+}
+
+export async function changeRole(id: string, role: string): Promise<void> {
+  await api(`/users/${id}/role`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ role }),
+  });
+}
+
+export async function changeStatus(id: string, active: boolean): Promise<void> {
+  await api(`/users/${id}/status`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ active }),
+  });
+}
+
+export async function deleteUser(id: string): Promise<void> {
+  await api(`/users/${id}`, { method: 'DELETE' });
+}
+
+export async function fetchSessions(userId: string): Promise<Session[]> {
+  return api(`/users/${userId}/sessions`);
+}
+
+export async function revokeSessions(userId: string): Promise<void> {
+  await api(`/users/${userId}/sessions`, { method: 'DELETE' });
+}
+
+export async function fetchAudit(page = 1, limit = 50): Promise<{ logs: AuditEntry[]; pagination: Pagination }> {
+  return api(`/audit?page=${page}&limit=${limit}`);
+}
+
+export async function fetchStats(): Promise<Stats> {
+  return api('/stats');
+}

--- a/apps/admin/src/main.ts
+++ b/apps/admin/src/main.ts
@@ -1,0 +1,376 @@
+/**
+ * Admin app — user management, audit log, stats.
+ */
+
+import './styles/admin.css';
+import { escapeHtml } from '@dsfr-data/shared';
+import {
+  fetchUsers, fetchUserDetail, fetchAudit, fetchStats,
+  changeRole, changeStatus, deleteUser, revokeSessions,
+  type User, type UserDetail, type AuditEntry, type Pagination, type Stats,
+} from './api.js';
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+let users: User[] = [];
+let usersPagination: Pagination = { page: 1, limit: 20, total: 0, pages: 0 };
+let auditLogs: AuditEntry[] = [];
+let auditPagination: Pagination = { page: 1, limit: 50, total: 0, pages: 0 };
+let stats: Stats | null = null;
+let currentTab: 'users' | 'audit' | 'stats' = 'users';
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+document.addEventListener('DOMContentLoaded', async () => {
+  // Check auth — fetch /api/auth/me to know if user is admin
+  try {
+    const res = await fetch('/api/auth/me', { credentials: 'include' });
+    if (!res.ok) {
+      showAccessDenied();
+      return;
+    }
+    const data = await res.json();
+    if (data.user.role !== 'admin') {
+      showAccessDenied();
+      return;
+    }
+  } catch {
+    showAccessDenied();
+    return;
+  }
+
+  document.getElementById('admin-tabs')!.style.display = 'block';
+  setupTabs();
+  await loadUsers(1);
+});
+
+function showAccessDenied(): void {
+  document.getElementById('access-denied')!.style.display = 'block';
+  document.getElementById('admin-subtitle')!.style.display = 'none';
+}
+
+// ---------------------------------------------------------------------------
+// Tabs
+// ---------------------------------------------------------------------------
+
+function setupTabs(): void {
+  const tabs = ['users', 'audit', 'stats'] as const;
+  for (const tab of tabs) {
+    document.getElementById(`tab-${tab}`)!.addEventListener('click', () => switchTab(tab));
+  }
+}
+
+async function switchTab(tab: typeof currentTab): Promise<void> {
+  currentTab = tab;
+  const tabs = ['users', 'audit', 'stats'] as const;
+  for (const t of tabs) {
+    const btn = document.getElementById(`tab-${t}`)!;
+    const panel = document.getElementById(`panel-${t}`)!;
+    const isActive = t === tab;
+    btn.setAttribute('aria-selected', String(isActive));
+    panel.classList.toggle('fr-tabs__panel--selected', isActive);
+  }
+
+  if (tab === 'users' && users.length === 0) await loadUsers(1);
+  if (tab === 'audit' && auditLogs.length === 0) await loadAudit(1);
+  if (tab === 'stats' && !stats) await loadStats();
+}
+
+// ---------------------------------------------------------------------------
+// Users
+// ---------------------------------------------------------------------------
+
+async function loadUsers(page: number): Promise<void> {
+  const el = document.getElementById('users-list')!;
+  el.innerHTML = '<p class="admin-loading">Chargement...</p>';
+
+  try {
+    const data = await fetchUsers(page);
+    users = data.users;
+    usersPagination = data.pagination;
+    renderUsersTable();
+  } catch (err) {
+    el.innerHTML = `<div class="fr-alert fr-alert--error"><p>${escapeHtml(String(err))}</p></div>`;
+  }
+}
+
+function renderUsersTable(): void {
+  const el = document.getElementById('users-list')!;
+  if (users.length === 0) {
+    el.innerHTML = '<p class="admin-loading">Aucun utilisateur.</p>';
+    return;
+  }
+
+  const rows = users.map(u => `
+    <tr data-clickable data-user-id="${escapeHtml(u.id)}">
+      <td>${escapeHtml(u.email)}</td>
+      <td>${escapeHtml(u.displayName)}</td>
+      <td><span class="badge badge--${u.role}">${u.role}</span></td>
+      <td><span class="badge badge--${u.authProvider}">${u.authProvider}</span></td>
+      <td><span class="badge badge--${u.isActive ? 'active' : 'inactive'}">${u.isActive ? 'Actif' : 'Inactif'}</span></td>
+      <td>${u.lastLogin ? formatDate(u.lastLogin) : '<span style="color:var(--text-mention-grey)">Jamais</span>'}</td>
+      <td>${formatDate(u.createdAt)}</td>
+    </tr>
+  `).join('');
+
+  el.innerHTML = `
+    <table class="admin-table">
+      <thead>
+        <tr>
+          <th>Email</th>
+          <th>Nom</th>
+          <th>Role</th>
+          <th>Provider</th>
+          <th>Statut</th>
+          <th>Derniere connexion</th>
+          <th>Inscription</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  `;
+
+  // Click handlers
+  el.querySelectorAll('tr[data-user-id]').forEach(tr => {
+    tr.addEventListener('click', () => openUserDetail(tr.getAttribute('data-user-id')!));
+  });
+
+  renderPagination('users-pagination', usersPagination, loadUsers);
+}
+
+// ---------------------------------------------------------------------------
+// User detail modal
+// ---------------------------------------------------------------------------
+
+async function openUserDetail(userId: string): Promise<void> {
+  const modal = document.getElementById('user-detail-modal') as HTMLDialogElement;
+  const body = document.getElementById('modal-body')!;
+  body.innerHTML = '<p class="admin-loading">Chargement...</p>';
+  modal.showModal();
+
+  document.getElementById('modal-close')!.onclick = () => modal.close();
+
+  try {
+    const { user, resources } = await fetchUserDetail(userId);
+    renderUserDetail(user, resources);
+  } catch (err) {
+    body.innerHTML = `<div class="fr-alert fr-alert--error"><p>${escapeHtml(String(err))}</p></div>`;
+  }
+}
+
+function renderUserDetail(user: UserDetail, resources: Record<string, number>): void {
+  const body = document.getElementById('modal-body')!;
+  const totalResources = Object.values(resources).reduce((s, n) => s + n, 0);
+
+  body.innerHTML = `
+    <dl class="detail-grid">
+      <dt>Email</dt><dd>${escapeHtml(user.email)}</dd>
+      <dt>Nom</dt><dd>${escapeHtml(user.displayName)}</dd>
+      <dt>Role</dt><dd><span class="badge badge--${user.role}">${user.role}</span></dd>
+      <dt>Provider</dt><dd><span class="badge badge--${user.authProvider}">${user.authProvider}</span></dd>
+      <dt>Statut</dt><dd><span class="badge badge--${user.isActive ? 'active' : 'inactive'}">${user.isActive ? 'Actif' : 'Inactif'}</span></dd>
+      <dt>Email verifie</dt><dd>${user.emailVerified ? 'Oui' : 'Non'}</dd>
+      <dt>Derniere connexion</dt><dd>${user.lastLogin ? formatDate(user.lastLogin) : 'Jamais'}</dd>
+      <dt>Inscription</dt><dd>${formatDate(user.createdAt)}</dd>
+      ${user.siret ? `<dt>SIRET</dt><dd>${escapeHtml(user.siret)}</dd>` : ''}
+      ${user.organizationalUnit ? `<dt>Service</dt><dd>${escapeHtml(user.organizationalUnit)}</dd>` : ''}
+      <dt>Ressources</dt><dd>${totalResources} (${resources.sources} sources, ${resources.favorites} favoris, ${resources.dashboards} dashboards)</dd>
+    </dl>
+
+    <div class="detail-actions">
+      <div class="fr-select-group" style="min-width:150px">
+        <label class="fr-label" for="detail-role">Role</label>
+        <select class="fr-select" id="detail-role">
+          <option value="admin" ${user.role === 'admin' ? 'selected' : ''}>admin</option>
+          <option value="editor" ${user.role === 'editor' ? 'selected' : ''}>editor</option>
+          <option value="viewer" ${user.role === 'viewer' ? 'selected' : ''}>viewer</option>
+        </select>
+      </div>
+      <button class="fr-btn fr-btn--sm" id="btn-save-role">Modifier le role</button>
+      <button class="fr-btn fr-btn--sm fr-btn--secondary" id="btn-toggle-status">
+        ${user.isActive ? 'Desactiver' : 'Activer'}
+      </button>
+      <button class="fr-btn fr-btn--sm fr-btn--secondary" id="btn-revoke-sessions">Revoquer les sessions</button>
+      <button class="fr-btn fr-btn--sm fr-btn--tertiary" id="btn-delete-user" style="color:var(--text-default-error)">Supprimer</button>
+    </div>
+  `;
+
+  // Actions
+  document.getElementById('btn-save-role')!.onclick = async () => {
+    const newRole = (document.getElementById('detail-role') as HTMLSelectElement).value;
+    try {
+      await changeRole(user.id, newRole);
+      (document.getElementById('user-detail-modal') as HTMLDialogElement).close();
+      await loadUsers(usersPagination.page);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  document.getElementById('btn-toggle-status')!.onclick = async () => {
+    try {
+      await changeStatus(user.id, !user.isActive);
+      (document.getElementById('user-detail-modal') as HTMLDialogElement).close();
+      await loadUsers(usersPagination.page);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  document.getElementById('btn-revoke-sessions')!.onclick = async () => {
+    if (!confirm(`Revoquer toutes les sessions de ${user.email} ?`)) return;
+    try {
+      await revokeSessions(user.id);
+      alert('Sessions revoquees.');
+    } catch (err) {
+      alert(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  document.getElementById('btn-delete-user')!.onclick = async () => {
+    if (!confirm(`Supprimer definitivement ${user.email} et toutes ses ressources ?`)) return;
+    try {
+      await deleteUser(user.id);
+      (document.getElementById('user-detail-modal') as HTMLDialogElement).close();
+      await loadUsers(usersPagination.page);
+    } catch (err) {
+      alert(err instanceof Error ? err.message : String(err));
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Audit log
+// ---------------------------------------------------------------------------
+
+async function loadAudit(page: number): Promise<void> {
+  const el = document.getElementById('audit-list')!;
+  el.innerHTML = '<p class="admin-loading">Chargement...</p>';
+
+  try {
+    const data = await fetchAudit(page);
+    auditLogs = data.logs;
+    auditPagination = data.pagination;
+    renderAuditTable();
+  } catch (err) {
+    el.innerHTML = `<div class="fr-alert fr-alert--error"><p>${escapeHtml(String(err))}</p></div>`;
+  }
+}
+
+function renderAuditTable(): void {
+  const el = document.getElementById('audit-list')!;
+  if (auditLogs.length === 0) {
+    el.innerHTML = '<p class="admin-loading">Aucune entree dans le journal d\'audit.</p>';
+    return;
+  }
+
+  const rows = auditLogs.map(l => `
+    <tr>
+      <td>${formatDate(l.createdAt)}</td>
+      <td><span class="audit-action">${escapeHtml(l.action)}</span></td>
+      <td>${l.targetType ? escapeHtml(l.targetType) : ''} ${l.targetId ? `<code>${escapeHtml(l.targetId.substring(0, 8))}...</code>` : ''}</td>
+      <td class="audit-details">${l.details ? escapeHtml(JSON.stringify(l.details)) : ''}</td>
+      <td>${l.ipAddress ? escapeHtml(l.ipAddress) : ''}</td>
+    </tr>
+  `).join('');
+
+  el.innerHTML = `
+    <table class="admin-table">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Action</th>
+          <th>Cible</th>
+          <th>Details</th>
+          <th>IP</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>
+  `;
+
+  renderPagination('audit-pagination', auditPagination, loadAudit);
+}
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+async function loadStats(): Promise<void> {
+  const el = document.getElementById('stats-content')!;
+  el.innerHTML = '<p class="admin-loading">Chargement...</p>';
+
+  try {
+    stats = await fetchStats();
+    renderStats();
+  } catch (err) {
+    el.innerHTML = `<div class="fr-alert fr-alert--error"><p>${escapeHtml(String(err))}</p></div>`;
+  }
+}
+
+function renderStats(): void {
+  if (!stats) return;
+  const el = document.getElementById('stats-content')!;
+
+  const kpi = (value: number | string, label: string) =>
+    `<div class="admin-kpi"><div class="admin-kpi__value">${value}</div><div class="admin-kpi__label">${label}</div></div>`;
+
+  el.innerHTML = `
+    <div class="admin-kpi-row fr-mb-4w">
+      ${kpi(stats.totalUsers, 'Utilisateurs')}
+      ${kpi(stats.activeUsers, 'Actifs')}
+      ${kpi(stats.totalUsers - stats.activeUsers, 'Inactifs')}
+    </div>
+    <h3 class="fr-mt-4w">Par role</h3>
+    <div class="admin-kpi-row fr-mb-4w">
+      ${kpi(stats.byRole.admin || 0, 'Admin')}
+      ${kpi(stats.byRole.editor || 0, 'Editor')}
+      ${kpi(stats.byRole.viewer || 0, 'Viewer')}
+    </div>
+    <h3 class="fr-mt-4w">Par provider</h3>
+    <div class="admin-kpi-row fr-mb-4w">
+      ${kpi(stats.byProvider.local || 0, 'Local')}
+      ${kpi(stats.byProvider.proconnect || 0, 'ProConnect')}
+    </div>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' })
+      + ' ' + d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return iso;
+  }
+}
+
+function renderPagination(containerId: string, pagination: Pagination, loadFn: (page: number) => Promise<void>): void {
+  const el = document.getElementById(containerId)!;
+  if (pagination.pages <= 1) {
+    el.innerHTML = '';
+    return;
+  }
+
+  const buttons: string[] = [];
+  if (pagination.page > 1) {
+    buttons.push(`<button class="fr-btn fr-btn--sm fr-btn--secondary" data-page="${pagination.page - 1}">&laquo; Prec.</button>`);
+  }
+  buttons.push(`<span>Page ${pagination.page} / ${pagination.pages} (${pagination.total} resultats)</span>`);
+  if (pagination.page < pagination.pages) {
+    buttons.push(`<button class="fr-btn fr-btn--sm fr-btn--secondary" data-page="${pagination.page + 1}">Suiv. &raquo;</button>`);
+  }
+
+  el.innerHTML = `<div class="admin-pagination">${buttons.join('')}</div>`;
+  el.querySelectorAll('button[data-page]').forEach(btn => {
+    btn.addEventListener('click', () => loadFn(parseInt(btn.getAttribute('data-page')!)));
+  });
+}

--- a/apps/admin/src/styles/admin.css
+++ b/apps/admin/src/styles/admin.css
@@ -1,0 +1,150 @@
+/* Admin app styles */
+
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+main { flex: 1; }
+
+.admin-loading {
+  color: var(--text-mention-grey);
+  font-style: italic;
+  padding: 2rem 0;
+  text-align: center;
+}
+
+/* KPI row */
+.admin-kpi-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.admin-kpi {
+  background: var(--background-default-grey);
+  border-left: 4px solid var(--border-action-high-blue-france);
+  padding: 1rem 1.5rem;
+  border-radius: 0 4px 4px 0;
+}
+
+.admin-kpi__value {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--text-title-grey);
+}
+
+.admin-kpi__label {
+  font-size: 0.875rem;
+  color: var(--text-mention-grey);
+  margin-top: 0.25rem;
+}
+
+/* Table */
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.admin-table th {
+  background: var(--background-alt-grey);
+  padding: 0.75rem;
+  text-align: left;
+  font-weight: 600;
+  border-bottom: 2px solid var(--border-default-grey);
+  font-size: 0.875rem;
+  white-space: nowrap;
+}
+
+.admin-table td {
+  padding: 0.75rem;
+  border-bottom: 1px solid var(--border-default-grey);
+  font-size: 0.875rem;
+}
+
+.admin-table tr:hover {
+  background: var(--background-contrast-grey);
+}
+
+.admin-table tr[data-clickable] {
+  cursor: pointer;
+}
+
+/* Badges */
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge--admin { background: var(--background-contrast-info); color: var(--text-default-info); }
+.badge--editor { background: var(--background-contrast-success); color: var(--text-default-success); }
+.badge--viewer { background: var(--background-alt-grey); color: var(--text-mention-grey); }
+.badge--active { background: var(--background-contrast-success); color: var(--text-default-success); }
+.badge--inactive { background: var(--background-contrast-error); color: var(--text-default-error); }
+.badge--local { background: var(--background-alt-grey); color: var(--text-mention-grey); }
+.badge--proconnect { background: var(--background-contrast-info); color: var(--text-default-info); }
+
+/* Pagination */
+.admin-pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.admin-pagination button {
+  min-width: 2.5rem;
+}
+
+/* Modal detail */
+.detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem 2rem;
+}
+
+.detail-grid dt {
+  font-weight: 600;
+  color: var(--text-mention-grey);
+  font-size: 0.875rem;
+}
+
+.detail-grid dd {
+  margin: 0 0 0.5rem;
+}
+
+.detail-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-default-grey);
+}
+
+/* Audit log */
+.audit-action {
+  font-family: monospace;
+  font-size: 0.8rem;
+  background: var(--background-alt-grey);
+  padding: 0.15rem 0.4rem;
+  border-radius: 2px;
+}
+
+.audit-details {
+  font-size: 0.8rem;
+  color: var(--text-mention-grey);
+  max-width: 300px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Tabs fix for non-JS DSFR init */
+.fr-tabs__panel:not(.fr-tabs__panel--selected) {
+  display: none;
+}

--- a/apps/admin/tsconfig.json
+++ b/apps/admin/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/admin/vite.config.ts
+++ b/apps/admin/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  root: resolve(__dirname),
+  base: './',
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+  resolve: {
+    alias: {
+      '@dsfr-data/shared': resolve(__dirname, '../../packages/shared/src'),
+    }
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,17 @@
         "vitest": "^3.0.0"
       }
     },
+    "apps/admin": {
+      "name": "@dsfr-data/app-admin",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dsfr-data/shared": "*"
+      },
+      "devDependencies": {
+        "typescript": "^5.3.0",
+        "vite": "^6.4.1"
+      }
+    },
     "apps/builder": {
       "name": "@dsfr-data/app-builder",
       "version": "0.1.0",
@@ -672,6 +683,10 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dsfr-data/app-admin": {
+      "resolved": "apps/admin",
+      "link": true
     },
     "node_modules/@dsfr-data/app-builder": {
       "resolved": "apps/builder",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dev": "vite",
     "build": "tsc && vite-node scripts/build-lib.ts && vite-node scripts/build-skills-json.ts",
     "build:shared": "npm run build --workspace=@dsfr-data/shared",
-    "build:apps": "npm run build --workspace=@dsfr-data/app-favorites && npm run build --workspace=@dsfr-data/app-playground && npm run build --workspace=@dsfr-data/app-sources && npm run build --workspace=@dsfr-data/app-builder-ia && npm run build --workspace=@dsfr-data/app-builder && npm run build --workspace=@dsfr-data/app-builder-carto && npm run build --workspace=@dsfr-data/app-dashboard && npm run build --workspace=@dsfr-data/app-monitoring && npm run build --workspace=@dsfr-data/app-grist-widgets",
+    "build:apps": "npm run build --workspace=@dsfr-data/app-favorites && npm run build --workspace=@dsfr-data/app-playground && npm run build --workspace=@dsfr-data/app-sources && npm run build --workspace=@dsfr-data/app-builder-ia && npm run build --workspace=@dsfr-data/app-builder && npm run build --workspace=@dsfr-data/app-builder-carto && npm run build --workspace=@dsfr-data/app-dashboard && npm run build --workspace=@dsfr-data/app-monitoring && npm run build --workspace=@dsfr-data/app-admin && npm run build --workspace=@dsfr-data/app-grist-widgets",
     "build:all": "npm run build:shared && npm run build && npm run build:apps",
     "preview": "vite preview",
     "test": "vitest",

--- a/src/components/layout/app-header.ts
+++ b/src/components/layout/app-header.ts
@@ -125,6 +125,7 @@ export class AppHeader extends LitElement {
       { id: 'playground', label: 'Playground', href: 'apps/playground/index.html' },
       { id: 'dashboard', label: 'Dashboard', href: 'apps/dashboard/index.html' },
       { id: 'monitoring', label: 'Monitoring', href: 'apps/monitoring/index.html' },
+      { id: 'admin', label: 'Admin', href: 'apps/admin/index.html' },
     ];
   }
 


### PR DESCRIPTION
## Summary

Cinquieme PR de [FR-002](https://github.com/bmatge/dsfr-data/issues/12) — interface frontend d'administration.

Nouvelle app `apps/admin/` (Vite + TypeScript + DSFR) avec 3 onglets :

### Utilisateurs
- Tableau pagine : email, nom, role, provider, statut, derniere connexion
- Clic sur un utilisateur ouvre un modal de detail
- Actions dans le modal : changer le role (select), activer/desactiver, revoquer les sessions, supprimer (avec confirmation)

### Journal d'audit
- Timeline paginee des actions sensibles (role_change, user_deactivate, user_delete, etc.)
- Colonnes : date, action, cible, details, IP

### Statistiques
- KPIs : total utilisateurs, actifs, inactifs
- Repartition par role (admin, editor, viewer)
- Repartition par provider (local, proconnect)

### Integration
- Controle d'acces : verifie `/api/auth/me` au chargement, bloque si non-admin
- Enregistre dans la nav header (`app-header.ts`)
- Ajoute au `build:apps` dans le root `package.json`
- Build valide (501ms, 87 Ko gzip)

## Test plan

- [x] Build OK (`npm run build --workspace=@dsfr-data/app-admin`)
- [ ] Test visuel en local (`npm run dev --workspace=@dsfr-data/app-admin`)
- [ ] Verifier les actions admin (role change, deactivate, delete) en integration

**Depends on** : PR #16 (PR 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)