### PR TITLE
fix(examples): remove unpkg Leaflet preload from exemple-masa-v2

### DIFF
--- a/guide/examples/exemple-masa-v2.html
+++ b/guide/examples/exemple-masa-v2.html
@@ -11,12 +11,7 @@
   <!-- DSFR Chart CSS -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css">
 
-  <!--
-    Leaflet pré-chargé AVANT dsfr-data.map pour contourner le dynamic import
-    qui peut échouer dans certains contextes (iframe, CSP).
-  -->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
-  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <!-- Leaflet est chargé dynamiquement par dsfr-data.umd.js depuis cdn.jsdelivr.net -->
 
   <!-- Chart.js — AVANT DSFRChart.js -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>


### PR DESCRIPTION
Les deux scripts Leaflet préchargés depuis unpkg.com étaient bloqués par la
CSP du proxy nginx (script-src autorise uniquement cdn.jsdelivr.net) et
sont inutiles : dsfr-data.umd.js charge déjà Leaflet dynamiquement depuis
cdn.jsdelivr.net, comme le démontre exemple-masa-v1.html qui fonctionne.