### PR TITLE
ci(security): add Gitleaks scan (CI + pre-commit) and incident runbook (#59)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,16 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: '1'
           trivyignores: .trivyignore
+
+  secrets:
+    name: Security — Secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,26 @@
+title = "dsfr-data gitleaks config"
+
+# Étend les règles par défaut de gitleaks (https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml).
+# Toute règle custom serait ajoutée ici sous [[rules]].
+[extend]
+useDefault = true
+
+# Allowlist prophylactique : chemins autorisés à contenir des patterns qui
+# ressemblent à des secrets (sans en être vraiment). Chaque entrée doit
+# être justifiée en commentaire.
+[allowlist]
+description = "Chemins autorisés à contenir des patterns de faux positif"
+
+paths = [
+  # .env.example ne contient que des variables commentées et des valeurs
+  # non sensibles (hosts, domaines). Il est commité pour documenter la config.
+  '''\.env\.example$''',
+
+  # Le CHANGELOG peut mentionner des noms de clés (JWT_SECRET, ENCRYPTION_KEY)
+  # sans en contenir la valeur.
+  '''CHANGELOG\.md$''',
+
+  # Runbook d'incident : référence des exemples de format de secret
+  # à des fins pédagogiques.
+  '''docs/security-incident-response\.md$''',
+]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,17 @@
+#!/usr/bin/env sh
+
+# Secrets scan — gitleaks sur les modifs staged.
+# Soft check : si gitleaks n'est pas installé, on skip (la CI rattrapera).
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks protect --staged --redact --verbose || {
+    echo ""
+    echo "✗ gitleaks a détecté un secret dans les modifs staged."
+    echo "  Runbook : docs/security-incident-response.md"
+    exit 1
+  }
+else
+  echo "[gitleaks] binaire non trouvé — scan pre-commit ignoré (la CI le fera)."
+  echo "[gitleaks] install local : brew install gitleaks"
+fi
+
 npx lint-staged

--- a/docs/security-incident-response.md
+++ b/docs/security-incident-response.md
@@ -1,0 +1,106 @@
+# Runbook — Fuite de secret détectée
+
+Ce document décrit la procédure à suivre quand un secret est détecté dans le repo
+(par Gitleaks en local, en CI, ou par un signalement externe).
+
+## Principe directeur
+
+> **Un secret qui a été poussé dans l'historique Git public est compromis, point.**
+>
+> Réécrire l'historique (`git filter-repo`, BFG…) est **secondaire** : il faut d'abord
+> **révoquer et régénérer** le secret, parce qu'il est impossible de garantir qu'il
+> n'a pas été lu ou cloné entre le push et la détection.
+
+## Secrets manipulés par le projet
+
+Liste à maintenir à jour. Pour chaque secret, savoir où il est utilisé et comment le régénérer.
+
+| Secret | Où | Comment le régénérer |
+|---|---|---|
+| `JWT_SECRET` | `server/` (signature JWT) | `openssl rand -hex 64` puis redéploiement ; **invalide toutes les sessions** |
+| `ENCRYPTION_KEY` | `server/` (AES-256-GCM sur `connections.api_key_encrypted`) | `openssl rand -hex 32` — ⚠️ **rotation non triviale** : toutes les API keys chiffrées deviennent illisibles, il faut les re-chiffrer ou les re-demander aux utilisateurs |
+| `DB_PASSWORD` / `DB_ROOT_PASSWORD` | MariaDB | `openssl rand -base64 32` puis mise à jour dans MariaDB + `.env` + redémarrage conteneur |
+| `IA_DEFAULT_TOKEN` (Albert) | `ia-default-server.js` (proxy IA) | Générer un nouveau token sur [albert.api.etalab.gouv.fr](https://albert.api.etalab.gouv.fr) et révoquer l'ancien |
+| Tokens SMTP | `server/` (nodemailer) | Dépend du fournisseur SMTP — généralement dashboard du provider |
+| Clés API utilisateurs (`connections.api_key_encrypted`) | MariaDB, chiffrées | Aucune rotation côté serveur — c'est la responsabilité de l'utilisateur, via l'UI de `apps/sources/` |
+
+## Procédure d'incident
+
+### Étape 1 — Confinement immédiat (minutes)
+
+1. **Ne pas paniquer et ne pas supprimer le commit.** Supprimer sans révoquer donne une fausse impression de sûreté.
+2. **Identifier le secret** exact qui a fuité : fichier, ligne, commit, date, branche.
+3. **Évaluer l'exposition** :
+   - Repo public ou privé ?
+   - Depuis quand le commit est en ligne ?
+   - Le secret a-t-il été utilisé en production ?
+
+### Étape 2 — Révocation & rotation (heures)
+
+4. **Révoquer le secret** chez le fournisseur (interface admin, dashboard…). Exemples :
+   - Albert : révoquer le token dans le dashboard utilisateur.
+   - MariaDB : `ALTER USER 'user'@'%' IDENTIFIED BY 'nouveau_password';` + redéploiement.
+   - JWT_SECRET : changer la valeur dans `.env` et redéployer (toutes les sessions sont invalidées).
+5. **Générer un nouveau secret** (voir tableau ci-dessus).
+6. **Déployer la nouvelle valeur** en production avant de faire quoi que ce soit côté repo.
+7. **Auditer les logs** du service correspondant : recherche d'utilisations anormales du secret compromis entre sa fuite et sa révocation.
+
+### Étape 3 — Nettoyage du repo (optionnel)
+
+Une fois le secret révoqué et remplacé, le nettoyage de l'historique Git est **optionnel mais souhaitable** pour éviter les scans automatisés qui signaleraient encore le secret (même compromis) et pour ne pas laisser de trace historique.
+
+**Options** :
+
+- **Option A — accepter** : le secret est révoqué, l'historique reste tel quel, on ajoute une entrée dans `.gitleaks.toml` pour allowlister le commit via son fingerprint. Simple, zéro rewrite, mais le secret reste lisible pour qui consulte l'historique.
+
+- **Option B — réécrire l'historique** : `git filter-repo --replace-text` ou `bfg --replace-text` pour réécrire tous les commits. **Casse tous les fetch/pull existants** — nécessite de coordonner avec tous les clones du repo (dev, CI, déploiement) et force-push.
+  ```bash
+  # Exemple avec git-filter-repo
+  echo "sk-xxx-compromised==>REDACTED" > /tmp/replacements.txt
+  git filter-repo --replace-text /tmp/replacements.txt
+  git push --force-with-lease origin main
+  ```
+  ⚠️ **Ne jamais force-push sans autorisation explicite** (cf. CLAUDE.md du projet et règles globales). Coordonner avec toute l'équipe avant.
+
+### Étape 4 — Post-mortem (jours)
+
+8. **Documenter l'incident** : créer une note dans `~/Documents/Obsidian/20-Sessions/YYYY-MM-DD.md` avec timeline, cause racine, mesures prises.
+9. **Renforcer la prévention** :
+   - Le hook Husky pre-commit a-t-il tourné ? Pourquoi a-t-il laissé passer ?
+   - Faut-il ajouter une règle custom dans `.gitleaks.toml` pour ce format de secret ?
+   - Y a-t-il une ADR à rédiger sur la rotation régulière ?
+
+## Outils
+
+### Scan local de l'historique
+
+```bash
+# Via Docker (zéro install)
+docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:latest detect --source /repo --verbose --redact
+
+# Via brew (macOS)
+brew install gitleaks
+gitleaks detect --verbose --redact
+```
+
+### Scan d'un commit spécifique
+
+```bash
+gitleaks detect --log-opts="<commit-sha>^..<commit-sha>" --verbose --redact
+```
+
+### Scan des modifications staged (avant commit)
+
+```bash
+gitleaks protect --staged --verbose --redact
+```
+
+C'est ce que fait automatiquement le hook `.husky/pre-commit` si gitleaks est installé localement.
+
+## Liens
+
+- [gitleaks — règles par défaut](https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml)
+- [OWASP — Secret Management Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html)
+- [git-filter-repo](https://github.com/newren/git-filter-repo)
+- Issue parent : #59
+- Milestone : Security baseline


### PR DESCRIPTION
## Summary

Nouveau job `secrets` dans `.github/workflows/ci.yml` qui scanne l'historique Git complet à chaque PR pour détecter les secrets fuités, et renforcement du hook Husky pre-commit avec un check `gitleaks protect --staged` en local.

### Ce qui change

- **`.github/workflows/ci.yml`** — job `secrets` avec `gitleaks/gitleaks-action@v2` et `fetch-depth: 0` (historique complet).
- **`.gitleaks.toml`** — extend des règles par défaut + allowlist prophylactique pour `.env.example`, `CHANGELOG.md`, et le runbook d'incident.
- **`.husky/pre-commit`** — soft check gitleaks avant `lint-staged`. Si le binaire n'est pas installé, le hook imprime un warning et continue (la CI rattrapera). Évite de bloquer les contributeurs qui n'ont pas gitleaks en local.
- **`docs/security-incident-response.md`** — runbook d'incident : principe directeur (révocation avant nettoyage), tableau des secrets manipulés, procédure en 4 étapes, options pour la réécriture d'historique, outils.

## Dry-run local

| Check | Résultat |
|---|---|
| `gitleaks detect --source . --config .gitleaks.toml` | **170 commits scannés, 0 leak** |
| `.husky/pre-commit` (gitleaks absent) | Warning + skip + lint-staged OK |

## Scope / hors scope

- ✅ **Dans le scope** : scan historique, scan pre-commit, config, runbook de base
- ❌ **Hors scope** : `SECURITY.md` à la racine (→ #63, qui créera la politique de divulgation et liera vers ce runbook)

## Changeset

Pas de changeset : aucune modification dans `packages/core/src/` ni `packages/shared/`.

## Test plan

- [ ] CI verte : `secrets` job ajouté et passant
- [ ] `sca` (#56) toujours vert
- [ ] `quality` et `changeset-check` toujours verts
- [ ] Hook pre-commit : commit local avec un fichier neutre ne déclenche pas d'erreur

Closes #59
Refs #65 (tracking)