### PR TITLE
chore(lint): type 11 no-explicit-any in core components (#45 phase 4b.1)

### DIFF
--- a/packages/core/src/components/dsfr-data-map-popup.ts
+++ b/packages/core/src/components/dsfr-data-map-popup.ts
@@ -173,7 +173,7 @@ export class DsfrDataMapPopup extends LitElement {
     closeBtn?.addEventListener('click', () => this.close());
 
     // Announce to screen reader via map's live region
-    const mapEl = mapParent as any;
+    const mapEl = mapParent as Element & { announceToScreenReader?: (msg: string) => void };
     if (title) {
       mapEl.announceToScreenReader?.(`Detail : ${title}`);
     }
@@ -242,7 +242,9 @@ export class DsfrDataMapPopup extends LitElement {
     document.addEventListener('keydown', escHandler);
 
     // Announce
-    const mapParent = this.closest('dsfr-data-map') as any;
+    const mapParent = this.closest('dsfr-data-map') as
+      | (Element & { announceToScreenReader?: (msg: string) => void })
+      | null;
     mapParent?.announceToScreenReader?.(`Modale ouverte : ${title}`);
   }
 

--- a/packages/core/src/components/dsfr-data-map.ts
+++ b/packages/core/src/components/dsfr-data-map.ts
@@ -49,9 +49,15 @@ async function loadLeaflet(): Promise<typeof import('leaflet')> {
   if (L) return L;
   L = await import('leaflet');
   // Expose L globally — required by Leaflet plugins (markercluster, heat)
-  (window as any).L = L;
+  (window as Window & { L?: typeof import('leaflet') }).L = L;
   return L;
 }
+
+/** Surface minimale appelée sur les dsfr-data-map-layer / timeline enfants. */
+type MapChildElement = Element & {
+  _onMapReady?: () => void;
+  _onViewportChange?: () => void;
+};
 
 @customElement('dsfr-data-map')
 export class DsfrDataMap extends LitElement {
@@ -362,7 +368,7 @@ export class DsfrDataMap extends LitElement {
         for (const node of m.addedNodes) {
           const tag = (node as HTMLElement).tagName?.toLowerCase();
           if (tag === 'dsfr-data-map-layer' || tag === 'dsfr-data-map-timeline') {
-            (node as any)._onMapReady?.();
+            (node as MapChildElement)._onMapReady?.();
           }
         }
       }
@@ -395,18 +401,18 @@ export class DsfrDataMap extends LitElement {
   private _notifyLayers() {
     const layers = this.querySelectorAll('dsfr-data-map-layer');
     for (const layer of layers) {
-      (layer as any)._onViewportChange?.();
+      (layer as MapChildElement)._onViewportChange?.();
     }
   }
 
   private _notifyExistingLayers() {
     const layers = this.querySelectorAll('dsfr-data-map-layer');
     for (const layer of layers) {
-      (layer as any)._onMapReady?.();
+      (layer as MapChildElement)._onMapReady?.();
     }
     const timelines = this.querySelectorAll('dsfr-data-map-timeline');
     for (const tl of timelines) {
-      (tl as any)._onMapReady?.();
+      (tl as MapChildElement)._onMapReady?.();
     }
   }
 

--- a/packages/core/src/components/dsfr-data-world-map.ts
+++ b/packages/core/src/components/dsfr-data-world-map.ts
@@ -269,7 +269,9 @@ export class DsfrDataWorldMap extends SourceSubscriberMixin(LitElement) {
     if (!this._topology) return [];
     const countries = this._topology.objects['countries'] as GeometryCollection;
     const fc = feature(this._topology, countries);
-    return (fc as any).features as CountryFeature[];
+    // `feature` peut renvoyer une Feature simple ou une FeatureCollection ; ici
+    // countries est une GeometryCollection donc on a une FeatureCollection.
+    return (fc as unknown as { features: CountryFeature[] }).features;
   }
 
   private _getBorders(): GeoPermissibleObjects | null {

--- a/packages/core/src/components/layout/app-header.ts
+++ b/packages/core/src/components/layout/app-header.ts
@@ -124,8 +124,10 @@ export class AppHeader extends LitElement {
           window.history.replaceState({}, '', url.toString());
           // Wait for next render then open modal
           await this.updateComplete;
-          const modal = this.querySelector('auth-modal') as any;
-          modal?.open('reset', resetToken);
+          const modal = this.querySelector('auth-modal') as
+            | (Element & { open?: (mode: string, token?: string) => void })
+            | null;
+          modal?.open?.('reset', resetToken);
         }
       }
     } catch {
@@ -134,14 +136,18 @@ export class AppHeader extends LitElement {
   }
 
   private _openAuthModal(): void {
-    const modal = this.querySelector('auth-modal') as any;
-    modal?.open('login');
+    const modal = this.querySelector('auth-modal') as
+      | (Element & { open?: (mode: string) => void })
+      | null;
+    modal?.open?.('login');
   }
 
   private _openPasswordChangeModal(): void {
     this._userMenuOpen = false;
-    const modal = this.querySelector('password-change-modal') as any;
-    modal?.open();
+    const modal = this.querySelector('password-change-modal') as
+      | (Element & { open?: () => void })
+      | null;
+    modal?.open?.();
   }
 
   private async _handleLogout(): Promise<void> {


### PR DESCRIPTION
## Summary

Phase 4b.1 de #45 — typage des 11 warnings dans les composants core (hors `dsfr-data-map-layer` qui garde 26 warnings liés à Leaflet et aura sa propre PR dédiée).

Compteur repo : **61 → 50 warnings** (−11).

## Fichiers touchés

| Fichier | # | Approche |
|---|:---:|---|
| `packages/core/src/components/dsfr-data-map.ts` | 5 | `(window as any).L` → `(window as Window & { L?: typeof import('leaflet') })` ; introduction d'un alias `MapChildElement = Element & { _onMapReady?, _onViewportChange? }` pour narrower les casts enfants (×4) |
| `packages/core/src/components/dsfr-data-map-popup.ts` | 2 | `mapParent as any` → `Element & { announceToScreenReader?: (msg: string) => void }` (×2) |
| `packages/core/src/components/dsfr-data-world-map.ts` | 1 | `(fc as any).features` → `(fc as unknown as { features: CountryFeature[] })` (double cast car `feature()` retourne une union Feature\|FeatureCollection que TS refuse de narrower directement) |
| `packages/core/src/components/layout/app-header.ts` | 3 | `querySelector(...) as any` + `modal?.open(...)` → narrowing sur `(Element & { open?: (...) => void }) \| null` + `modal?.open?.()` optional chaining (×3, auth-modal / password-change-modal) |

## Validation

- [x] `npm run typecheck` : ✅
- [x] `npm run build` (bundles core) : ✅
- [x] 356 tests components (map + popup + world-map) : ✅
- [x] `npm run lint` : **50 warnings no-explicit-any** (vs 61 avant)

## Reste dans #45

- **Phase 4b.2** : `dsfr-data-map-layer.ts` (26 warnings, types Leaflet riches : `L.GeoJSON`, `L.Marker`, events)
- **Phase 5** : `apps/pipeline-helper/` (24 warnings, drawflow + éditeur visuel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)