### PR TITLE
chore(security): add sca-advisory non-blocking CI job (closes #73)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,16 @@
 version: 2
 updates:
+  # See ADR-004 — Politique de sévérité SCA et défense en profondeur.
+  # Advisory-driven PRs get the "security" label automatically so they can be
+  # fast-tracked independently of the dev/production dependency groups.
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    labels:
+      - security
     groups:
       dev-dependencies:
         dependency-type: development
@@ -22,6 +27,8 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 3
+    labels:
+      - security
 
   - package-ecosystem: cargo
     directory: /src-tauri
@@ -29,6 +36,8 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    labels:
+      - security
     groups:
       cargo-minor-patch:
         update-types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,61 @@ jobs:
           exit-code: '1'
           trivyignores: .trivyignore
 
+  sca-advisory:
+    # Non-blocking advisory channel — see ADR-004 (Politique de sévérité SCA).
+    # Gate reste HIGH/CRITICAL (job `sca` above). Ce job remonte les MODERATE
+    # en step summary sans casser la CI. Remédiation asynchrone via Dependabot
+    # (labels: [security] configurés dans .github/dependabot.yml).
+    name: Security — SCA advisory (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: npm audit (root, moderate+)
+        id: audit_root
+        continue-on-error: true
+        run: |
+          echo "### 📋 npm audit — root (moderate+)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          npm audit --audit-level=moderate --omit=optional 2>&1 | tee -a $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: npm audit (mcp-server, moderate+)
+        id: audit_mcp
+        continue-on-error: true
+        working-directory: mcp-server
+        run: |
+          echo "### 📋 npm audit — mcp-server (moderate+)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          npm audit --audit-level=moderate 2>&1 | tee -a $GITHUB_STEP_SUMMARY || true
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+      - name: Trivy — filesystem (MEDIUM+)
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          scan-type: fs
+          scanners: vuln
+          severity: MEDIUM,HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '0'
+          format: table
+          output: trivy-advisory.txt
+          trivyignores: .trivyignore
+
+      - name: Append Trivy output to summary
+        if: always()
+        run: |
+          echo "### 🛡️ Trivy fs — MEDIUM+ (non-blocking)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat trivy-advisory.txt 2>/dev/null || echo "(no output)" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
   secrets:
     name: Security — Secrets
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Implémente [ADR-004 — Politique de sévérité SCA et défense en profondeur](https://github.com/bmatge/dsfr-data/issues/73). Ferme #73.

### Changes

**`.github/dependabot.yml`** — `labels: [security]` ajouté sur les 3 ecosystems (npm, github-actions, cargo). Les advisory-driven PRs sont maintenant automatiquement taggées, ce qui permet de les fast-tracker indépendamment des groupes dev/production.

**`.github/workflows/ci.yml`** — nouveau job `sca-advisory` non-bloquant (`continue-on-error: true`) qui complète le gate HIGH/CRITICAL existant :

- `npm audit --audit-level=moderate` sur root et mcp-server
- `trivy fs --severity=MEDIUM,HIGH,CRITICAL`
- Résultats en **Step Summary** de chaque PR, pas d'échec CI

Le gate bloquant reste **HIGH/CRITICAL** (job `sca`) — ce nouveau job ajoute seulement un canal de visibilité sur les MODERATE.

### Pourquoi

Le gap identifié dans #73 : les 9 advisories Dependabot historiques (7× `hono`/`nodemailer`, 2× Cargo) passaient sous le radar parce qu'aucun outil ne les remontait dans les PRs. Les 7 npm ont été fermées par la vague Dependabot du 14-15 avril, il reste 2 Cargo pinnées par tauri — mais la politique ne peut pas rester implicite.

### Alternative rejetée

"Tout bloquant MODERATE+" aurait cassé la CI sur chaque nouvelle advisory (friction élevée, pression à ignorer). Voir les Options A-F dans l'ADR.

### Test plan

- [x] YAML syntax validé (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI verte sur la PR
- [ ] Sur une PR test future, vérifier que le step summary `sca-advisory` apparaît avec les advisories MODERATE

Closes #73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)