### PR TITLE
chore(lint): type 16 no-explicit-any (#45 phase 2+3)

### DIFF
--- a/apps/builder/src/main.ts
+++ b/apps/builder/src/main.ts
@@ -33,10 +33,10 @@ import { startTourIfFirstVisit, injectTourStyles, resetTour, startTour } from '@
 import { BUILDER_TOUR } from './ui/tour.js';
 
 // Expose functions called from inline onclick in HTML
-(window as any).toggleSection = toggleSection;
+(window as Window & { toggleSection?: typeof toggleSection }).toggleSection = toggleSection;
 
 // Expose state for E2E tests
-(window as any).__BUILDER_STATE__ = state;
+(window as Window & { __BUILDER_STATE__?: typeof state }).__BUILDER_STATE__ = state;
 
 document.addEventListener('DOMContentLoaded', async () => {
   await initAuth();

--- a/apps/builder/src/sources.ts
+++ b/apps/builder/src/sources.ts
@@ -18,7 +18,7 @@ import {
   SAMPLE_DATASETS,
   isUnsafeKey,
 } from '@dsfr-data/shared';
-import { state, type Source, type Field } from './state.js';
+import { state, type ChartType, type Source, type Field } from './state.js';
 import { selectChartType } from './ui/chart-type-selector.js';
 import { populateFieldSelects } from './sources-fields.js';
 import { generateCodeForLocalData } from './ui/code-generator.js';
@@ -295,7 +295,7 @@ export function loadSampleDataset(sampleId: string): void {
   }
 
   // Pre-select suggested chart type and fields
-  selectChartType(dataset.suggestedChartType as any);
+  selectChartType(dataset.suggestedChartType as ChartType);
 
   setTimeout(() => {
     const labelSelect = document.getElementById('label-field') as HTMLSelectElement | null;

--- a/apps/builder/src/ui/code-generator.ts
+++ b/apps/builder/src/ui/code-generator.ts
@@ -19,7 +19,7 @@ import {
   extractResourceIds,
   getProvider,
 } from '@dsfr-data/shared';
-import { state, PROXY_BASE_URL, LIB_URL } from '../state.js';
+import { state, type DataRecord, PROXY_BASE_URL, LIB_URL } from '../state.js';
 import { renderPreview } from './preview.js';
 import { updateAccessibleTable } from './accessible-table.js';
 
@@ -604,7 +604,7 @@ export function generateChartFromLocalData(): void {
         state.queryFilter
       );
     }
-    state.data = filteredLocal as any[];
+    state.data = filteredLocal as DataRecord[];
 
     const rawDataEl = document.getElementById('raw-data');
     if (rawDataEl) rawDataEl.textContent = JSON.stringify(state.data, null, 2);
@@ -880,7 +880,7 @@ datalist.onSourceData(data);
     let count = 0;
 
     state.data.forEach((d) => {
-      const rawCode = (d[state.codeField] ?? (d as any).code ?? '') as string | number;
+      const rawCode = (d[state.codeField] ?? d.code ?? '') as string | number;
       let code = String(rawCode).trim();
       if (/^\d+$/.test(code) && code.length < 3) {
         code = code.padStart(2, '0');
@@ -1367,7 +1367,7 @@ ${middlewareHtml}
   );
 
   // For maps, group by codeField (not labelField)
-  const isMap = state.chartType === 'map' || state.chartType === ('mapReg' as any);
+  const isMap = state.chartType === 'map';
   const groupByPath =
     isMap && state.codeField
       ? isFlattened
@@ -1676,7 +1676,7 @@ ${middlewareHtml}
   }
 
   // For maps, group by codeField (not labelField)
-  const isMap = state.chartType === 'map' || state.chartType === ('mapReg' as any);
+  const isMap = state.chartType === 'map';
   const groupByPath = isMap && state.codeField ? state.codeField : labelFieldPath;
 
   let queryElement: string;

--- a/apps/builder/src/ui/ui-helpers.ts
+++ b/apps/builder/src/ui/ui-helpers.ts
@@ -128,8 +128,10 @@ export function saveFavorite(): void {
  * Switch the active tab in the preview panel.
  */
 export function switchTab(tabId: string): void {
-  const previewPanel = document.querySelector('app-preview-panel') as any;
-  if (previewPanel && previewPanel.setActiveTab) {
+  const previewPanel = document.querySelector('app-preview-panel') as
+    | (Element & { setActiveTab?: (id: string) => void })
+    | null;
+  if (previewPanel?.setActiveTab) {
     previewPanel.setActiveTab(tabId);
   }
 }

--- a/apps/pipeline-helper/src/code-generator.ts
+++ b/apps/pipeline-helper/src/code-generator.ts
@@ -34,8 +34,12 @@ export function generateCode(
     const targetGraphNode = graphNodes.get(conn.target);
     if (!sourceGraphNode || !targetGraphNode) continue;
 
-    const sourceKey = (conn as any).sourceOutput as string;
-    const targetKey = (conn as any).targetInput as string;
+    // Les champs `sourceOutput` / `targetInput` sont ajoutés par le runtime
+    // éditeur (drawflow) sur la connexion, pas présents dans le type exposé.
+    const { sourceOutput: sourceKey, targetInput: targetKey } = conn as typeof conn & {
+      sourceOutput: string;
+      targetInput: string;
+    };
 
     if (sourceKey === 'data' && targetKey === 'data') {
       // Data connection: target reads from source

--- a/packages/core/src/utils/beacon.ts
+++ b/packages/core/src/utils/beacon.ts
@@ -29,7 +29,11 @@ function sanitizeUrl(href: string): string {
  */
 export function sendWidgetBeacon(component: string, subtype?: string): void {
   // Opt-in: beacons are disabled unless explicitly enabled
-  if (typeof window === 'undefined' || !(window as any).DSFR_DATA_BEACON) return;
+  if (
+    typeof window === 'undefined' ||
+    !(window as Window & { DSFR_DATA_BEACON?: boolean }).DSFR_DATA_BEACON
+  )
+    return;
 
   const key = `${component}:${subtype || ''}`;
   if (sent.has(key)) return;
@@ -56,7 +60,9 @@ export function sendWidgetBeacon(component: string, subtype?: string): void {
 
   // In DB mode, send as JSON POST to the API (more reliable, stored in MariaDB)
   // Fallback to pixel tracking if the POST fails
-  const useApi = typeof window !== 'undefined' && (window as any).__gwDbMode === true;
+  const useApi =
+    typeof window !== 'undefined' &&
+    (window as Window & { __gwDbMode?: boolean }).__gwDbMode === true;
 
   if (useApi) {
     try {

--- a/packages/core/src/utils/data-bridge.ts
+++ b/packages/core/src/utils/data-bridge.ts
@@ -44,7 +44,12 @@ export const DATA_EVENTS = {
 } as const;
 
 // Cache global des données par sourceId — stocké sur window pour partage entre bundles UMD
-const _win = typeof window !== 'undefined' ? (window as any) : ({} as any);
+type WindowWithCache = Window & {
+  __dsfrDataCache?: Map<string, unknown>;
+  __dsfrDataMeta?: Map<string, PaginationMeta>;
+};
+const _win: WindowWithCache | Record<string, never> =
+  typeof window !== 'undefined' ? (window as WindowWithCache) : {};
 if (!_win.__dsfrDataCache) _win.__dsfrDataCache = new Map<string, unknown>();
 if (!_win.__dsfrDataMeta) _win.__dsfrDataMeta = new Map<string, PaginationMeta>();
 const dataCache: Map<string, unknown> = _win.__dsfrDataCache;

--- a/packages/core/src/utils/source-subscriber.ts
+++ b/packages/core/src/utils/source-subscriber.ts
@@ -7,7 +7,10 @@
 import type { LitElement } from 'lit';
 import { subscribeToSource, getDataCache } from './data-bridge.js';
 
-type Constructor<T = {}> = new (...args: any[]) => T;
+// Pattern Lit mixin canonique : le constructor doit être callable avec
+// n'importe quels args pour permettre le chaînage `class extends mixin(Parent)`.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- any[] est le pattern canonique des mixins Lit
+type Constructor<T = object> = new (...args: any[]) => T;
 
 export interface SourceSubscriberInterface {
   source: string;

--- a/packages/shared/src/auth/auth-service.ts
+++ b/packages/shared/src/auth/auth-service.ts
@@ -152,7 +152,7 @@ export async function isDbMode(): Promise<boolean> {
 
   // Set a global flag so fire-and-forget code (beacon) can detect DB mode synchronously
   if (_dbMode && typeof window !== 'undefined') {
-    (window as any).__gwDbMode = true;
+    (window as Window & { __gwDbMode?: boolean }).__gwDbMode = true;
   }
 
   return _dbMode;


### PR DESCRIPTION
## Summary

Phases 2+3 de #45 — attaque 16 warnings `@typescript-eslint/no-explicit-any` dans les code generators + les packages `shared` & `core/utils` les plus simples.

Compteur repo : **97 → 81 warnings** (−16).

## Patterns appliqués

| Avant | Après |
|---|---|
| `(window as any).__gwDbMode` | `(window as Window & { __gwDbMode?: boolean })` (auth-service, beacon) |
| `(window as any).DSFR_DATA_BEACON` | `(window as Window & { DSFR_DATA_BEACON?: boolean })` |
| `(window as any).__dsfrDataCache` | `(window as WindowWithCache)` avec alias typé (data-bridge) |
| `(window as any).toggleSection` | `(window as Window & { toggleSection?: typeof toggleSection })` |
| `(conn as any).sourceOutput` | destructuration via type intersection (`conn as typeof conn & { sourceOutput: string, targetInput: string }`) |
| `filteredLocal as any[]` | `as DataRecord[]` (avec import) |
| `(d as any).code` | `d.code` (DataRecord a une signature d'index ouverte `[key: string]: unknown`) |
| `selectChartType(... as any)` | `as ChartType` |
| `querySelector(...) as any` | `as (Element & { setActiveTab?: (id: string) => void }) \| null` |
| `state.chartType === ('mapReg' as any)` | **supprimé** — `mapReg` n'est pas dans `ChartType`, condition toujours false, dead code |
| `type Constructor<T> = new (...args: any[]) => T` | retenu avec `eslint-disable-next-line` + justification inline (pattern Lit mixin canonique) |

## Fichiers touchés

- `packages/shared/src/auth/auth-service.ts` (1)
- `packages/core/src/utils/{beacon,data-bridge,source-subscriber}.ts` (5)
- `apps/builder/src/{main,sources,ui/code-generator,ui/ui-helpers}.ts` (8)
- `apps/pipeline-helper/src/code-generator.ts` (2)

## Validation

- [x] `npm run typecheck` : ✅
- [x] Build shared + core + builder + pipeline-helper : ✅
- [x] 870 tests (builder + pipeline-helper + shared) : ✅
- [x] `npm run lint` : **81 warnings no-explicit-any** (vs 97 avant)

## Reste dans le plan #45

| Phase | Cible | ~Warnings |
|---|---|---:|
| 4 | `packages/core/src/components/` (Leaflet, Chart.js, Grist) | ~40 |
| 5 | `apps/pipeline-helper/src/` (editor visuel) | ~23 |
| Divers | `apps/builder-carto/`, restes builder / builder-ia | ~18 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)