### PR TITLE
ci(deps): enable Dependabot Cargo for src-tauri

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,15 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

Adds a \`cargo\` package-ecosystem updater to \`.github/dependabot.yml\` pointing at \`/src-tauri\`, so Dependabot surfaces the Rust advisories on \`rand\` and \`glib\` identified in the security baseline triage (#73). Minor and patch updates are grouped into a single PR to keep review noise low; majors still land as individual PRs for manual review.

## Test plan

- [ ] CI green on PR
- [ ] After merge: confirm at least one Cargo PR (or a grouped one) appears within the week on the next Dependabot run
- [ ] Follow up on #73 once the rand/glib advisories are remediated

🤖 Generated with [Claude Code](https://claude.com/claude-code)