### PR TITLE
ci(security): add eslint-plugin-security with tuned overrides (#60)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import litPlugin from 'eslint-plugin-lit';
+import securityPlugin from 'eslint-plugin-security';
 
 export default tseslint.config(
   // Ignored paths
@@ -27,6 +28,9 @@ export default tseslint.config(
   // Lit plugin recommended
   litPlugin.configs['flat/recommended'],
 
+  // Security plugin recommended (complément léger au SAST Semgrep/CodeQL)
+  securityPlugin.configs.recommended,
+
   // Project-wide rules
   {
     rules: {
@@ -48,6 +52,23 @@ export default tseslint.config(
       'prefer-const': 'error',
       'no-var': 'error',
       eqeqeq: ['error', 'always', { null: 'ignore' }],
+
+      // eslint-plugin-security : overrides globaux
+      //
+      // detect-object-injection : trop bruyant sur TypeScript. Toute indexation
+      //   obj[key] où key n'est pas un littéral déclenche la règle, y compris
+      //   les simples array[i], les builders paramétrés typés, les reducers…
+      //   Le typage TS + les corrections de prototype pollution via
+      //   `isUnsafeKey()` (cf. #57) couvrent déjà le risque réel. Désactivée
+      //   globalement, comme recommandé dans le README de eslint-plugin-security
+      //   pour les projets TS.
+      'security/detect-object-injection': 'off',
+
+      // detect-non-literal-fs-filename : uniquement pertinente pour du code
+      //   qui lit des chemins fournis par l'utilisateur. Nos seuls fs.*Sync
+      //   sont dans les configs Vite et les scripts de build, où les chemins
+      //   sont des constantes de projet.
+      'security/detect-non-literal-fs-filename': 'off',
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@vitest/coverage-v8": "^3.0.0",
         "eslint": "^10.2.0",
         "eslint-plugin-lit": "^2.2.1",
+        "eslint-plugin-security": "^4.0.0",
         "happy-dom": "^20.8.9",
         "husky": "^9.1.7",
         "jsdom": "^28.0.0",
@@ -5334,6 +5335,22 @@
         "eslint": ">= 8"
       }
     },
+    "node_modules/eslint-plugin-security": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.0.tgz",
+      "integrity": "sha512-tfuQT8K/Li1ZxhFzyD8wPIKtlzZxqBcPr9q0jFMQ77wWAbKBVEhaMPVQRTMTvCMUDhwBe5vPVqQPwAGk/ASfxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
@@ -8764,6 +8781,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -9031,6 +9058,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@vitest/coverage-v8": "^3.0.0",
     "eslint": "^10.2.0",
     "eslint-plugin-lit": "^2.2.1",
+    "eslint-plugin-security": "^4.0.0",
     "happy-dom": "^20.8.9",
     "husky": "^9.1.7",
     "jsdom": "^28.0.0",

--- a/packages/core/src/components/dsfr-data-map.ts
+++ b/packages/core/src/components/dsfr-data-map.ts
@@ -181,6 +181,8 @@ export class DsfrDataMap extends LitElement {
    * Other CSS units (px, vh, rem, etc.) are applied directly.
    */
   private _applyHeight() {
+    // Linear: \d and literal '.' / '%' don't overlap → no catastrophic backtracking.
+    // eslint-disable-next-line security/detect-unsafe-regex
     const pctMatch = this.height.match(/^(\d+(?:\.\d+)?)%$/);
     if (pctMatch) {
       const ratio = parseFloat(pctMatch[1]) / 100;

--- a/packages/core/src/components/dsfr-data-search.ts
+++ b/packages/core/src/components/dsfr-data-search.ts
@@ -438,7 +438,9 @@ export class DsfrDataSearch extends LitElement {
   _addHighlight(record: Record<string, unknown>, term: string): Record<string, unknown> {
     const clone = { ...record };
     const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // `escaped` is already regex-escaped above, so the resulting regex is linear.
     // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
+    // eslint-disable-next-line security/detect-non-literal-regexp
     const regex = new RegExp('(' + escaped + ')', 'gi');
     const fields = this._getFields();
     const searchIn =

--- a/packages/core/src/components/dsfr-data-search.ts
+++ b/packages/core/src/components/dsfr-data-search.ts
@@ -439,9 +439,8 @@ export class DsfrDataSearch extends LitElement {
     const clone = { ...record };
     const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     // `escaped` is already regex-escaped above, so the resulting regex is linear.
-    // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
     // eslint-disable-next-line security/detect-non-literal-regexp
-    const regex = new RegExp('(' + escaped + ')', 'gi');
+    const regex = new RegExp('(' + escaped + ')', 'gi'); // nosemgrep: javascript.lang.security.audit.detect-non-literal-regexp.detect-non-literal-regexp
     const fields = this._getFields();
     const searchIn =
       fields.length > 0 ? fields : Object.keys(record).filter((k) => typeof record[k] === 'string');

--- a/packages/shared/src/utils/number-parser.ts
+++ b/packages/shared/src/utils/number-parser.ts
@@ -50,5 +50,7 @@ export function looksLikeNumber(val: unknown): boolean {
   if (typeof val !== 'string') return false;
   const cleaned = val.trim();
   if (cleaned === '') return false;
+  // Linear: [\d\s] and [.,] character classes don't overlap → no catastrophic backtracking.
+  // eslint-disable-next-line security/detect-unsafe-regex
   return /^-?[\d\s]+([.,]\d+)?$/.test(cleaned);
 }


### PR DESCRIPTION
## Summary

Installe `eslint-plugin-security@^4` et active son ruleset recommandé dans `eslint.config.js`. Complément léger au SAST Semgrep (#57) et CodeQL (#58), intégré au workflow ESLint existant et au hook pre-commit.

## Triage des findings initiaux (471 warnings)

| Règle | Findings | Décision |
|---|---|---|
| `security/detect-object-injection` | 241 | **Disabled globally** — trop bruyante en TS, le plugin README le reconnaît. Type safety + `isUnsafeKey()` de #57 couvrent le risque réel. |
| `security/detect-non-literal-fs-filename` | 6 | **Disabled globally** — nos seuls `fs.*Sync` sont dans Vite configs et scripts de build (chemins constants). |
| `security/detect-unsafe-regex` | 2 | Inline `eslint-disable-next-line` avec justification (regex linéaires). |
| `security/detect-non-literal-regexp` | 1 | Inline (escape déjà appliqué — même site déjà traité par `nosemgrep` en #57). |

## Net result

- **Avant #60** : 0 security findings (rule not installed)
- **Après #60** : 0 security findings (tous triagés)
- **Tests** : 80 files / 2848 tests verts, pas de régression
- **Typecheck** : pass
- **Format** : pass

## Pre-commit

Pas de changement nécessaire : `lint-staged` lance déjà `eslint --fix` sur les `.ts` staged (cf. `package.json`), donc les nouvelles règles security s'appliquent automatiquement au pre-commit.

## Changeset

Pas de changeset : les modifications dans `packages/core/src/` et `packages/shared/src/` sont des commentaires `eslint-disable-next-line` uniquement, zéro changement de comportement runtime.

## Test plan

- [ ] CI `quality` vert (ESLint pass avec les nouvelles règles)
- [ ] Les 4 autres jobs `sca`, `secrets`, `sast`, CodeQL toujours verts
- [ ] `changeset-check` : warning attendu sur `packages/core/src/` modifié sans changeset (non bloquant, justifié par la nature comment-only des modifs)

Closes #60
Refs #65 (tracking)
