### PR TITLE
feat(docker): nginx non-root (closes #66)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -9,14 +9,4 @@
 # Règle d'or : jamais de masquage silencieux. Toute entrée sans justification
 # ou sans date de revue doit être retirée ou remplie.
 
-# ──────────────────────────────────────────────────────────────────
-# DS-0002 — Dockerfiles nginx sans directive USER non-root
-# Quoi   : trivy config signale docker/Dockerfile et docker/Dockerfile.db
-#          qui héritent de nginx:alpine et tournent en root.
-# Pourquoi : l'image de base binde le port 80 (privileged < 1024) et requiert
-#          donc root, ou une migration vers nginxinc/nginx-unprivileged:alpine
-#          avec adaptation de nginx.conf + docker-compose + healthcheck.
-#          Le fix propre est non trivial et sort du scope du job SCA (#56).
-# Suivi  : #66
-# Revue  : 2026-07-14
-DS-0002
+# (vide — toutes les entrées passées ont été résolues par des fixes applicatifs.)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,8 +22,15 @@ RUN node scripts/build-app.js
 # Build MCP server (separate package, outside workspace)
 RUN cd mcp-server && npm ci && npm run build
 
-# Production stage - Nginx + MCP server
-FROM nginx:alpine
+# Production stage — nginx non-root + MCP server.
+# L'image `nginxinc/nginx-unprivileged:alpine` tourne en utilisateur `nginx`
+# (uid 101) et écoute sur 8080 par défaut — aucun privilège root requis.
+# Ferme le finding Trivy DS-0002. Cf. issue #66.
+FROM nginxinc/nginx-unprivileged:alpine
+
+# Les installs + copies doivent se faire en root ; on reviendra à `nginx`
+# en fin de stage pour le runtime.
+USER root
 
 # Add Node.js for the MCP server
 RUN apk add --no-cache nodejs
@@ -54,9 +61,16 @@ COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # IA default proxy server (serves /ia-server-config and /ia-proxy-default)
 COPY scripts/ia-default-server.js /app/scripts/ia-default-server.js
 
-EXPOSE 80
+# Donner à l'utilisateur `nginx` l'écriture sur les répertoires de cache,
+# de logs (beacon-logs volume) et le workspace /app (MCP + ia-default).
+RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /app \
+ && chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/parse-beacon-logs.sh
+
+USER nginx
+
+EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -qO- http://127.0.0.1/ || exit 1
+  CMD wget -qO- http://127.0.0.1:8080/ || exit 1
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker/Dockerfile.db
+++ b/docker/Dockerfile.db
@@ -32,8 +32,13 @@ RUN mkdir /server-prod \
 # Build MCP server (separate package, outside workspace)
 RUN cd mcp-server && npm ci && npm run build
 
-# Production stage - Nginx + Express backend + MCP server
-FROM nginx:alpine
+# Production stage — nginx non-root + Express backend + MCP server.
+# L'image nginxinc/nginx-unprivileged:alpine tourne en user `nginx` (uid 101)
+# et écoute sur 8080 par défaut — ferme le finding Trivy DS-0002 (cf. #66).
+FROM nginxinc/nginx-unprivileged:alpine
+
+# Installs + copies en root ; `USER nginx` en fin de stage pour le runtime.
+USER root
 
 # Copy Node.js binary from builder (same version that compiled native modules)
 # and add C++ runtime libraries needed by bcrypt native addon
@@ -69,9 +74,15 @@ COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # IA default proxy server (serves /ia-server-config and /ia-proxy-default)
 COPY scripts/ia-default-server.js /app/scripts/ia-default-server.js
 
-EXPOSE 80
+# Ownership au user `nginx` sur les répertoires que l'entrypoint écrira.
+RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /app \
+ && chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/parse-beacon-logs.sh
+
+USER nginx
+
+EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget -qO- http://127.0.0.1/ || exit 1
+  CMD wget -qO- http://127.0.0.1:8080/ || exit 1
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker/docker-compose.ci.yml
+++ b/docker/docker-compose.ci.yml
@@ -8,7 +8,8 @@
 #     up -d --build
 #
 # Differences vs production:
-#   - Maps nginx port 80 to host port 8080 (accessible from the runner / ZAP)
+#   - Maps nginx container port 8080 to host port 8080 (nginx runs non-root
+#     depuis #66 et écoute sur 8080 sans capability privileged)
 #   - Turns `ecosystem-network` into a locally-managed bridge (no external Traefik)
 #   - Sets `CORS_ORIGIN` so cookie-based auth flows don't reject the ZAP origin
 #
@@ -17,7 +18,7 @@
 services:
   chartsbuilder:
     ports:
-      - "8080:80"
+      - "8080:8080"
     environment:
       - CORS_ORIGIN=http://localhost:8080
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,8 +38,8 @@ services:
       - "traefik.http.routers.chartsbuilder-https.tls.options=anssi-strict@file"
       # Pas de Basic Auth - les clés API sont stockées en localStorage (privées par utilisateur)
 
-      # Service
-      - "traefik.http.services.chartsbuilder.loadbalancer.server.port=80"
+      # Service — nginx non-root écoute 8080 (cf. #66 / docker/Dockerfile)
+      - "traefik.http.services.chartsbuilder.loadbalancer.server.port=8080"
 
       # Middleware de redirection HTTPS
       - "traefik.http.middlewares.redirect-to-https.redirectscheme.scheme=https"

--- a/docker/nginx-db.conf
+++ b/docker/nginx-db.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name localhost;
     server_tokens off;
     include /etc/nginx/conf.d/security-headers.conf;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name localhost;
     server_tokens off;
     include /etc/nginx/conf.d/security-headers.conf;


### PR DESCRIPTION
## Summary

Migre les 2 images de prod vers **`nginxinc/nginx-unprivileged:alpine`** qui tourne en user `nginx` (uid 101) et écoute sur 8080 sans privileged capability.

Closes #66. Ferme le finding Trivy **DS-0002** sur `Dockerfile` et `Dockerfile.db`.

## Changements

| Fichier | Diff |
|---|---|
| `docker/Dockerfile` + `Dockerfile.db` | `FROM nginxinc/nginx-unprivileged:alpine`, `USER root` pour les installs/COPYs, `chown -R nginx:nginx /var/cache/nginx /var/log/nginx /app` puis `USER nginx`, `EXPOSE 8080`, HEALTHCHECK sur `:8080` |
| `docker/nginx.conf` + `nginx-db.conf` | `listen 8080;` (au lieu de `listen 80;`) |
| `docker/docker-compose.yml` | label Traefik `loadbalancer.server.port=8080` |
| `docker/docker-compose.ci.yml` | mapping `"8080:8080"` (host:container, les deux côtés 8080) |
| `.trivyignore` | retrait de l'exception DS-0002 |

## Validation

- [x] `nginx -t` passe sur les 2 configs avec `nginxinc/nginx-unprivileged:alpine`
- [x] `docker compose config` rend bien `ports: 8080:8080` + label Traefik `8080`
- [x] `trivy config --severity HIGH,CRITICAL docker/` → **0 misconfigs** (DS-0002 éliminé)
- [ ] CI : build des 2 images via `docker-scan.yml` (matrix Trivy image)
- [ ] Smoke test post-merge : déploiement staging, vérifier que Traefik route correctement et que les beacons + healthcheck fonctionnent

## Impact runtime Traefik (prod)

Rien à adapter côté Traefik : il accède au container via le load balancer Docker, **pas** par port mapping. Il lit le label `traefik.http.services.chartsbuilder.loadbalancer.server.port=8080` et route dessus. Aucun changement `APP_DOMAIN` ou DNS.

## Backlog post-baseline restant

- #45 no-explicit-any (incrémental)
- #103 elkjs major, #105 vite 2-majors (Dependabot en hold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)