### PR TITLE
chore(lint): type 7 no-explicit-any in chart-renderers (#45 phase 4a)

### DIFF
--- a/apps/builder-ia/src/ui/chart-renderer.ts
+++ b/apps/builder-ia/src/ui/chart-renderer.ts
@@ -8,8 +8,12 @@ import type { ChartConfig, AggregatedResult } from '../state.js';
 import { addMessage } from '../chat/chat.js';
 import { generateCode } from './code-generator.js';
 
-/** Chart.js loaded via CDN - access from window */
-const Chart = (window as unknown as Record<string, unknown>).Chart as unknown;
+/**
+ * Chart.js loaded via CDN — pas de package npm, on expose la surface
+ * minimale utilisée (constructor qui retourne une instance).
+ */
+type ChartJsCtor = new (canvas: HTMLCanvasElement, config: Record<string, unknown>) => unknown;
+const Chart = (window as Window & { Chart?: ChartJsCtor }).Chart;
 
 /**
  * Resolve a palette name to an array of colors, cycling if needed.
@@ -407,7 +411,7 @@ function renderChart(config: ChartConfig, data: AggregatedResult[]): void {
       y: d.value,
     }));
 
-    state.chart = new (Chart as any)(canvas, {
+    state.chart = new (Chart as ChartJsCtor)(canvas, {
       type: 'scatter',
       data: {
         datasets: [
@@ -465,7 +469,7 @@ function renderChart(config: ChartConfig, data: AggregatedResult[]): void {
     });
   }
 
-  state.chart = new (Chart as any)(canvas, {
+  state.chart = new (Chart as ChartJsCtor)(canvas, {
     type: chartType,
     data: {
       labels: labels,

--- a/apps/builder/src/ui/chart-renderer.ts
+++ b/apps/builder/src/ui/chart-renderer.ts
@@ -13,8 +13,16 @@ import {
 } from '@dsfr-data/shared';
 import { state } from '../state.js';
 
-// Chart.js loaded via CDN
-const ChartJS = (): any => (window as any).Chart;
+/**
+ * Chart.js loaded via CDN — pas de package npm, on expose la surface
+ * minimale utilisée (constructor + destroy).
+ */
+type ChartJsLike = {
+  new (canvas: HTMLCanvasElement, config: Record<string, unknown>): ChartJsInstance;
+};
+type ChartJsInstance = { destroy: () => void };
+
+const ChartJS = (): ChartJsLike | undefined => (window as Window & { Chart?: ChartJsLike }).Chart;
 
 /**
  * Render the chart preview based on current state.
@@ -29,7 +37,7 @@ export function renderChart(): void {
 
   // Destroy previous chart
   if (state.chartInstance) {
-    (state.chartInstance as any).destroy();
+    (state.chartInstance as ChartJsInstance).destroy();
     state.chartInstance = null;
   }
 
@@ -132,7 +140,7 @@ export function renderChart(): void {
 
     state.data.forEach((d) => {
       // Department code can be in codeField or direct key
-      const rawCode = (d[state.codeField] ?? (d as any).code ?? '') as string | number;
+      const rawCode = (d[state.codeField] ?? d.code ?? '') as string | number;
       // Normalize the code: convert to string and pad if necessary
       let code = String(rawCode).trim();
       // Handle numeric codes (1 -> "01", 34 -> "34")
@@ -263,7 +271,9 @@ export function renderChart(): void {
       y: (d.value as number) || 0,
     }));
 
-    state.chartInstance = new (ChartJS())(canvas, {
+    const ChartCtor = ChartJS();
+    if (!ChartCtor) return;
+    state.chartInstance = new ChartCtor(canvas, {
       type: 'scatter',
       data: {
         datasets: [
@@ -296,7 +306,7 @@ export function renderChart(): void {
     : primaryColor;
 
   // Build datasets array
-  const datasets: any[] = [
+  const datasets: Record<string, unknown>[] = [
     {
       label: state.valueField,
       data: values,
@@ -327,7 +337,9 @@ export function renderChart(): void {
     });
   });
 
-  state.chartInstance = new (ChartJS())(canvas, {
+  const ChartCtor = ChartJS();
+  if (!ChartCtor) return;
+  state.chartInstance = new ChartCtor(canvas, {
     type: chartType,
     data: {
       labels: labels,


### PR DESCRIPTION
## Summary

Phase 4a de #45 — typage des 7 warnings `no-explicit-any` dans les chart-renderers des apps builder (5) et builder-ia (2).

Compteur repo : **68 → 61 warnings** (−7).

## Approche Chart.js

Chart.js est chargé via CDN (pas de package npm → pas de types fournis). On déclare la surface minimale utilisée, en local, dans chaque fichier :

```ts
type ChartJsLike = new (canvas: HTMLCanvasElement, config: Record<string, unknown>) => ChartJsInstance;
type ChartJsInstance = { destroy: () => void };

const ChartJS = (): ChartJsLike | undefined =>
  (window as Window & { Chart?: ChartJsLike }).Chart;
```

## Changements apps/builder

- `ChartJS = (): any => (window as any).Chart` → type `ChartJsLike | undefined` + fenêtre typée
- `(state.chartInstance as any).destroy()` → `as ChartJsInstance`
- `(d as any).code` → `d.code` (DataRecord a une signature d'index ouverte)
- `const datasets: any[]` → `Record<string, unknown>[]`
- Ajout de guards `const ChartCtor = ChartJS(); if (!ChartCtor) return;` autour des `new (ChartJS())(…)` (le type retour nullable force une narrowing).

## Changements apps/builder-ia

- Même pattern : `new (Chart as any)(…)` → `new (Chart as ChartJsCtor)(…)` (2 occurrences)

## Validation

- [x] `npm run typecheck` : ✅
- [x] `npm run build --workspace=@dsfr-data/app-builder` : ✅
- [x] `npm run build --workspace=@dsfr-data/app-builder-ia` : ✅
- [x] `npm run lint` : **61 warnings no-explicit-any** (vs 68 avant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)