### PR TITLE
ci(security): add Trivy SCA + config scan and mcp-server audit (#56)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,35 @@ jobs:
 
       - name: Build app-dist
         run: node scripts/build-app.js
+
+  sca:
+    name: Security — SCA & config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: npm audit — mcp-server
+        working-directory: mcp-server
+        run: npm audit --audit-level=high
+
+      - name: Trivy — filesystem (vulnerabilities)
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          scan-type: fs
+          scanners: vuln
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+          trivyignores: .trivyignore
+
+      - name: Trivy — config (Dockerfiles)
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          scan-type: config
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          trivyignores: .trivyignore

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,22 @@
+# .trivyignore — findings Trivy ignorés sur ce repo
+#
+# Format : un ID de finding par ligne, précédé d'un commentaire qui explique
+#   - quoi : règle / CVE ignorée
+#   - pourquoi : justification technique
+#   - suivi : issue follow-up qui tracke le fix
+#   - revue : date après laquelle cette entrée doit être réévaluée
+#
+# Règle d'or : jamais de masquage silencieux. Toute entrée sans justification
+# ou sans date de revue doit être retirée ou remplie.
+
+# ──────────────────────────────────────────────────────────────────
+# DS-0002 — Dockerfiles nginx sans directive USER non-root
+# Quoi   : trivy config signale docker/Dockerfile et docker/Dockerfile.db
+#          qui héritent de nginx:alpine et tournent en root.
+# Pourquoi : l'image de base binde le port 80 (privileged < 1024) et requiert
+#          donc root, ou une migration vers nginxinc/nginx-unprivileged:alpine
+#          avec adaptation de nginx.conf + docker-compose + healthcheck.
+#          Le fix propre est non trivial et sort du scope du job SCA (#56).
+# Suivi  : #66
+# Revue  : 2026-07-14
+DS-0002


### PR DESCRIPTION
## Summary

Nouveau job `sca` dans `.github/workflows/ci.yml` qui complète le `npm audit --audit-level=high` déjà en place sur le workspace root :

- **`npm audit`** sur `mcp-server/` (lockfile hors workspace npm)
- **`trivy fs`** — scan de vulnérabilités sur tous les lockfiles (root, mcp-server, Cargo), `--ignore-unfixed`, gate HIGH/CRITICAL
- **`trivy config`** — scan misconfig sur les Dockerfiles, gate HIGH/CRITICAL

## Trivy ignorefile

Ajout de `.trivyignore` avec une entrée documentée pour **DS-0002** (les images nginx de prod tournent en root). Fix tracké dans #66, revue le **2026-07-14**.

Politique : jamais de masquage silencieux. Chaque entrée de `.trivyignore` doit porter quoi / pourquoi / suivi / date de revue.

## Dry-run local

Les 3 checks ont été exécutés localement via `public.ecr.aws/aquasecurity/trivy:latest` :

| Check | Résultat |
|---|---|
| `npm audit --audit-level=high` (mcp-server) | 0 findings bloquants (2 moderate non bloquants : `hono`, `@hono/node-server`) |
| `trivy fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed` | 0 findings (root, mcp-server, `src-tauri/Cargo.lock`) |
| `trivy config --severity HIGH,CRITICAL --ignorefile .trivyignore` | 0 findings (DS-0002 masqué) |

## Scope / hors scope

- ✅ **Dans le scope** : outillage SCA + config scan + mcp-server audit
- ❌ **Hors scope** : fix DS-0002 (→ #66), scan docker-compose (non supporté par Trivy misconfig), scan `trivy image` (→ #62)

## Changeset

Pas de changeset : aucune modification dans `packages/core/src/` ni `packages/shared/`.

## Test plan

- [ ] CI passe sur cette PR (job `sca` vert)
- [ ] Les 3 étapes du job `sca` s'exécutent (npm audit, trivy fs, trivy config)
- [ ] Job `quality` existant toujours vert
- [ ] `changeset-check` existant toujours vert (pas requis ici)

Closes #56
Refs #65 (tracking), #66 (follow-up DS-0002)