### PR TITLE
feat(security): CSRF protection via double-submit cookie (closes #92)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,14 @@ APP_DOMAIN=chartsbuilder.matge.com
 # ENCRYPTION_KEY=
 
 # ---------------------------------------------------------------------------
+# CSRF Secret (mode serveur uniquement)
+# ---------------------------------------------------------------------------
+# Cle HMAC pour la generation/validation des tokens CSRF (csrf-csrf v4).
+# Generer avec : openssl rand -hex 32
+# Si non defini, fallback sur ENCRYPTION_KEY (portees disjointes, AES vs HMAC).
+# CSRF_SECRET=
+
+# ---------------------------------------------------------------------------
 # SMTP - Envoi d'emails (mode serveur uniquement)
 # ---------------------------------------------------------------------------
 # Serveur SMTP pour l'envoi d'emails (verification, bienvenue).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,6 +49,18 @@ Les scans périodiques :
 - **Trivy image** : hebdomadaire, lundi 07:00 UTC
 - **ZAP DAST** : hebdomadaire, lundi 08:00 UTC (+ `workflow_dispatch` manuel)
 
+## Backend — défenses applicatives
+
+Côté Express, trois couches empilées couvrent les surfaces auth + API :
+
+| Couche | Mécanisme | Activé sur | Raison |
+|---|---|---|---|
+| **Session** | Cookie httpOnly `gw-auth-token` (JWT 7j, SameSite=Strict) | toutes les routes `/api/*` via `authMiddleware` | Authentifie l'utilisateur sans exposer le token au JS côté navigateur |
+| **CSRF** | Double-submit cookie (`csrf-csrf` v4) — header `X-CSRF-Token` + cookie `gw-csrf`, liés à `userId` (ou IP si anonyme) | `POST/PUT/PATCH/DELETE` sauf auth-bootstrap (login, register, reset-password, verify-email) | Empêche qu'une form tierce déclenche une mutation via le cookie d'auth de la victime (cf. issue #92) |
+| **Rate limiting** | `express-rate-limit` 10/15min sur auth, 300/min safety-net sur `/api/*` | auth + global | Absorbe l'énumération / brute force avant qu'il ne tape l'application |
+
+Chiffrement au repos : les `connections.api_key_encrypted` sont chiffrées en AES-256-GCM (clé `ENCRYPTION_KEY`, 64 hex). Le secret CSRF dérive de la même env var par défaut ou est spécifié séparément via `CSRF_SECRET`.
+
 ## Dépendances — Dependabot
 
 - **Alertes Dependabot** : activées, visibles dans [l'onglet Security → Dependabot](https://github.com/bmatge/dsfr-data/security/dependabot).

--- a/docs/security-dev-guide.md
+++ b/docs/security-dev-guide.md
@@ -114,6 +114,36 @@ Le script est idempotent : une 2e passe ne modifie rien. Il fetch uniquement les
 
 **Quand relancer `npm run generate-sri`** : à chaque bump de version CDN — le hash est lié à un contenu précis, donc tout `@1.14.4 → @1.14.5` invalide le hash et casse la prod. Le job `quality` de la CI lance `check:sri` à chaque PR ; une divergence remonte en erreur.
 
+## CSRF — double-submit cookie
+
+Toutes les routes muantes (`POST/PUT/PATCH/DELETE`) exigent un header `X-CSRF-Token` dont la valeur matche le cookie `gw-csrf`. Implémenté via `csrf-csrf` v4 (cf. [server/src/middleware/csrf.ts](../server/src/middleware/csrf.ts) + issue #92).
+
+### Côté frontend
+
+Le helper [`authenticatedFetch`](../packages/shared/src/auth/auth-service.ts) injecte automatiquement le header sur chaque mutation et retry une fois si le serveur renvoie `403 { code: 'CSRF_INVALID' }` (token expiré ou rotaté). Les consommateurs externes à auth-service (sync-queue, adapters) doivent importer ce helper au lieu de `fetch` natif :
+
+```ts
+import { authenticatedFetch } from '@dsfr-data/shared';
+
+// ✓ auto CSRF sur POST/PUT/DELETE
+await authenticatedFetch('/api/sources', { method: 'POST', body: JSON.stringify(src) });
+
+// ✗ raw fetch sur mutation → 403 CSRF_INVALID
+await fetch('/api/sources', { method: 'POST', ... });
+```
+
+### Routes exemptées
+
+Les routes d'auth-bootstrap (`login`, `register`, `forgot-password`, `reset-password`, `verify-email`, `resend-verification`) sont **skippées** — elles s'exécutent avant qu'un token puisse exister. Leur anti-CSRF repose sur `SameSite=Strict` du cookie d'auth + le rate-limiter.
+
+### Tests d'intégration
+
+Activer CSRF dans un test via l'option `csrf: true` de `createTestApp` + `process.env.CSRF_ENABLED = '1'`. Cf. [tests/server/csrf.test.ts](../tests/server/csrf.test.ts) pour l'exemple canonique.
+
+### Provisioning du secret
+
+`CSRF_SECRET=$(openssl rand -hex 32)` dans `.env` (ou s'appuyer sur `ENCRYPTION_KEY` en fallback — lisible par le middleware, pas de collision puisque les usages sont disjoints — AES vs HMAC).
+
 ## DAST — OWASP ZAP baseline
 
 Le scan DAST tourne en CI sur `workflow_dispatch` + chaque lundi 08:00 UTC (workflow [`.github/workflows/dast.yml`](../.github/workflows/dast.yml)). Pour le rejouer en local :

--- a/package-lock.json
+++ b/package-lock.json
@@ -4906,6 +4906,44 @@
         "node": ">= 8"
       }
     },
+    "node_modules/csrf-csrf": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/csrf-csrf/-/csrf-csrf-4.0.3.tgz",
+      "integrity": "sha512-DaygOzelL4Qo1pHwI9LPyZL+X2456/OzpT596kNeZGiTSqKVDOk/9PPJ+FjzZacjMUEusOHw3WJKe1RW4iUhrw==",
+      "license": "ISC",
+      "dependencies": {
+        "http-errors": "^2.0.0"
+      }
+    },
+    "node_modules/csrf-csrf/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/csrf-csrf/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -12052,6 +12090,7 @@
         "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "csrf-csrf": "^4.0.3",
         "express": "^4.21.0",
         "express-rate-limit": "^8.3.2",
         "helmet": "^8.0.0",

--- a/packages/shared/src/auth/auth-service.ts
+++ b/packages/shared/src/auth/auth-service.ts
@@ -25,6 +25,22 @@ const _listeners: Set<AuthChangeCallback> = new Set();
 
 const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
+/**
+ * Endpoints qui ne requièrent PAS de token CSRF côté client — doit rester
+ * synchronisé avec la SKIP_PATHS de server/src/middleware/csrf.ts (routes
+ * d'auth-bootstrap + health check + l'émetteur du token lui-même).
+ */
+const CSRF_SKIP_PATHS = new Set<string>([
+  '/api/health',
+  '/api/auth/csrf',
+  '/api/auth/login',
+  '/api/auth/register',
+  '/api/auth/verify-email',
+  '/api/auth/resend-verification',
+  '/api/auth/forgot-password',
+  '/api/auth/reset-password',
+]);
+
 function notify(): void {
   for (const cb of _listeners) {
     try {
@@ -59,7 +75,7 @@ async function fetchCsrfToken(): Promise<string | null> {
 
 async function apiFetchOnce(path: string, options?: RequestInit): Promise<Response> {
   const method = (options?.method ?? 'GET').toUpperCase();
-  const needsCsrf = MUTATION_METHODS.has(method);
+  const needsCsrf = MUTATION_METHODS.has(method) && !CSRF_SKIP_PATHS.has(path);
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -85,8 +101,9 @@ async function apiFetchOnce(path: string, options?: RequestInit): Promise<Respon
  */
 async function apiFetch(path: string, options?: RequestInit): Promise<Response> {
   const res = await apiFetchOnce(path, options);
+  const method = (options?.method ?? 'GET').toUpperCase();
 
-  if (res.status === 403 && MUTATION_METHODS.has((options?.method ?? 'GET').toUpperCase())) {
+  if (res.status === 403 && MUTATION_METHODS.has(method) && !CSRF_SKIP_PATHS.has(path)) {
     // Peek body for CSRF_INVALID without consuming it
     const cloned = res.clone();
     try {
@@ -404,6 +421,15 @@ export function _resetAuthState(): void {
   _baseUrl = '';
   _csrfToken = null;
   _listeners.clear();
+}
+
+/**
+ * Pré-positionne le CSRF token pour les tests qui veulent éviter le fetch
+ * implicite vers /api/auth/csrf avant leur première mutation. À n'utiliser
+ * que dans les tests.
+ */
+export function _setCsrfTokenForTest(token: string | null): void {
+  _csrfToken = token;
 }
 
 /**

--- a/packages/shared/src/auth/auth-service.ts
+++ b/packages/shared/src/auth/auth-service.ts
@@ -20,7 +20,10 @@ let _state: AuthState = { ...AUTH_STATE_DEFAULTS };
 let _dbMode: boolean | null = null; // null = not yet detected
 let _checkAuthPromise: Promise<AuthState> | null = null;
 let _baseUrl = '';
+let _csrfToken: string | null = null; // fetched lazily, stored in memory only
 const _listeners: Set<AuthChangeCallback> = new Set();
+
+const MUTATION_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
 function notify(): void {
   for (const cb of _listeners) {
@@ -37,15 +40,68 @@ function setState(partial: Partial<AuthState>): void {
   notify();
 }
 
-async function apiFetch(path: string, options?: RequestInit): Promise<Response> {
+/**
+ * Fetch a fresh CSRF token from GET /api/auth/csrf and cache it in memory.
+ * Le token est distribué via cookie non-httpOnly ET body — on lit le body et
+ * on l'écho dans `X-CSRF-Token`.
+ */
+async function fetchCsrfToken(): Promise<string | null> {
+  try {
+    const res = await fetch(`${_baseUrl}/api/auth/csrf`, { credentials: 'include' });
+    if (!res.ok) return null;
+    const data = await res.json();
+    _csrfToken = typeof data?.csrfToken === 'string' ? data.csrfToken : null;
+    return _csrfToken;
+  } catch {
+    return null;
+  }
+}
+
+async function apiFetchOnce(path: string, options?: RequestInit): Promise<Response> {
+  const method = (options?.method ?? 'GET').toUpperCase();
+  const needsCsrf = MUTATION_METHODS.has(method);
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(options?.headers as Record<string, string> | undefined),
+  };
+
+  if (needsCsrf) {
+    if (!_csrfToken) await fetchCsrfToken();
+    if (_csrfToken) headers['X-CSRF-Token'] = _csrfToken;
+  }
+
   return fetch(`${_baseUrl}${path}`, {
     ...options,
     credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...options?.headers,
-    },
+    headers,
   });
+}
+
+/**
+ * Fetch wrapper aware of CSRF. Pour les requêtes muantes, injecte le header
+ * `X-CSRF-Token` depuis le cache mémoire. Si le server rejette avec 403
+ * CSRF_INVALID (token expiré/rotaté), refetch le token et retry UNE fois.
+ */
+async function apiFetch(path: string, options?: RequestInit): Promise<Response> {
+  const res = await apiFetchOnce(path, options);
+
+  if (res.status === 403 && MUTATION_METHODS.has((options?.method ?? 'GET').toUpperCase())) {
+    // Peek body for CSRF_INVALID without consuming it
+    const cloned = res.clone();
+    try {
+      const data = await cloned.json();
+      if (data?.code === 'CSRF_INVALID') {
+        _csrfToken = null;
+        await fetchCsrfToken();
+        return apiFetchOnce(path, options);
+      }
+    } catch {
+      // Not JSON — fall through to returning the original response
+    }
+  }
+
+  return res;
 }
 
 // ──────────────────────────────────────────────────────────────
@@ -140,6 +196,12 @@ export async function login(request: LoginRequest): Promise<{ success: boolean; 
     const data = await res.json();
     setState({ user: data.user, isAuthenticated: true, isLoading: false });
 
+    // La session côté server vient de changer (anonymous → userId), donc le
+    // token CSRF mis en cache est lié à l'ancienne session. On force un fresh
+    // fetch pour les mutations qui suivent (auto-migrate, saves…).
+    _csrfToken = null;
+    await fetchCsrfToken();
+
     // Auto-migrate localStorage data if not yet done
     await autoMigrateIfNeeded();
 
@@ -168,6 +230,10 @@ export async function register(
 
     const data = await res.json();
     setState({ user: data.user, isAuthenticated: true, isLoading: false });
+
+    // Cf. login : session change → CSRF token à rafraîchir.
+    _csrfToken = null;
+    await fetchCsrfToken();
 
     // Auto-migrate localStorage data after first registration
     await autoMigrateIfNeeded();
@@ -260,6 +326,7 @@ export async function logout(): Promise<void> {
   } catch {
     // Ignore errors — clear state anyway
   }
+  _csrfToken = null;
   setState({ user: null, isAuthenticated: false, isLoading: false });
 }
 
@@ -335,5 +402,16 @@ export function _resetAuthState(): void {
   _dbMode = null;
   _checkAuthPromise = null;
   _baseUrl = '';
+  _csrfToken = null;
   _listeners.clear();
+}
+
+/**
+ * Fetch wrapper avec credentials + auto-injection CSRF.
+ * Pour les consommateurs qui ne sont PAS dans auth-service lui-même :
+ * sync-queue, api-storage-adapter, etc. Les requêtes muantes (POST/PUT/…)
+ * reçoivent automatiquement `X-CSRF-Token` et retry 1 fois sur 403.
+ */
+export async function authenticatedFetch(path: string, options?: RequestInit): Promise<Response> {
+  return apiFetch(path, options);
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -96,6 +96,7 @@ export {
   changePassword,
   forgotPassword,
   resetPassword,
+  authenticatedFetch,
   onAuthChange,
   getAuthState,
   getUser,

--- a/packages/shared/src/storage/sync-queue.ts
+++ b/packages/shared/src/storage/sync-queue.ts
@@ -9,6 +9,8 @@
  * - Persists queue to localStorage so operations survive page reloads
  */
 
+import { authenticatedFetch } from '../auth/auth-service.js';
+
 export type SyncStatus = 'idle' | 'syncing' | 'error' | 'offline';
 
 type SyncStatusCallback = (status: SyncStatus, errorCount: number) => void;
@@ -178,10 +180,11 @@ async function processQueue(): Promise<void> {
     setStatus('syncing', _errorCount);
 
     try {
-      const response = await fetch(op.url, {
+      // authenticatedFetch auto-inject `X-CSRF-Token` sur les mutations
+      // (POST/PUT/DELETE) et retry 1 fois sur 403 CSRF_INVALID (cf. #92).
+      const response = await authenticatedFetch(op.url, {
         method: op.method,
         headers: op.body ? { 'Content-Type': 'application/json' } : undefined,
-        credentials: 'include',
         body: op.body,
       });
 

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
+    "csrf-csrf": "^4.0.3",
     "express": "^4.21.0",
     "express-rate-limit": "^8.3.2",
     "helmet": "^8.0.0",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import cors from 'cors';
 import cookieParser from 'cookie-parser';
 import { initDatabase, closeDatabase, execute } from './db/database.js';
 import { authMiddleware } from './middleware/auth.js';
+import { doubleCsrfProtection, csrfErrorHandler } from './middleware/csrf.js';
 import { globalApiRateLimiter } from './middleware/rate-limit.js';
 import authRoutes from './routes/auth.js';
 import sourcesRoutes from './routes/sources.js';
@@ -38,6 +39,13 @@ app.use('/api', globalApiRateLimiter);
 // Auth middleware (sets req.user on all requests)
 app.use(authMiddleware);
 
+// CSRF protection — double-submit cookie pattern (csrf-csrf v4). Mounted
+// AFTER cookieParser + authMiddleware so it can access req.cookies + req.user
+// for session binding. Skips GET/HEAD/OPTIONS and auth-bootstrap routes
+// (login, register, forgot-password, reset-password, verify-email). See
+// server/src/middleware/csrf.ts for the skip list.
+app.use(doubleCsrfProtection);
+
 // Health check
 app.get('/api/health', (_req, res) => {
   res.json({ status: 'ok', mode: 'database' });
@@ -55,6 +63,10 @@ app.use('/api/cache', cacheRoutes);
 app.use('/api/migrate', migrateRoutes);
 app.use('/api/monitoring', monitoringRoutes);
 app.use('/api/admin', adminRoutes);
+
+// CSRF error handler — renvoie 403 JSON structuré que le frontend détecte
+// pour refetch le token. Doit être déclaré APRÈS les routes.
+app.use(csrfErrorHandler);
 
 // Graceful shutdown
 async function shutdown() {

--- a/server/src/middleware/csrf.ts
+++ b/server/src/middleware/csrf.ts
@@ -1,0 +1,102 @@
+/**
+ * CSRF protection via double-submit cookie (csrf-csrf v4).
+ *
+ * Modèle de menace : l'app utilise un cookie httpOnly `gw-auth-token` (JWT)
+ * pour l'authentification, avec `cors({ credentials: true })`. Une form HTML
+ * hébergée sur un domaine tiers pourrait POST vers nos routes en incluant
+ * automatiquement le cookie d'auth via le navigateur de la victime
+ * (attaque CSRF classique).
+ *
+ * Mitigation : chaque requête muante (POST/PUT/PATCH/DELETE) doit porter un
+ * header `X-CSRF-Token` dont la valeur est dérivée d'un secret serveur et
+ * liée à la session de l'utilisateur. Le token est distribué au frontend via
+ * un cookie non-httpOnly `gw-csrf` + renvoyé dans le body de `GET /api/auth/csrf`.
+ *
+ * Routes exemptées (déclarées dans SKIP_PATHS) : routes d'auth-bootstrap
+ * (login/register/reset-password/…) qui s'exécutent AVANT qu'un token CSRF
+ * puisse exister. L'anti-CSRF de ces routes repose sur le rate-limiter + la
+ * SameSite policy du cookie d'auth.
+ *
+ * cf. issue #92, ADR-004.
+ */
+
+import { doubleCsrf } from 'csrf-csrf';
+import type { Request, Response, NextFunction } from 'express';
+import type { AuthenticatedRequest } from './auth.js';
+
+const SKIP_PATHS = new Set<string>([
+  '/api/health',
+  '/api/auth/login',
+  '/api/auth/register',
+  '/api/auth/verify-email',
+  '/api/auth/resend-verification',
+  '/api/auth/forgot-password',
+  '/api/auth/reset-password',
+]);
+
+const CSRF_SECRET = (): string => {
+  const s = process.env.CSRF_SECRET;
+  if (s) return s;
+  // Fallback sur ENCRYPTION_KEY (déjà requis en prod, 64 hex chars) pour
+  // éviter de multiplier les secrets à provisionner. Les deux secrets ont
+  // des portées différentes (AES vs HMAC) donc pas de risque de collision.
+  const enc = process.env.ENCRYPTION_KEY;
+  if (enc && enc.length >= 32) return enc;
+  if (process.env.NODE_ENV === 'test') return 'test-csrf-secret-do-not-use-in-prod';
+  throw new Error('CSRF_SECRET (or ENCRYPTION_KEY fallback) environment variable is required');
+};
+
+const csrfUtils = doubleCsrf({
+  getSecret: () => CSRF_SECRET(),
+  getSessionIdentifier: (req: Request) => {
+    const u = (req as AuthenticatedRequest).user;
+    return u?.userId ?? req.ip ?? 'anonymous';
+  },
+  cookieName: 'gw-csrf',
+  cookieOptions: {
+    sameSite: 'strict',
+    secure: process.env.NODE_ENV === 'production',
+    httpOnly: false, // frontend lit la valeur pour l'écho via X-CSRF-Token
+    path: '/',
+  },
+  size: 32,
+  ignoredMethods: ['GET', 'HEAD', 'OPTIONS'],
+  getCsrfTokenFromRequest: (req: Request) => {
+    const h = req.headers['x-csrf-token'];
+    return Array.isArray(h) ? h[0] : h;
+  },
+  skipCsrfProtection: (req: Request): boolean => {
+    // Désactivé en test sauf si explicitement demandé (évite de casser les
+    // 61+ tests d'intégration existants qui ne passent pas de token).
+    if (process.env.NODE_ENV === 'test' && process.env.CSRF_ENABLED !== '1') return true;
+    return SKIP_PATHS.has(req.path);
+  },
+  errorConfig: {
+    statusCode: 403,
+    message: 'Invalid CSRF token',
+    code: 'CSRF_INVALID',
+  },
+});
+
+export const doubleCsrfProtection = csrfUtils.doubleCsrfProtection;
+export const generateCsrfToken = csrfUtils.generateCsrfToken;
+
+/**
+ * Express error handler spécifique aux erreurs CSRF — renvoie un JSON
+ * structuré que le frontend peut détecter pour déclencher un refetch.
+ */
+export function csrfErrorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  if (
+    err === csrfUtils.invalidCsrfTokenError ||
+    (err as { code?: string })?.code === 'CSRF_INVALID'
+  ) {
+    res.status(403).json({ error: 'Invalid CSRF token', code: 'CSRF_INVALID' });
+    return;
+  }
+  next(err);
+}

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -9,6 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { query, queryOne, execute } from '../db/database.js';
 import { createToken, setAuthCookie, clearAuthCookie, requireAuth } from '../middleware/auth.js';
 import type { AuthenticatedRequest } from '../middleware/auth.js';
+import { generateCsrfToken } from '../middleware/csrf.js';
 import { authLimiter } from '../middleware/rate-limit.js';
 import { isValidEmail, isStrongPassword } from '../utils/validation.js';
 import { sendVerificationEmail, sendPasswordResetEmail } from '../utils/mailer.js';
@@ -610,6 +611,18 @@ router.get('/users', requireAuth, async (req, res) => {
     console.error('Search users error:', err);
     res.status(500).json({ error: 'Internal server error' });
   }
+});
+
+/**
+ * GET /api/auth/csrf
+ * Émet un fresh CSRF token (double-submit pattern). Pose le cookie `gw-csrf`
+ * ET renvoie la valeur dans le body pour que le frontend puisse l'écho dans
+ * le header `X-CSRF-Token` sur chaque requête muante. Appelable sans auth —
+ * le token est lié à `req.user?.userId ?? req.ip` côté server.
+ */
+router.get('/csrf', (req, res) => {
+  const token = generateCsrfToken(req, res);
+  res.json({ csrfToken: token });
 });
 
 export default router;

--- a/tests/server/csrf.test.ts
+++ b/tests/server/csrf.test.ts
@@ -1,0 +1,102 @@
+/**
+ * CSRF protection integration tests (issue #92).
+ * Vérifie que les routes muantes rejettent les requêtes sans token valide,
+ * et acceptent celles qui portent un token obtenu via GET /api/auth/csrf.
+ *
+ * Ces tests activent explicitement CSRF (short-circuité par défaut en NODE_ENV=test
+ * pour ne pas casser les 61+ autres tests qui n'exercent pas ce chemin).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import request from 'supertest';
+import type { Express } from 'express';
+import { createTestApp, closeTestApp } from './test-helpers.js';
+
+describe('CSRF protection (issue #92)', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    process.env.CSRF_ENABLED = '1';
+  });
+
+  beforeEach(async () => {
+    app = await createTestApp({ csrf: true });
+  });
+
+  afterAll(async () => {
+    delete process.env.CSRF_ENABLED;
+    await closeTestApp();
+  });
+
+  it('GET /api/auth/csrf retourne un token et pose le cookie gw-csrf', async () => {
+    const res = await request(app).get('/api/auth/csrf');
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body.csrfToken).toBe('string');
+    expect(res.body.csrfToken.length).toBeGreaterThan(20);
+    const setCookie = res.headers['set-cookie'];
+    const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+    expect(cookies.some((c: string) => c.startsWith('gw-csrf='))).toBe(true);
+  });
+
+  it('POST muant sans token → 403 CSRF_INVALID', async () => {
+    // /api/migrate est un POST non-auth-bootstrap, c'est un bon canari :
+    // il retourne 401 (auth manquante) OU 403 (CSRF manquant) selon quelle
+    // protection matche en premier. L'ordre middleware fait que CSRF matche
+    // avant requireAuth.
+    const res = await request(app).post('/api/migrate').send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('CSRF_INVALID');
+  });
+
+  it('POST muant avec token valide → pas de 403 (rejoint la route)', async () => {
+    // On enchaîne : GET /csrf pour obtenir token+cookie, puis POST en renvoyant
+    // le cookie + X-CSRF-Token. Le test ne valide PAS le contenu de /migrate
+    // (il retournera probablement 401 sans auth), seulement l'absence de 403
+    // CSRF.
+    const csrfRes = await request(app).get('/api/auth/csrf');
+    const token = csrfRes.body.csrfToken as string;
+    const cookies = csrfRes.headers['set-cookie'] as unknown as string[];
+
+    const res = await request(app)
+      .post('/api/migrate')
+      .set('Cookie', cookies)
+      .set('X-CSRF-Token', token)
+      .send({ sources: [], connections: [], favorites: [], dashboards: [] });
+
+    expect(res.status).not.toBe(403);
+    expect(res.body.code).not.toBe('CSRF_INVALID');
+  });
+
+  it("POST auth-bootstrap (login, register, reset-password) n'exige PAS de token", async () => {
+    // Ces routes s'exécutent AVANT qu'un token puisse exister (cf. SKIP_PATHS
+    // dans csrf.ts). Elles s'appuient sur le rate-limiter + SameSite du cookie.
+    const login = await request(app).post('/api/auth/login').send({ email: 'x', password: 'y' });
+    expect(login.status).not.toBe(403);
+
+    const register = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'x', password: 'y' });
+    expect(register.status).not.toBe(403);
+
+    const reset = await request(app).post('/api/auth/forgot-password').send({ email: 'x' });
+    expect(reset.status).not.toBe(403);
+  });
+
+  it("GET/HEAD/OPTIONS n'exigent pas de token (idempotents)", async () => {
+    const get = await request(app).get('/api/health');
+    expect(get.status).not.toBe(403);
+  });
+
+  it('POST muant avec token invalide → 403 CSRF_INVALID', async () => {
+    const res = await request(app)
+      .post('/api/migrate')
+      .set('X-CSRF-Token', 'token-totalement-bidon')
+      .set('Cookie', 'gw-csrf=cookie-bidon')
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('CSRF_INVALID');
+  });
+});

--- a/tests/server/test-helpers.ts
+++ b/tests/server/test-helpers.ts
@@ -16,9 +16,10 @@
 
 import express from 'express';
 import cookieParser from 'cookie-parser';
-import { initDatabase, closeDatabase, execute, query } from '../../server/src/db/database.js';
+import { initDatabase, closeDatabase, execute } from '../../server/src/db/database.js';
 import { authMiddleware, createToken } from '../../server/src/middleware/auth.js';
 import type { JwtPayload } from '../../server/src/middleware/auth.js';
+import { doubleCsrfProtection, csrfErrorHandler } from '../../server/src/middleware/csrf.js';
 import authRoutes from '../../server/src/routes/auth.js';
 import sourcesRoutes from '../../server/src/routes/sources.js';
 import connectionsRoutes from '../../server/src/routes/connections.js';
@@ -61,12 +62,21 @@ const TABLES_TO_TRUNCATE = [
   'users',
 ];
 
+export interface TestAppOptions {
+  /**
+   * Enable CSRF protection in the test app (short-circuited by default via
+   * NODE_ENV=test). Set `true` on tests that verify CSRF behavior. Caller
+   * must also set `process.env.CSRF_ENABLED = '1'` before the request.
+   */
+  csrf?: boolean;
+}
+
 /**
  * Create a test Express app backed by MariaDB.
  * On first call, initializes the database pool and schema.
  * On subsequent calls, truncates all tables for a clean state.
  */
-export async function createTestApp(): Promise<Express> {
+export async function createTestApp(options: TestAppOptions = {}): Promise<Express> {
   if (!initialized) {
     await initDatabase();
     initialized = true;
@@ -89,6 +99,10 @@ export async function createTestApp(): Promise<Express> {
   app.use(cookieParser());
   app.use(authMiddleware);
 
+  if (options.csrf) {
+    app.use(doubleCsrfProtection);
+  }
+
   app.use('/api/auth', authRoutes);
   app.use('/api/sources', sourcesRoutes);
   app.use('/api/connections', connectionsRoutes);
@@ -100,6 +114,10 @@ export async function createTestApp(): Promise<Express> {
   app.use('/api/migrate', migrateRoutes);
   app.use('/api/monitoring', monitoringRoutes);
   app.use('/api/admin', adminRoutes);
+
+  if (options.csrf) {
+    app.use(csrfErrorHandler);
+  }
 
   return app;
 }

--- a/tests/shared/sync-queue.test.ts
+++ b/tests/shared/sync-queue.test.ts
@@ -8,11 +8,16 @@ import {
   deleteItem,
   _resetSyncQueue,
 } from '../../packages/shared/src/storage/sync-queue';
+import { _setCsrfTokenForTest } from '../../packages/shared/src/auth/auth-service';
 
 describe('SyncQueue', () => {
   beforeEach(() => {
     _resetSyncQueue();
     vi.restoreAllMocks();
+    // Pré-positionne un token CSRF pour éviter qu'authenticatedFetch (utilisé
+    // dans le background sync) déclenche un fetch implicite vers /api/auth/csrf
+    // avant chaque mutation — les tests mockent directement les URLs d'API.
+    _setCsrfTokenForTest('test-csrf-token');
   });
 
   describe('getSyncStatus', () => {
@@ -41,13 +46,15 @@ describe('SyncQueue', () => {
     it('should set the base URL for operations', () => {
       setSyncBaseUrl('http://localhost:3000');
       // Verify indirectly by checking that enqueueSync uses it
-      const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response('{}', { status: 200 }));
       enqueueSync('POST', '/api/test', { id: '1' });
       // processQueue runs async, wait a tick
       return vi.waitFor(() => {
         expect(fetchMock).toHaveBeenCalledWith(
           'http://localhost:3000/api/test',
-          expect.objectContaining({ method: 'POST' }),
+          expect.objectContaining({ method: 'POST' })
         );
       });
     });
@@ -56,49 +63,47 @@ describe('SyncQueue', () => {
   describe('enqueueSync', () => {
     it('should process a POST operation successfully', async () => {
       setSyncBaseUrl('http://test');
-      const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-        new Response('{}', { status: 200 }),
-      );
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response('{}', { status: 200 }));
 
       enqueueSync('POST', '/api/sources', { id: 'a', name: 'src' });
 
+      // authenticatedFetch adds extra async hops vs raw fetch ; wait on the
+      // final state plutôt que sur le call count pour éviter le race.
       await vi.waitFor(() => {
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(getSyncStatus().status).toBe('idle');
       });
 
+      expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(fetchMock).toHaveBeenCalledWith(
         'http://test/api/sources',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ id: 'a', name: 'src' }),
           credentials: 'include',
-        }),
+        })
       );
-
-      // After success, status should be idle
-      expect(getSyncStatus().status).toBe('idle');
     });
 
     it('should handle 404 as success (resource already gone)', async () => {
       setSyncBaseUrl('http://test');
-      const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-        new Response('', { status: 404 }),
-      );
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response('', { status: 404 }));
 
       enqueueSync('DELETE', '/api/sources/123');
 
       await vi.waitFor(() => {
-        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(getSyncStatus().status).toBe('idle');
       });
 
-      expect(getSyncStatus().status).toBe('idle');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it('should handle 409 as success (resource already exists)', async () => {
       setSyncBaseUrl('http://test');
-      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-        new Response('', { status: 409 }),
-      );
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 409 }));
 
       enqueueSync('POST', '/api/sources', { id: '1' });
 
@@ -109,9 +114,7 @@ describe('SyncQueue', () => {
 
     it('should clear queue on 401 (unauthorized)', async () => {
       setSyncBaseUrl('http://test');
-      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-        new Response('', { status: 401 }),
-      );
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 401 }));
 
       enqueueSync('POST', '/api/sources', { id: '1' });
       enqueueSync('POST', '/api/sources', { id: '2' });
@@ -123,17 +126,18 @@ describe('SyncQueue', () => {
 
     it('should retry on server error and give up after MAX_RETRIES', async () => {
       setSyncBaseUrl('http://test');
-      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-        new Response('', { status: 500 }),
-      );
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 500 }));
 
       enqueueSync('POST', '/api/sources', { id: '1' });
 
       // Wait for retries to complete (3 attempts with backoff)
       // Retries have exponential backoff but we're in test env
-      await vi.waitFor(() => {
-        expect(getSyncStatus().errorCount).toBeGreaterThan(0);
-      }, { timeout: 20000 });
+      await vi.waitFor(
+        () => {
+          expect(getSyncStatus().errorCount).toBeGreaterThan(0);
+        },
+        { timeout: 20000 }
+      );
 
       expect(getSyncStatus().status).toBe('error');
     }, 25000);
@@ -142,16 +146,16 @@ describe('SyncQueue', () => {
   describe('deleteItem', () => {
     it('should enqueue a DELETE operation', async () => {
       setSyncBaseUrl('http://test');
-      const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-        new Response('{}', { status: 200 }),
-      );
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response('{}', { status: 200 }));
 
       deleteItem('/api/sources', 'abc-123');
 
       await vi.waitFor(() => {
         expect(fetchMock).toHaveBeenCalledWith(
           'http://test/api/sources/abc-123',
-          expect.objectContaining({ method: 'DELETE' }),
+          expect.objectContaining({ method: 'DELETE' })
         );
       });
     });
@@ -174,9 +178,10 @@ describe('SyncQueue', () => {
       setSyncBaseUrl('http://test');
 
       // First call: GET remote items (return one existing item)
-      const fetchMock = vi.spyOn(globalThis, 'fetch')
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce(
-          new Response(JSON.stringify([{ id: 'existing-1' }]), { status: 200 }),
+          new Response(JSON.stringify([{ id: 'existing-1' }]), { status: 200 })
         )
         // Then: PUT for existing, POST for new
         .mockResolvedValue(new Response('{}', { status: 200 }));
@@ -196,7 +201,7 @@ describe('SyncQueue', () => {
       expect(fetchMock.mock.calls[0][0]).toBe('http://test/api/sources');
 
       // The enqueued operations should use PUT for existing and POST for new
-      const methods = fetchMock.mock.calls.slice(1).map(c => (c[1] as RequestInit).method);
+      const methods = fetchMock.mock.calls.slice(1).map((c) => (c[1] as RequestInit).method);
       expect(methods).toContain('PUT');
       expect(methods).toContain('POST');
     });
@@ -207,7 +212,7 @@ describe('SyncQueue', () => {
       // Remote has items A and B, local only has A
       vi.spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce(
-          new Response(JSON.stringify([{ id: 'A' }, { id: 'B' }]), { status: 200 }),
+          new Response(JSON.stringify([{ id: 'A' }, { id: 'B' }]), { status: 200 })
         )
         .mockResolvedValue(new Response('{}', { status: 200 }));
 
@@ -219,16 +224,14 @@ describe('SyncQueue', () => {
 
       // No DELETE call should have been made
       const allCalls = vi.mocked(globalThis.fetch).mock.calls;
-      const deleteCall = allCalls.find(c => (c[1] as RequestInit)?.method === 'DELETE');
+      const deleteCall = allCalls.find((c) => (c[1] as RequestInit)?.method === 'DELETE');
       expect(deleteCall).toBeUndefined();
     });
 
     it('should skip silently on 401', async () => {
       setSyncBaseUrl('http://test');
 
-      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
-        new Response('', { status: 401 }),
-      );
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response('', { status: 401 }));
 
       await syncItems('/api/sources', [{ id: '1', name: 'test' }]);
 
@@ -249,7 +252,8 @@ describe('SyncQueue', () => {
     it('should skip items without id', async () => {
       setSyncBaseUrl('http://test');
 
-      const fetchMock = vi.spyOn(globalThis, 'fetch')
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce(new Response('[]', { status: 200 }))
         .mockResolvedValue(new Response('{}', { status: 200 }));
 
@@ -270,12 +274,12 @@ describe('SyncQueue', () => {
   describe('status notifications', () => {
     it('should notify listeners on status changes', async () => {
       setSyncBaseUrl('http://test');
-      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-        new Response('{}', { status: 200 }),
-      );
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
 
       const statuses: string[] = [];
-      onSyncStatusChange((status) => { statuses.push(status); });
+      onSyncStatusChange((status) => {
+        statuses.push(status);
+      });
 
       enqueueSync('POST', '/api/test', { id: '1' });
 
@@ -286,7 +290,9 @@ describe('SyncQueue', () => {
     });
 
     it('should not throw if listener throws', () => {
-      const badCb = vi.fn(() => { throw new Error('oops'); });
+      const badCb = vi.fn(() => {
+        throw new Error('oops');
+      });
       expect(() => onSyncStatusChange(badCb)).not.toThrow();
     });
   });
@@ -319,13 +325,14 @@ describe('SyncQueue', () => {
 
     it('should restore persisted queue on setSyncBaseUrl', async () => {
       // Pre-persist a queue entry
-      localStorage.setItem('dsfr-data-sync-queue', JSON.stringify([
-        { method: 'DELETE', url: 'http://test/api/sources/old-id', retries: 2 },
-      ]));
-
-      const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-        new Response('{}', { status: 200 }),
+      localStorage.setItem(
+        'dsfr-data-sync-queue',
+        JSON.stringify([{ method: 'DELETE', url: 'http://test/api/sources/old-id', retries: 2 }])
       );
+
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response('{}', { status: 200 }));
 
       // Setting the base URL triggers restore + processing
       setSyncBaseUrl('http://test');
@@ -333,15 +340,16 @@ describe('SyncQueue', () => {
       await vi.waitFor(() => {
         expect(fetchMock).toHaveBeenCalledWith(
           'http://test/api/sources/old-id',
-          expect.objectContaining({ method: 'DELETE' }),
+          expect.objectContaining({ method: 'DELETE' })
         );
       });
     });
 
     it('should reset retries on restored operations', () => {
-      localStorage.setItem('dsfr-data-sync-queue', JSON.stringify([
-        { method: 'POST', url: 'http://test/api/x', body: '{}', retries: 5 },
-      ]));
+      localStorage.setItem(
+        'dsfr-data-sync-queue',
+        JSON.stringify([{ method: 'POST', url: 'http://test/api/x', body: '{}', retries: 5 }])
+      );
 
       vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
       setSyncBaseUrl('http://test');


### PR DESCRIPTION
## Summary

Ajoute une protection **CSRF** (Cross-Site Request Forgery) sur toutes les routes muantes de l'API Express. Closes #92 et devrait auto-résoudre [CodeQL alert #21](https://github.com/bmatge/dsfr-data/security/code-scanning/21) (`js/missing-token-validation`) qui flaggait les 24 routes cookie-authenticated au prochain scan.

Pattern : **double-submit cookie** via [`csrf-csrf@4.0.3`](https://www.npmjs.com/package/csrf-csrf) (HMAC, maintenu activement ; `csurf` est archivé depuis 2022).

## Surface protégée

| Méthode | Protection |
|---|---|
| `GET` / `HEAD` / `OPTIONS` | ✗ Idempotent, pas de token requis |
| `POST/PUT/PATCH/DELETE` sur `/api/{sources,connections,favorites,dashboards,groups,shares,cache,migrate,monitoring,admin}` | ✓ Header `X-CSRF-Token` obligatoire |
| `POST /api/auth/{login,register,forgot-password,reset-password,verify-email,resend-verification}` | ✗ Skip list — s'exécutent avant qu'un token existe. Anti-CSRF via `SameSite=Strict` du cookie d'auth + rate limiter |
| `/api/health` | ✗ Skip — pas de cookie |

## Changements

### Server

- **Nouveau middleware** [`server/src/middleware/csrf.ts`](server/src/middleware/csrf.ts). Session identifier lié à `req.user?.userId ?? req.ip` — le token ne reste valide que pour la session où il a été émis.
- Monté dans `index.ts` après `cookieParser` + `authMiddleware`.
- **Nouveau endpoint** `GET /api/auth/csrf` qui émet un token en body + cookie non-httpOnly `gw-csrf`.
- Error handler dédié : 403 `{ error: 'Invalid CSRF token', code: 'CSRF_INVALID' }`.
- Secret : `CSRF_SECRET` (nouveau) ou fallback `ENCRYPTION_KEY` — portées disjointes (HMAC SHA-256 vs AES-256-GCM), aucune collision.

### Frontend

- `packages/shared/src/auth/auth-service.ts` :
  - Cache CSRF token en **mémoire** (pas localStorage — éphémère, moins de surface XSS).
  - `apiFetch()` auto-inject `X-CSRF-Token` sur les mutations.
  - Refetch + retry une fois sur `403 CSRF_INVALID` (token expiré ou rotaté).
  - Invalidation du cache sur login / register / logout (session change → nouveau token requis).
  - Nouveau export `authenticatedFetch()` pour les consommateurs hors auth-service.
- `packages/shared/src/storage/sync-queue.ts` : `fetch` brut → `authenticatedFetch` sur les mutations du background sync.

### Tests

- **Nouveau** [`tests/server/csrf.test.ts`](tests/server/csrf.test.ts) : 6 tests supertest qui valident :
  - `GET /api/auth/csrf` pose cookie + retourne token
  - `POST` sans token → 403 `CSRF_INVALID`
  - `POST` avec token valide → pas de 403
  - Routes d'auth-bootstrap : pas de 403 (skip list)
  - `GET` idempotents : pas de 403
  - Token bidon → 403 `CSRF_INVALID`
- `tests/server/test-helpers.ts` : `createTestApp({ csrf: true })` active la protection pour les tests qui la validifient. Par défaut `csrf: false` pour préserver les 61+ tests existants. `CSRF_ENABLED=1` est requis pour override le short-circuit `NODE_ENV=test`.

### Docs

- `SECURITY.md` : nouvelle section "Backend — défenses applicatives" documentant les 3 couches (session, CSRF, rate limiting).
- `docs/security-dev-guide.md` : section CSRF avec exemples côté front + tests.
- `.env.example` : entrée `CSRF_SECRET`.

## Test plan

- [x] `npx tsc --noEmit` OK sur `server/`, `packages/shared/`, `packages/core/`
- [ ] `npm test -- tests/server/csrf.test.ts` — à vérifier en CI (nécessite MariaDB)
- [ ] Smoke test du flow complet après merge : login → create source → save dashboard → logout, sans régression
- [ ] Vérifier à l'étape suivante que la CodeQL alert #21 est bien fermée

## Out of scope (follow-ups)

- Migration vers `Authorization: Bearer` token (plus gros refactor auth)
- Token rotation par requête (one-shot par session suffit en v1)
- `Express 4 → 5` ([#94](https://github.com/bmatge/dsfr-data/issues/94)), à faire après le merge de celui-ci car interactions middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)