### PR TITLE
fix(map): prevent DSFR CSS conflicts causing map overflow

### DIFF
--- a/src/components/dsfr-data-map.ts
+++ b/src/components/dsfr-data-map.ts
@@ -346,22 +346,29 @@ export class DsfrDataMap extends LitElement {
       dsfr-data-map {
         display: block;
         position: relative;
+        overflow: hidden;
       }
       .dsfr-data-map__container {
         z-index: 0;
+        overflow: hidden;
       }
-      /* Fix DSFR vs Leaflet conflict — DSFR styles all [href] with underlines and ::before/::after */
-      .dsfr-data-map__container .leaflet-control-zoom a {
+      /* Fix DSFR vs Leaflet conflicts — DSFR styles all [href] with underlines, background-image and ::before/::after */
+      .dsfr-data-map__container a,
+      .dsfr-data-map__container a[href] {
         text-decoration: none;
         background-image: none !important;
       }
-      .dsfr-data-map__container .leaflet-control-zoom a::before,
-      .dsfr-data-map__container .leaflet-control-zoom a::after {
+      .dsfr-data-map__container a::before,
+      .dsfr-data-map__container a::after,
+      .dsfr-data-map__container a[href]::before,
+      .dsfr-data-map__container a[href]::after {
         content: none !important;
+        display: none !important;
       }
-      /* Also neutralize DSFR [href] on popup close button and attribution links */
-      .dsfr-data-map__container a[href] {
-        background-image: none !important;
+      /* Fix DSFR img max-width:100% breaking Leaflet tile positioning */
+      .dsfr-data-map__container img {
+        max-width: none !important;
+        max-height: none !important;
       }
       .dsfr-data-map__marker {
         background: none !important;

--- a/tests/dsfr-data-map.test.ts
+++ b/tests/dsfr-data-map.test.ts
@@ -1066,7 +1066,7 @@ describe('DsfrDataMap styles and a11y elements', () => {
     expect(style).not.toBeNull();
     expect(style?.textContent).toContain('dsfr-data-map__container');
     expect(style?.textContent).toContain('dsfr-data-map__skiplink');
-    expect(style?.textContent).toContain('leaflet-control-zoom');
+    expect(style?.textContent).toContain('max-width: none !important');
     // Cleanup
     style?.remove();
   });


### PR DESCRIPTION
- Add overflow:hidden on dsfr-data-map and its container to clip Leaflet panes
- Neutralize DSFR a[href] ::before/::after pseudo-elements on ALL links inside the map container (not just zoom controls)
- Counter DSFR img max-width:100% rule that breaks Leaflet tile positioning (tiles need exact 256px sizing)

https://claude.ai/code/session_016kP5wzSMvYFKJX5ND4e8oD