### PR TITLE
docs(security): SECURITY.md + dev guide + SARIF upload + badges (#63)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,9 @@ jobs:
   secrets:
     name: Security — Secrets
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -131,6 +134,9 @@ jobs:
   sast:
     name: Security — SAST
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     container:
       image: semgrep/semgrep
     steps:
@@ -148,5 +154,13 @@ jobs:
             --severity=ERROR \
             --severity=WARNING \
             --metrics=off \
+            --sarif --output=semgrep.sarif \
             --error \
             packages/core/src apps server/src scripts
+
+      - name: Upload Semgrep SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![npm version](https://img.shields.io/npm/v/dsfr-data)](https://www.npmjs.com/package/dsfr-data)
 [![CI](https://github.com/bmatge/dsfr-data/actions/workflows/ci.yml/badge.svg)](https://github.com/bmatge/dsfr-data/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/bmatge/dsfr-data/actions/workflows/codeql.yml/badge.svg)](https://github.com/bmatge/dsfr-data/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Security Policy](https://img.shields.io/badge/security-policy-red.svg)](./SECURITY.md)
 
 dsfr-data est un module complementaire au [Systeme de design de l'Etat](https://www.systeme-de-design.gouv.fr/) (DSFR) pour l'integration de donnees dynamiques. Il s'agit d'une bibliotheque de [Web Components](https://developer.mozilla.org/fr/docs/Web/API/Web_components) (Lit), sous la forme de balises HTML `<dsfr-data-*>`, a destination des developpeurs et integrateurs ayant besoin d'afficher des donnees issues d'APIs ouvertes dans leurs pages web.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,86 @@
+# Sécurité
+
+Ce document décrit la politique de sécurité de `dsfr-data`, la manière de signaler une vulnérabilité, et l'ensemble des outils qui contrôlent en permanence l'état de sécurité du projet.
+
+## Signaler une vulnérabilité
+
+**Merci de ne pas ouvrir d'issue publique** pour signaler une vulnérabilité. Utilisez à la place l'un de ces deux canaux privés :
+
+1. **GitHub Security Advisories** (préférence) — [Report a vulnerability](https://github.com/bmatge/dsfr-data/security/advisories/new) depuis l'onglet Security du repo. C'est le canal le plus rapide, il crée automatiquement un espace de discussion privé avec les mainteneurs.
+2. **Email** — envoyer un rapport à l'auteur du repo ([bmatge](https://github.com/bmatge)).
+
+Merci d'inclure dans votre signalement :
+
+- Une description du problème et de son impact potentiel
+- Les étapes de reproduction ou un proof-of-concept minimal
+- La version concernée de `dsfr-data` (tag ou commit SHA)
+- Vos coordonnées si vous souhaitez être recontacté
+
+Nous nous engageons à accuser réception sous 72 heures, à évaluer l'impact et proposer un correctif ou un plan de mitigation sous 7 jours pour les vulnérabilités significatives.
+
+## Versions supportées
+
+Ce projet est en développement actif. Seule la branche `main` et la dernière version publiée sur npm reçoivent des correctifs de sécurité.
+
+| Version | Supportée |
+|---|---|
+| `main` (dev) | ✅ |
+| Dernière release npm | ✅ |
+| Releases antérieures | ❌ |
+
+## Pipeline de sécurité
+
+La CI exécute **8 jobs de sécurité** sur chaque pull request, et plusieurs workflows périodiques pour rattraper les CVE qui arrivent après un build :
+
+| Brique | Outil | Job / Workflow | Sévérité bloquante |
+|---|---|---|---|
+| **SCA — dépendances** | `npm audit` | `quality` (root) + `sca` (mcp-server) | HIGH/CRITICAL |
+| **SCA — lockfiles** | `trivy fs` | `sca` (root + mcp-server + Cargo) | HIGH/CRITICAL (fixable) |
+| **Misconfig — Dockerfiles** | `trivy config` | `sca` | HIGH/CRITICAL |
+| **Secrets** | `gitleaks` | `secrets` + Husky pre-commit | toute détection |
+| **SAST** | `semgrep` | `sast` | ERROR/WARNING (rulesets curated) |
+| **SAST — data flow** | `CodeQL` | `codeql.yml` | `security-and-quality` |
+| **Lint sécurité** | `eslint-plugin-security` | `quality` | toute erreur |
+| **Images Docker** | `trivy image` | `docker-scan.yml` (matrix sur 2 images) | CRITICAL |
+
+Les scans périodiques :
+- **CodeQL** : hebdomadaire, lundi 06:00 UTC
+- **Trivy image** : hebdomadaire, lundi 07:00 UTC
+
+## Dépendances — Dependabot
+
+- **Alertes Dependabot** : activées, visibles dans [l'onglet Security → Dependabot](https://github.com/bmatge/dsfr-data/security/dependabot).
+- **Correctifs automatiques** : Dependabot ouvre automatiquement des PRs quand une advisory impacte nos dépendances (setting `dependabot_security_updates` activé).
+- **Secret scanning** : activé avec push protection — un push contenant un secret connu d'un provider est bloqué avant même d'atteindre le serveur.
+
+## Politique de sévérité
+
+Tous nos gates SCA actuels bloquent sur **HIGH/CRITICAL**. Les advisories MODERATE sont **visibles** (via Dependabot et les rapports Trivy) mais **non bloquantes**. Cette politique est tracée dans **[issue #73](https://github.com/bmatge/dsfr-data/issues/73)** qui documente le rationale et les options de calibration.
+
+## Faux positifs et exclusions
+
+Aucun masquage silencieux. Toute exclusion de règle ou CVE est documentée avec :
+
+- **Quoi** : règle ou CVE ignorée
+- **Pourquoi** : justification technique
+- **Suivi** : issue de follow-up si un fix est prévu
+- **Revue** : date après laquelle l'entrée doit être réévaluée
+
+Les fichiers d'exclusion à jour :
+
+- [`.trivyignore`](./.trivyignore)
+- [`.semgrepignore`](./.semgrepignore)
+- [`.gitleaks.toml`](./.gitleaks.toml)
+- Exclusions inline (`// nosemgrep:`, `// eslint-disable-next-line security/…`) toujours avec un commentaire en ligne adjacente
+
+## Procédures
+
+- **Fuite de secret détectée** → [docs/security-incident-response.md](./docs/security-incident-response.md) — runbook avec priorité révocation/rotation, options de réécriture d'historique, tableau des secrets manipulés.
+- **Lancer les scans en local** → [docs/security-dev-guide.md](./docs/security-dev-guide.md) — commandes Docker-only pour Trivy, Semgrep, Gitleaks.
+
+## Liens utiles
+
+- [Security Advisories](https://github.com/bmatge/dsfr-data/security/advisories)
+- [Dependabot alerts](https://github.com/bmatge/dsfr-data/security/dependabot)
+- [Code scanning alerts](https://github.com/bmatge/dsfr-data/security/code-scanning)
+- [Tracking de la baseline sécurité — issue #65](https://github.com/bmatge/dsfr-data/issues/65)

--- a/docs/security-dev-guide.md
+++ b/docs/security-dev-guide.md
@@ -1,0 +1,113 @@
+# Guide développeur — scans de sécurité en local
+
+Ce document rassemble les commandes pour lancer en local les mêmes scans que la CI, avant de pousser. Toutes les commandes utilisent **Docker uniquement**, zéro install requise (sauf Docker Desktop). Les images sont pinnées à `:latest` ici pour la simplicité ; en CI on pinne une version stable.
+
+> 💡 **Pas obligatoire** : les hooks Husky et la CI rattrapent tout, mais un scan local avant un push coûteux t'évite d'attendre 2 minutes que GitHub te dise ce que tu aurais pu voir tout de suite.
+
+## Secrets — Gitleaks
+
+Scanner l'historique Git complet (ce que fait le job CI `secrets`) :
+
+```bash
+docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:latest \
+  detect --source /repo --verbose --redact
+```
+
+Scanner uniquement les modifications staged (ce que fait le hook Husky pre-commit si `gitleaks` est installé en local) :
+
+```bash
+docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:latest \
+  protect --source /repo --staged --verbose --redact
+```
+
+La config `.gitleaks.toml` est appliquée automatiquement (elle est à la racine du repo).
+
+## SCA — dépendances et config Docker — Trivy
+
+Scanner les lockfiles (root + mcp-server + Cargo) pour des CVE HIGH/CRITICAL :
+
+```bash
+docker run --rm -v "$PWD:/src" -v /tmp/trivy-cache:/root/.cache/trivy \
+  -w /src public.ecr.aws/aquasecurity/trivy:latest \
+  fs --scanners vuln --severity HIGH,CRITICAL --ignore-unfixed \
+  --no-progress .
+```
+
+Scanner les Dockerfiles (misconfig) :
+
+```bash
+docker run --rm -v "$PWD:/src" -v /tmp/trivy-cache:/root/.cache/trivy \
+  -w /src public.ecr.aws/aquasecurity/trivy:latest \
+  config --severity HIGH,CRITICAL --ignorefile .trivyignore -q .
+```
+
+Scanner une image Docker construite localement (CRITICAL only, comme la CI) :
+
+```bash
+# Build
+docker build -f docker/Dockerfile -t dsfr-data:scan .
+
+# Scan
+docker run --rm \
+  -v /tmp/trivy-cache:/root/.cache/trivy \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  public.ecr.aws/aquasecurity/trivy:latest \
+  image --severity CRITICAL --ignore-unfixed -q dsfr-data:scan
+```
+
+Pour `dsfr-data-db`, remplacer `docker/Dockerfile` par `docker/Dockerfile.db`.
+
+## SAST — Semgrep
+
+Scanner avec les mêmes rulesets que la CI :
+
+```bash
+docker run --rm -v "$PWD:/src" -w /src semgrep/semgrep:latest \
+  semgrep scan \
+  --config=p/default \
+  --config=p/typescript \
+  --config=p/javascript \
+  --config=p/xss \
+  --config=p/security-audit \
+  --exclude-rule=html.security.audit.missing-integrity.missing-integrity \
+  --severity=ERROR \
+  --severity=WARNING \
+  --metrics=off \
+  packages/core/src apps server/src scripts
+```
+
+Les exclusions de chemin sont lues depuis `.semgrepignore`. Pour forcer l'échec (comme en CI), ajouter `--error`.
+
+## npm audit
+
+```bash
+# Workspace root
+npm audit --audit-level=high
+
+# mcp-server (hors workspace)
+cd mcp-server && npm audit --audit-level=high
+```
+
+## Lint security
+
+Inclus dans `npm run lint` (eslint-plugin-security est déjà dans la config). Pour ne regarder que les findings sécurité :
+
+```bash
+npm run lint 2>&1 | grep 'security/'
+```
+
+## Workflow suggéré avant un push coûteux
+
+1. `npm run lint` — catch les warnings security/* locaux
+2. Trivy fs + config — catch les CVE HIGH/CRITICAL et les misconfig Docker
+3. Semgrep — catch les XSS / SQLi / patterns à risque
+4. Gitleaks `protect --staged` — catch les secrets avant commit
+
+Si les 4 passent, la CI passera aussi (sauf régression transverse).
+
+## Liens
+
+- Politique globale : [SECURITY.md](../SECURITY.md)
+- Runbook d'incident : [security-incident-response.md](./security-incident-response.md)
+- Tracking baseline : [issue #65](https://github.com/bmatge/dsfr-data/issues/65)
+- Policy calibration : [issue #73](https://github.com/bmatge/dsfr-data/issues/73)


### PR DESCRIPTION
## Summary

Consolidation de la baseline sécurité : politique publique, documentation développeur, et agrégation des findings dans l'onglet **Security** de GitHub.

## Ce qui change

### Nouveaux fichiers

- **`SECURITY.md`** à la racine (convention GitHub, affiché dans l'onglet Security)
  - Reporting via GitHub Security Advisories (préféré) ou email
  - Versions supportées : main + dernière release npm
  - **Table du pipeline sécurité** — 8 jobs listés avec outil, job/workflow, sévérité bloquante
  - Politique de sévérité (HIGH/CRITICAL blocking, MODERATE advisory — référencée à #73)
  - Faux positifs : politique de documentation (quoi / pourquoi / suivi / revue)
  - Liens vers les fichiers d'ignore et les procédures
- **`docs/security-dev-guide.md`** — commandes prêtes à copier-coller pour Trivy (fs, config, image), Semgrep, Gitleaks, npm audit, eslint-plugin-security — **tout en Docker, zéro install**

### Agrégation des findings (onglet Security)

Jusqu'ici, seul CodeQL remontait dans l'onglet Security → Code scanning. Semgrep et Gitleaks tournaient en CI mais leurs findings restaient dans les logs.

- **Job `sast`** : Semgrep produit désormais `semgrep.sarif`, uploadé via `github/codeql-action/upload-sarif@v3` (category: `semgrep`), avec `if: always()` pour garder l'upload même si le scan a fail.
- **Job `secrets`** : `gitleaks-action@v2` upload déjà automatiquement en SARIF quand `security-events: write` est présent → permission ajoutée au job.
- Permissions ajoutées aux deux jobs : `contents: read` + `security-events: write`.

### README

- Nouveau badge **CodeQL** (workflow status)
- Nouveau badge **Security Policy** → lien vers `SECURITY.md`

### Setting GitHub activé via API (pas dans le diff)

- **`dependabot_security_updates` : enabled** — Dependabot crée désormais automatiquement des PRs de fix quand une advisory impacte nos deps (pas juste l'alerte visible, mais un PR actionnable).

Vérification :
```bash
gh api repos/bmatge/dsfr-data --jq '.security_and_analysis.dependabot_security_updates'
# → {"status":"enabled"}
```

## Scope / hors scope

- ✅ Dans le scope : SECURITY.md, dev guide, SARIF upload, badges, activation `dependabot_security_updates`
- ❌ Hors scope : calibration de la politique de sévérité (→ #73), DAST (→ #61), extraction baseline (→ #64)

## Changeset

Pas de changeset : docs + workflows uniquement.

## Test plan

- [ ] `sast` job toujours vert, et `Upload Semgrep SARIF` step s'exécute
- [ ] `secrets` job toujours vert, gitleaks upload SARIF automatique
- [ ] Les 2 SARIF apparaissent dans [Security → Code scanning](https://github.com/bmatge/dsfr-data/security/code-scanning) **après merge sur main**
- [ ] Badges CodeQL et Security Policy s'affichent dans le README sur l'UI GitHub
- [ ] `SECURITY.md` détecté et affiché dans [Security → Security policy](https://github.com/bmatge/dsfr-data/security/policy)

Closes #63
Refs #65 (tracking), #73 (policy)
