### PR TITLE
ci(security): add Trivy image scan workflow for Docker images (#62)

### DIFF
--- a/.github/workflows/docker-scan.yml
+++ b/.github/workflows/docker-scan.yml
@@ -1,0 +1,62 @@
+name: Docker image scan
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/**'
+      - 'package-lock.json'
+      - 'mcp-server/package-lock.json'
+      - 'server/**'
+      - 'packages/**'
+      - 'apps/**'
+      - 'scripts/build-app.js'
+      - '.github/workflows/docker-scan.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docker/**'
+      - '.github/workflows/docker-scan.yml'
+  schedule:
+    # Scan hebdomadaire — les CVE OS arrivent après le build de l'image
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+jobs:
+  scan:
+    name: Trivy image (${{ matrix.image.name }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - name: dsfr-data
+            dockerfile: docker/Dockerfile
+            tag: dsfr-data:scan
+          - name: dsfr-data-db
+            dockerfile: docker/Dockerfile.db
+            tag: dsfr-data-db:scan
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: |
+          docker build \
+            -f ${{ matrix.image.dockerfile }} \
+            -t ${{ matrix.image.tag }} \
+            .
+
+      - name: Trivy — scan image
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ matrix.image.tag }}
+          severity: CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          format: table


### PR DESCRIPTION
## Summary

Nouveau workflow dédié `.github/workflows/docker-scan.yml` qui build et scanne les deux images Docker de production (`docker/Dockerfile` et `docker/Dockerfile.db`) avec Trivy.

## Pourquoi un workflow dédié

L'issue #62 dit *« ou workflow dédié »* — c'est la bonne voie ici parce que `release.yml` ne build pas d'images Docker (il produit les binaires **Tauri desktop** macOS/Linux/Windows). Les images Docker sont buildées via `deploy-server.sh` sur le VPS, pas en CI. Un workflow dédié est plus simple que d'accrocher un step sur un workflow qui ne touche pas au sujet.

## Triggers

- `push` main quand `docker/**`, `server/**`, `packages/**`, `apps/**` ou leurs lockfiles changent
- `pull_request` main quand `docker/**` change
- `schedule` hebdomadaire (lundi 07:00 UTC) — les CVE OS arrivent après le build
- `workflow_dispatch` pour déclenchement manuel

## Configuration

- **Matrix** : 2 images en parallèle (`dsfr-data`, `dsfr-data-db`)
- **Gate** : `severity: CRITICAL` uniquement (conforme à l'énoncé de #62)
- **`ignore-unfixed: true`** : pas de blocage sur des CVE sans patch dispo upstream
- **`trivyignores: .trivyignore`** : réutilise le fichier d'ignore existant de #56

## Dry-run local

Les deux images buildées et scannées localement :

| Image | CRITICAL | HIGH (pas bloquant) |
|---|---|---|
| `dsfr-data` | **0** | 5 |
| `dsfr-data-db` | **0** | 5 |

Les 5 HIGH dans chaque image sont sous le gate `CRITICAL` de #62, donc ne bloquent pas. Ils rejoignent le gap identifié dans **#73** (calibration de politique de sévérité) — si on décide d'abaisser le seuil à HIGH, il faudra les traiter ou les ignorer explicitement.

## Scope / hors scope

- ✅ **Dans le scope** : workflow dédié, matrix 2 images, gate CRITICAL, schedule hebdo
- ❌ **Hors scope** : descendre à HIGH (→ #73), push des images vers un registry pour scan post-build en prod (pas notre workflow prod actuellement)

## Changeset

Pas de changeset : workflow CI uniquement, aucune modification de `packages/core/src/` ou `packages/shared/`.

## Test plan

- [ ] `Trivy image (dsfr-data)` vert
- [ ] `Trivy image (dsfr-data-db)` vert
- [ ] `sca`, `secrets`, `sast`, `quality`, CodeQL, `changeset-check` toujours verts

Closes #62
Refs #65 (tracking), #73 (policy)
