### PR TITLE
ci(security): add CodeQL SAST workflow (#58)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,52 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Hebdomadaire — lundi 06:00 UTC (les CVE arrivent aussi après le build)
+    - cron: '0 6 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+          config: |
+            paths-ignore:
+              - dist
+              - app-dist
+              - node_modules
+              - packages/**/dist
+              - tests
+              - e2e
+              - '**/*.test.ts'
+              - '**/*.spec.ts'
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

Nouveau workflow `.github/workflows/codeql.yml` qui active CodeQL en complément de Semgrep (#57). CodeQL est un moteur SAST avec data-flow / taint analysis plus profond, et ses alertes remontent directement dans l'onglet **Security** du repo.

## Ce qui change

- **Trigger** : `push` main, `pull_request` main, `schedule` hebdomadaire (lundi 06:00 UTC — rattrape les CVE qui arrivent après un build)
- **Language** : `javascript-typescript` (couvre Node backend + frontend Lit)
- **Queries** : `security-and-quality` (plus riche que le pack default)
- **`paths-ignore`** : `dist`, `app-dist`, `node_modules`, `packages/**/dist`, `tests`, `e2e`, `*.test.ts`, `*.spec.ts`
- **Permissions minimales** : `security-events: write`, `actions: read`, `contents: read`

## Scope / hors scope

- ✅ Dans le scope : workflow CodeQL, triggers, config paths-ignore, queries pack
- ❌ Hors scope : triage des findings initiaux (on verra ce que CodeQL remonte après le premier run — follow-up si besoin)

## Changeset

Pas de changeset : workflow CI uniquement.

## Test plan

- [ ] Le workflow `CodeQL / Analyze` démarre sur la PR
- [ ] Build autobuild réussit
- [ ] Pas de findings HIGH/CRITICAL ou findings triagés (follow-up si nécessaire)
- [ ] Les alertes apparaissent dans l'onglet Security après merge sur main

Closes #58
Refs #65 (tracking)
