### PR TITLE
chore(deps): remove deprecated @types/uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3124,13 +3124,6 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/whatwg-mimetype": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
@@ -9529,6 +9522,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9546,6 +9540,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9563,6 +9558,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9580,6 +9576,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9597,6 +9594,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9614,6 +9612,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9631,6 +9630,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9648,6 +9648,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9665,6 +9666,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9682,6 +9684,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9699,6 +9702,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9716,6 +9720,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9733,6 +9738,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9750,6 +9756,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9767,6 +9774,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9784,6 +9792,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9801,6 +9810,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9818,6 +9828,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9835,6 +9846,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9852,6 +9864,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9869,6 +9882,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9886,6 +9900,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9903,6 +9918,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9920,6 +9936,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9937,6 +9954,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9954,6 +9972,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10011,6 +10030,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -10783,7 +10803,6 @@
         "@types/jsonwebtoken": "^9.0.7",
         "@types/nodemailer": "^8.0.0",
         "@types/supertest": "^6.0.2",
-        "@types/uuid": "^10.0.0",
         "better-sqlite3": "^12.9.0",
         "supertest": "^7.0.0",
         "tsx": "^4.19.0",

--- a/server/package.json
+++ b/server/package.json
@@ -31,7 +31,6 @@
     "@types/jsonwebtoken": "^9.0.7",
     "@types/nodemailer": "^8.0.0",
     "@types/supertest": "^6.0.2",
-    "@types/uuid": "^10.0.0",
     "better-sqlite3": "^12.9.0",
     "supertest": "^7.0.0",
     "tsx": "^4.19.0",


### PR DESCRIPTION
## Summary

\`@types/uuid@11\` is now a stub that aliases to the \`uuid\` package. Since we merged \`uuid@13\` (#53), the package ships its own TypeScript definitions (\`uuid/package.json\` declares \`\"types\": \"./dist/index.d.ts\"\`). Keeping \`@types/uuid\` as a dev dependency is redundant.

Supersedes #88 which bumped 10 → 11 instead of removing the package.

## Test plan

- [x] \`npm install\` — lockfile regenerates cleanly
- [x] \`npm run build:server\` — \`tsc\` happy, no missing types
- [ ] CI green on PR
- [ ] Close #88 on merge

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)