### PR TITLE
fix(security): rate limiting on /logout and global /api safety net

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import { initDatabase, closeDatabase, execute } from './db/database.js';
 import { authMiddleware } from './middleware/auth.js';
+import { globalApiRateLimiter } from './middleware/rate-limit.js';
 import authRoutes from './routes/auth.js';
 import sourcesRoutes from './routes/sources.js';
 import connectionsRoutes from './routes/connections.js';
@@ -29,6 +30,10 @@ app.use(
 );
 app.use(express.json({ limit: '10mb' }));
 app.use(cookieParser());
+
+// Global safety-net rate limiter on all /api/* routes. Per-route auth limiters
+// (authLimiter) apply on top for sensitive auth flows.
+app.use('/api', globalApiRateLimiter);
 
 // Auth middleware (sets req.user on all requests)
 app.use(authMiddleware);

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -46,3 +46,25 @@ export function beaconRateLimiter(req: Request, res: Response, next: NextFunctio
   }
   beaconLimiter(req, res, next);
 }
+
+const globalApiLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 300, // 300 requests per minute per IP (safety net against scraping/brute force)
+  message: { error: 'Trop de requetes, ralentissez' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
+ * Global safety-net rate limiter applied to every /api/* route before auth
+ * middleware kicks in. Much more permissive than the per-route auth limiter;
+ * its job is only to catch obvious abuse (scraping, brute force).
+ * Disabled in test environment.
+ */
+export function globalApiRateLimiter(req: Request, res: Response, next: NextFunction): void {
+  if (process.env.NODE_ENV === 'test') {
+    next();
+    return;
+  }
+  globalApiLimiter(req, res, next);
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -314,7 +314,7 @@ router.post('/login', authLimiter, async (req, res) => {
  * POST /api/auth/logout
  * Clear the auth cookie and revoke the session.
  */
-router.post('/logout', async (req, res) => {
+router.post('/logout', authLimiter, async (req, res) => {
   const token = req.cookies?.['gw-auth-token'];
   if (token) {
     try {


### PR DESCRIPTION
## Summary

Fixes two CodeQL \`js/missing-rate-limiting\` findings surfaced in the [security code-scanning dashboard](https://github.com/bmatge/dsfr-data/security/code-scanning).

| # | Severity | Rule | Location |
|---|---|---|---|
| [22](https://github.com/bmatge/dsfr-data/security/code-scanning/22) | high | \`js/missing-rate-limiting\` | [server/src/index.ts:34](server/src/index.ts#L34) |
| [23](https://github.com/bmatge/dsfr-data/security/code-scanning/23) | high | \`js/missing-rate-limiting\` | [server/src/routes/auth.ts:317](server/src/routes/auth.ts#L317) |

## #23 — POST /api/auth/logout

This mutation route read the session cookie and called \`revokeSession(token)\` without any rate limiter. A malicious actor who captured a victim's token could spam \`/logout\` to force repeated DB writes. Fix: apply \`authLimiter\` (10 req / 15 min / IP) like the other auth mutation routes (register, login, forgot-password, reset-password).

## #22 — global \`/api/*\` safety net

The \`authMiddleware\` at \`server/src/index.ts:34\` runs on every request but had no upstream rate limiter, so any unauthenticated \`/api/*\` endpoint (including the health probe and beacon fallback) was unthrottled. Fix: introduce a new \`globalApiRateLimiter\` (300 req / min / IP) mounted on \`/api/*\` before \`authMiddleware\`. The limit is permissive by design — it's only a safety net against scraping and brute force; the tighter \`authLimiter\` still protects the sensitive auth flows on top.

Both limiters are disabled in \`NODE_ENV=test\` to keep the test suite deterministic (same pattern as the existing \`authLimiter\` and \`beaconRateLimiter\`).

## Test plan

- [x] \`npm run test:run\` — 2851/2851 passing
- [x] \`npm run typecheck\` — clean
- [x] \`npm run build:server\` — clean
- [ ] CI green on PR
- [ ] Post-merge: CodeQL alerts #22 and #23 auto-close on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)