### PR TITLE
feat(ci): add OWASP ZAP DAST workflow (closes #61)

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -1,0 +1,114 @@
+name: DAST
+
+# Dynamic Application Security Testing — OWASP ZAP baseline scan.
+#
+# Spins up the full production stack (MariaDB + Express + nginx) inside the
+# runner, waits for /api/health, then runs ZAP passive scan (+ AJAX spider)
+# against the single entry point at http://localhost:8080/. The scan discovers
+# both the frontend surface and the /api/* routes since nginx proxies both on
+# the same origin — a separate "frontend" and "API" job would duplicate the
+# 3-4 min boot cost for zero coverage benefit.
+#
+# Non-blocking advisory channel, see ADR-004 (Politique de sévérité SCA et
+# défense en profondeur). Findings are uploaded as artifacts and surfaced via
+# the ZAP action's step summary; remediation is asynchronous.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 08:00 UTC (after docker-scan Monday 07:00 UTC).
+    - cron: '0 8 * * 1'
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  dast:
+    name: DAST — OWASP ZAP baseline (non-blocking)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate ephemeral secrets for the CI stack
+        run: |
+          set -euo pipefail
+          JWT_SECRET=$(openssl rand -base64 48 | tr -d '\n=/+' | head -c 64)
+          DB_PASSWORD=$(openssl rand -base64 24 | tr -d '\n=/+' | head -c 24)
+          DB_ROOT_PASSWORD=$(openssl rand -base64 24 | tr -d '\n=/+' | head -c 24)
+          ENCRYPTION_KEY=$(openssl rand -hex 32)
+
+          # Mask in logs before writing anywhere.
+          echo "::add-mask::$JWT_SECRET"
+          echo "::add-mask::$DB_PASSWORD"
+          echo "::add-mask::$DB_ROOT_PASSWORD"
+          echo "::add-mask::$ENCRYPTION_KEY"
+
+          {
+            echo "JWT_SECRET=$JWT_SECRET"
+            echo "DB_PASSWORD=$DB_PASSWORD"
+            echo "DB_ROOT_PASSWORD=$DB_ROOT_PASSWORD"
+            echo "ENCRYPTION_KEY=$ENCRYPTION_KEY"
+          } > docker/.env
+
+      - name: Build and start stack (MariaDB + Express + nginx)
+        working-directory: docker
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.db.yml \
+            -f docker-compose.ci.yml \
+            up -d --build
+
+      - name: Wait for /api/health
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8080/api/health >/dev/null 2>&1; then
+              echo "App is healthy after ${i} attempts:"
+              curl -s http://localhost:8080/api/health
+              exit 0
+            fi
+            echo "Attempt ${i}/60 — not ready yet, retrying in 5s…"
+            sleep 5
+          done
+          echo "::error::App did not become healthy within 5 minutes"
+          exit 1
+
+      - name: Dump stack logs if app never came up
+        if: failure()
+        working-directory: docker
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.db.yml \
+            -f docker-compose.ci.yml \
+            logs --tail=300
+
+      - name: OWASP ZAP baseline scan
+        # Passive scan + AJAX spider to cover the SPA-driven routing.
+        # -a: include alpha passive rules
+        # -j: use AJAX spider (headless Chromium bundled in the action image)
+        # -m 3: max spider time (minutes)
+        # -T 15: max total scan time (minutes, safety cap)
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: 'http://localhost:8080/'
+          rules_file_name: '.zap/rules.tsv'
+          cmd_options: '-a -j -m 3 -T 15'
+          fail_action: false
+          allow_issue_writing: false
+          artifact_name: zap-baseline-report
+
+      - name: Tear down stack
+        if: always()
+        working-directory: docker
+        run: |
+          docker compose \
+            -f docker-compose.yml \
+            -f docker-compose.db.yml \
+            -f docker-compose.ci.yml \
+            down -v

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,16 @@
+# ZAP Baseline rules — ignorations documentées.
+#
+# Format (tab-separated) : RULE_ID	ACTION	[URL_REGEX]	[NOTE]
+# Actions :
+#   IGNORE — règle totalement désactivée (faux positif ou non pertinent)
+#   WARN   — passe en WARN au lieu de FAIL
+#   FAIL   — passe en FAIL au lieu de WARN
+#
+# Référentiel des IDs : https://www.zaproxy.org/docs/alerts/
+#
+# Règle d'or (cf. SECURITY.md — section « Faux positifs et exclusions ») :
+# toute ligne ajoutée doit porter une note explicite avec la justification et
+# la date d'ajout, pour que les entrées restent réévaluables dans le temps.
+#
+# Liste initialement vide — on remplira au fil des premières exécutions, une
+# fois qu'on aura distingué signal et bruit sur cette app.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,7 @@ Ce projet est en développement actif. Seule la branche `main` et la dernière v
 
 ## Pipeline de sécurité
 
-La CI exécute **8 jobs de sécurité** sur chaque pull request, et plusieurs workflows périodiques pour rattraper les CVE qui arrivent après un build :
+La CI exécute **9 jobs de sécurité** sur chaque pull request, et plusieurs workflows périodiques pour rattraper les CVE qui arrivent après un build :
 
 | Brique | Outil | Job / Workflow | Sévérité bloquante |
 |---|---|---|---|
@@ -42,10 +42,12 @@ La CI exécute **8 jobs de sécurité** sur chaque pull request, et plusieurs wo
 | **SAST — data flow** | `CodeQL` | `codeql.yml` | `security-and-quality` |
 | **Lint sécurité** | `eslint-plugin-security` | `quality` | toute erreur |
 | **Images Docker** | `trivy image` | `docker-scan.yml` (matrix sur 2 images) | CRITICAL |
+| **DAST — app live** | `OWASP ZAP baseline` | `dast.yml` (stack MariaDB+Express+nginx bootée dans le runner) | non bloquant (advisory) |
 
 Les scans périodiques :
 - **CodeQL** : hebdomadaire, lundi 06:00 UTC
 - **Trivy image** : hebdomadaire, lundi 07:00 UTC
+- **ZAP DAST** : hebdomadaire, lundi 08:00 UTC (+ `workflow_dispatch` manuel)
 
 ## Dépendances — Dependabot
 
@@ -71,6 +73,7 @@ Les fichiers d'exclusion à jour :
 - [`.trivyignore`](./.trivyignore)
 - [`.semgrepignore`](./.semgrepignore)
 - [`.gitleaks.toml`](./.gitleaks.toml)
+- [`.zap/rules.tsv`](./.zap/rules.tsv) — faux positifs DAST (ZAP baseline)
 - Exclusions inline (`// nosemgrep:`, `// eslint-disable-next-line security/…`) toujours avec un commentaire en ligne adjacente
 
 ## Procédures

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -1,0 +1,26 @@
+# Docker Compose override for CI (GitHub Actions runner).
+#
+# Usage (from repo root):
+#   cd docker && docker compose \
+#     -f docker-compose.yml \
+#     -f docker-compose.db.yml \
+#     -f docker-compose.ci.yml \
+#     up -d --build
+#
+# Differences vs production:
+#   - Maps nginx port 80 to host port 8080 (accessible from the runner / ZAP)
+#   - Turns `ecosystem-network` into a locally-managed bridge (no external Traefik)
+#   - Sets `CORS_ORIGIN` so cookie-based auth flows don't reject the ZAP origin
+#
+# Used only by `.github/workflows/dast.yml`. Not intended for dev or prod.
+
+services:
+  chartsbuilder:
+    ports:
+      - "8080:80"
+    environment:
+      - CORS_ORIGIN=http://localhost:8080
+
+networks:
+  ecosystem-network:
+    external: false

--- a/docs/security-dev-guide.md
+++ b/docs/security-dev-guide.md
@@ -96,6 +96,45 @@ Inclus dans `npm run lint` (eslint-plugin-security est déjà dans la config). P
 npm run lint 2>&1 | grep 'security/'
 ```
 
+## DAST — OWASP ZAP baseline
+
+Le scan DAST tourne en CI sur `workflow_dispatch` + chaque lundi 08:00 UTC (workflow [`.github/workflows/dast.yml`](../.github/workflows/dast.yml)). Pour le rejouer en local :
+
+```bash
+# 1. Démarrer la stack (MariaDB + Express + nginx) avec l'override CI
+cd docker
+cat > .env <<EOF
+JWT_SECRET=$(openssl rand -base64 48 | tr -d '\n=/+' | head -c 64)
+DB_PASSWORD=$(openssl rand -base64 24 | tr -d '\n=/+' | head -c 24)
+DB_ROOT_PASSWORD=$(openssl rand -base64 24 | tr -d '\n=/+' | head -c 24)
+ENCRYPTION_KEY=$(openssl rand -hex 32)
+EOF
+docker compose -f docker-compose.yml -f docker-compose.db.yml -f docker-compose.ci.yml up -d --build
+
+# 2. Attendre que l'API soit prête
+until curl -sf http://localhost:8080/api/health; do sleep 3; done
+
+# 3. Lancer ZAP baseline (même commande que la CI, artifacts locaux dans ./zap-report)
+mkdir -p zap-report
+docker run --rm \
+  --network host \
+  -v "$PWD/zap-report:/zap/wrk:rw" \
+  -v "$PWD/../.zap/rules.tsv:/zap/wrk/rules.tsv:ro" \
+  ghcr.io/zaproxy/zaproxy:stable \
+  zap-baseline.py -t http://localhost:8080/ -a -j -m 3 -T 15 \
+    -r report.html -w report.md -J report.json -c /zap/wrk/rules.tsv
+
+# 4. Lire le rapport
+open zap-report/report.html   # (Linux : xdg-open)
+
+# 5. Tear down
+docker compose -f docker-compose.yml -f docker-compose.db.yml -f docker-compose.ci.yml down -v
+```
+
+Les scans sont **non bloquants** (cf. [ADR-004](https://github.com/bmatge/dsfr-data/blob/main/CHANGELOG.md) — politique de sévérité SCA et défense en profondeur). Les findings sont traités asynchroniquement via les artifacts GitHub Actions.
+
+Pour ajouter un faux positif, éditer [`.zap/rules.tsv`](../.zap/rules.tsv) en suivant le format documenté en en-tête du fichier (RULE_ID, ACTION, URL_REGEX optionnel, note obligatoire avec date).
+
 ## Workflow suggéré avant un push coûteux
 
 1. `npm run lint` — catch les warnings security/* locaux


### PR DESCRIPTION
## Summary

- Ajoute le dernier job de la baseline sécurité : **DAST via OWASP ZAP baseline** (closes #61, milestone *Security baseline*).
- Le workflow spin-up la stack complète (MariaDB + Express + nginx) dans le runner, attend `/api/health`, lance ZAP en passive + AJAX spider, puis publie le rapport HTML/MD/JSON en artifact.
- **Non-bloquant** (`continue-on-error: true`) — advisory channel aligné sur la politique [ADR-004](https://github.com/bmatge/dsfr-data/blob/main/CHANGELOG.md) (SCA : remédiation asynchrone via artifacts et triage manuel).

## Fichiers ajoutés

| Fichier | Rôle |
|---|---|
| `.github/workflows/dast.yml` | `workflow_dispatch` + `schedule: 0 8 * * 1` (lundi 08:00 UTC, après docker-scan 07:00) |
| `docker/docker-compose.ci.yml` | Override CI : expose port 80 → 8080, neutralise `ecosystem-network` (pas de Traefik) |
| `.zap/rules.tsv` | Fichier d'ignorations DAST, initialement vide, format documenté (RULE_ID / ACTION / note + date) |
| `SECURITY.md` | Table des jobs passée à 9 entrées, ZAP DAST listé + réfs aux scans périodiques |
| `docs/security-dev-guide.md` | Section « DAST — OWASP ZAP baseline » avec procédure locale complète |

## Choix d'implémentation

- **Un seul job** au lieu des deux suggérés dans l'issue (frontend + API) : les deux surfaces sont servies par le même nginx sur le même origin (`http://localhost:8080/` + proxy pass `/api/*` vers Express sur 3002). Splitter doublerait le coût de boot (~3-4 min) pour zéro gain de couverture.
- **AJAX spider** (`-j`) activé pour couvrir les routes SPA-driven du frontend Vite.
- **Secrets éphémères** : `JWT_SECRET`, `DB_PASSWORD`, `DB_ROOT_PASSWORD`, `ENCRYPTION_KEY` générés à la volée via `openssl rand`, masqués via `::add-mask::`. Pas de secret GitHub à configurer.
- **Caps de sécurité** : `-m 3 -T 15` (3 min spider, 15 min total) + `timeout-minutes: 45` au niveau job.
- **Pas d'issue writing** (`allow_issue_writing: false`) : on privilégie l'artifact et le step summary à la pollution de l'onglet Issues.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` sur `dast.yml` et `docker-compose.ci.yml` → OK
- [x] `docker compose -f yml -f db -f ci config` se rend sans erreur et expose `ports: 8080:80`
- [ ] **Lancer manuellement le workflow via `gh workflow run dast.yml`** après merge pour valider le boot de la stack en conditions réelles (3-4 min) et la génération du 1er rapport. Les findings initiaux serviront à peupler `.zap/rules.tsv`.
- [ ] Vérifier que le schedule hebdo se déclenche bien lundi prochain (08:00 UTC).

## Impact baseline sécurité

Milestone *Security baseline* : **7/7 issues baseline fermées** (voir [#65](https://github.com/bmatge/dsfr-data/issues/65)). Reste le backlog post-baseline : #69 (SRI), #92 (CSRF), #94 (Express 5), #66 (nginx non-root), #45 (no-explicit-any).

🤖 Generated with [Claude Code](https://claude.com/claude-code)