### PR TITLE
fix(security): type confusion on /auth/users and XSS in playground back-link

### DIFF
--- a/apps/playground/src/main.ts
+++ b/apps/playground/src/main.ts
@@ -195,19 +195,27 @@ function saveFavorite(): void {
 document.addEventListener('DOMContentLoaded', async () => {
   await initAuth();
 
-  // Show back link if navigated from another app
+  // Show back link if navigated from another app. The `from` query param is
+  // user-controlled, so only accept a whitelisted set of values and build the
+  // anchor via DOM APIs (textContent) to avoid XSS.
   const fromApp = new URLSearchParams(window.location.search).get('from');
-  if (fromApp) {
-    // When going back to builder, pass from=playground so builder can restore its state
+  const BACK_LABELS: Record<string, string> = {
+    builder: 'Builder',
+    'builder-ia': 'Builder IA',
+    favorites: 'Favoris',
+  };
+  if (fromApp && Object.prototype.hasOwnProperty.call(BACK_LABELS, fromApp)) {
     const backHref =
       fromApp === 'builder' || fromApp === 'builder-ia'
-        ? appHref(fromApp as any, { from: 'playground' })
-        : appHref(fromApp as any);
-    const backLabel =
-      fromApp === 'builder' ? 'Builder' : fromApp === 'builder-ia' ? 'Builder IA' : fromApp;
+        ? appHref(fromApp as 'builder' | 'builder-ia', { from: 'playground' })
+        : appHref(fromApp as 'favorites');
     const backBar = document.createElement('div');
     backBar.className = 'fr-mb-1w';
-    backBar.innerHTML = `<a href="${backHref}" class="fr-link fr-icon-arrow-left-line fr-link--icon-left">Retour au ${backLabel}</a>`;
+    const link = document.createElement('a');
+    link.href = backHref;
+    link.className = 'fr-link fr-icon-arrow-left-line fr-link--icon-left';
+    link.textContent = `Retour au ${BACK_LABELS[fromApp]}`;
+    backBar.appendChild(link);
     const main = document.querySelector('main .fr-container') || document.querySelector('main');
     if (main) main.prepend(backBar);
   }

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -585,8 +585,8 @@ router.post('/reset-password', authLimiter, async (req, res) => {
  */
 router.get('/users', requireAuth, async (req, res) => {
   try {
-    const q = req.query.q as string;
-    if (!q || q.length < 2) {
+    const q = req.query.q;
+    if (typeof q !== 'string' || q.length < 2) {
       res.json([]);
       return;
     }


### PR DESCRIPTION
## Summary

Fixes two CodeQL findings from the [security code-scanning dashboard](https://github.com/bmatge/dsfr-data/security/code-scanning):

| # | Severity | Rule | File |
|---|---|---|---|
| [6](https://github.com/bmatge/dsfr-data/security/code-scanning/6) | **critical** | \`js/type-confusion-through-parameter-tampering\` | [server/src/routes/auth.ts:589](server/src/routes/auth.ts#L589) |
| [17](https://github.com/bmatge/dsfr-data/security/code-scanning/17) | **high** | \`js/xss\` | [apps/playground/src/main.ts:210](apps/playground/src/main.ts#L210) |

## #6 — type confusion on \`GET /api/auth/users\`

\`req.query.q\` is typed \`string | string[] | ParsedQs | ParsedQs[]\` in Express, so the old \`as string\` cast lied about the type and \`q.length < 2\` would not behave as expected when the request contained \`?q=a&q=b\` (q becomes an array). Replaced the cast with a \`typeof q !== 'string'\` guard so non-string inputs short-circuit to an empty result before reaching the parameterised SQL query.

## #17 — XSS in playground back-link

The playground back-link was built via \`innerHTML\` and interpolated \`fromApp\` directly into the anchor text when the value was neither \`builder\` nor \`builder-ia\`:
\`\`\`ts
backBar.innerHTML = \`<a href="\${backHref}" ...>Retour au \${backLabel}</a>\`;
\`\`\`
Since \`fromApp\` comes from \`URLSearchParams(window.location.search).get('from')\`, a crafted \`?from=<img src onerror=alert(1)>\` would execute. Fix:

- Whitelist accepted values via \`BACK_LABELS\` (\`builder\`, \`builder-ia\`, \`favorites\`) — unknown values short-circuit and the back bar is not rendered at all.
- Build the anchor via DOM APIs (\`createElement\` + \`setAttribute\` + \`textContent\`) so the label is never parsed as HTML.

## Scope

This PR only addresses the critical + highest-impact XSS finding. The other three high-error alerts surfaced during the same triage (#11 clear-text storage, #21 missing CSRF middleware) require either architectural discussion (#11) or a dedicated session (#21) and are tracked separately.

## Test plan

- [x] \`npm run test:run\` — 2851/2851 passing
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build:server\` — clean
- [ ] CI green on PR
- [ ] Post-merge: CodeQL alerts #6 and #17 should auto-close on the next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)