### PR TITLE
chore(lint): eliminate last 24 no-explicit-any — CLOSE #45

### DIFF
--- a/apps/pipeline-helper/src/editor.ts
+++ b/apps/pipeline-helper/src/editor.ts
@@ -17,8 +17,11 @@ import './ui/status-control-element.js';
 import './ui/saved-source-control.js';
 import './ui/aggregate-control-element.js';
 
-// Use 'any' for Rete schemes — Rete v2's generics are very strict
-// about Node subclass inference and fight with custom node types.
+// Use 'any' for Rete schemes — Rete v2's generics are très strictes sur
+// l'inférence des Node subclass et entrent en conflit avec nos custom nodes.
+// Les lignes suivantes utilisent des casts ou des paramètres typés `any`
+// pour la même raison : les types Rete (ControlContext, Pipe, Connection,
+// Node…) ne sont pas correctement narrowables avec nos classes custom.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type S = any;
 
@@ -40,6 +43,9 @@ export class PipelineEditor {
     render.addPreset(
       LitPresets.classic.setup({
         customize: {
+          // Rete ControlContext est génériquement typé ; `any` reste requis
+          // tant que type S = any.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           control(context: any) {
             if (context.payload instanceof SavedSourceSelector) {
               const ctrl = context.payload as SavedSourceSelector;
@@ -59,12 +65,16 @@ export class PipelineEditor {
               return () =>
                 html`<attribute-control-element .ctrl=${ctrl}></attribute-control-element>`;
             }
-            return null as any;
+            return () => null;
           },
         },
+        // LitPresets.classic.setup a un type de retour dépendant des generics
+        // Rete ; cf. commentaire bloc sur `type S = any` au-dessus.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       }) as any
     );
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- idem ConnectionPresets
     connection.addPreset(ConnectionPresets.classic.setup() as any);
     this.arrange.addPreset(ArrangePresets.classic.setup());
 
@@ -79,12 +89,16 @@ export class PipelineEditor {
       accumulating: AreaExtensions.accumulateOnCtrl(),
     });
 
-    // Listen for node picks (clicks)
-    this.area.addPipe((context: any) => {
-      if (context.type === 'nodepicked') {
-        const nodeId = context.data?.id;
+    // Listen for node picks (clicks). Rete area pipes reçoivent un contexte
+    // union (nodepicked, noderemoved, etc.) dont les fields sont dépendants
+    // du scheme ; on narrowe sur le seul cas qui nous intéresse.
+    type NodePickedEvent = { type: 'nodepicked'; data: { id: string } };
+    this.area.addPipe((context) => {
+      const evt = context as Partial<NodePickedEvent>;
+      if (evt.type === 'nodepicked') {
+        const nodeId = evt.data?.id;
         if (nodeId && this.onNodeSelected) {
-          const node = this.editor.getNodes().find((n: any) => n.id === nodeId) as
+          const node = this.editor.getNodes().find((n) => n.id === nodeId) as
             | PipelineNode
             | undefined;
           if (node) this.onNodeSelected(node);
@@ -119,10 +133,14 @@ export class PipelineEditor {
   async removeSelected(): Promise<void> {
     const nodes = this.editor.getNodes();
     for (const node of nodes) {
-      if ((node as any).selected) {
+      // Rete's selectableNodes extension attaches `selected: boolean` au
+      // runtime sans le typer.
+      if ((node as { selected?: boolean }).selected) {
         const connections = this.editor
           .getConnections()
-          .filter((c: any) => c.source === node.id || c.target === node.id);
+          .filter(
+            (c: { source: string; target: string }) => c.source === node.id || c.target === node.id
+          );
         for (const conn of connections) {
           await this.editor.removeConnection(conn.id);
         }

--- a/apps/pipeline-helper/src/main.ts
+++ b/apps/pipeline-helper/src/main.ts
@@ -85,7 +85,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     // Run the pipeline
     try {
       await executor.execute(editor.getNodes(), editor.getConnections());
-    } catch (err: any) {
+    } catch (err) {
       console.error('Pipeline execution error:', err);
     }
 

--- a/apps/pipeline-helper/src/nodes/base-node.ts
+++ b/apps/pipeline-helper/src/nodes/base-node.ts
@@ -51,9 +51,30 @@ export class AttributeControl extends ClassicPreset.Control {
  * Special control for selecting a saved source from the app's source catalog.
  * When a source is selected, it auto-fills the node's attribute controls.
  */
+/**
+ * Payload émis par le saved-source-control : soit une Source de l'utilisateur
+ * (STORAGE_KEYS.SOURCES), soit une Connection avec un flag `_isConnection`.
+ * Les deux types ont des champs dynamiques selon le provider (api-type, url,
+ * dataset-id…) ; on liste ici les champs concrètement lus par les consumers
+ * (pipeline-nodes.ts) et on laisse la signature ouverte pour le reste.
+ */
+export interface SavedSourcePayload {
+  id?: string;
+  _isConnection?: boolean;
+  provider?: string;
+  type?: string;
+  apiUrl?: string;
+  baseUrl?: string;
+  apiKey?: string | null;
+  documentId?: string;
+  tableId?: string;
+  resourceIds?: Record<string, string>;
+  [key: string]: unknown;
+}
+
 export class SavedSourceSelector extends ClassicPreset.Control {
   onChange?: () => void;
-  onSourceSelected?: (source: any | null) => void;
+  onSourceSelected?: (source: SavedSourcePayload | null) => void;
 
   constructor(public value: string = '') {
     super();

--- a/apps/pipeline-helper/src/nodes/pipeline-nodes.ts
+++ b/apps/pipeline-helper/src/nodes/pipeline-nodes.ts
@@ -4,6 +4,7 @@ import {
   AttributeControl,
   SavedSourceSelector,
   AggregateControl,
+  type SavedSourcePayload,
 } from './base-node.js';
 import { DataSocket, CommandSocket } from './sockets.js';
 import { NODE_CONFIGS } from './node-configs.js';
@@ -35,12 +36,12 @@ export function createSourceNode(): PipelineNode {
 
   // Add saved-source selector as the FIRST control (inserted before attributes)
   const selector = new SavedSourceSelector();
-  selector.onSourceSelected = (source: any | null) => {
+  selector.onSourceSelected = (source: SavedSourcePayload | null) => {
     if (!source) return;
 
     // Connection selected (from saved-source-control)
     if (source._isConnection) {
-      const apiType = PROVIDER_TO_API_TYPE[source.provider] || 'generic';
+      const apiType = PROVIDER_TO_API_TYPE[source.provider ?? ''] || 'generic';
       setCtrl(node, 'api-type', apiType);
 
       if (source.type === 'grist') {
@@ -75,7 +76,7 @@ export function createSourceNode(): PipelineNode {
     }
 
     // Regular saved source
-    const apiType = PROVIDER_TO_API_TYPE[source.provider] || 'generic';
+    const apiType = PROVIDER_TO_API_TYPE[source.provider ?? ''] || 'generic';
     setCtrl(node, 'api-type', apiType);
 
     if (source.apiUrl) {

--- a/apps/pipeline-helper/src/pipeline-executor.ts
+++ b/apps/pipeline-helper/src/pipeline-executor.ts
@@ -70,8 +70,12 @@ export class PipelineExecutor {
       const target = this.graphNodes.get(conn.target);
       if (!source || !target) continue;
 
-      const sourceKey = (conn as any).sourceOutput as string;
-      const targetKey = (conn as any).targetInput as string;
+      // Les champs `sourceOutput` / `targetInput` sont attachés par Rete au
+      // runtime mais pas exposés dans les types de Connection.
+      const { sourceOutput: sourceKey, targetInput: targetKey } = conn as typeof conn & {
+        sourceOutput: string;
+        targetInput: string;
+      };
 
       if (sourceKey === 'data' && targetKey === 'data') {
         target.dataSource = source;
@@ -290,10 +294,13 @@ export class PipelineExecutor {
 
     if (Array.isArray(data)) {
       rows = data as Record<string, unknown>[];
-    } else if (data && typeof data === 'object' && 'results' in (data as any)) {
-      rows = (data as any).results;
-    } else if (data && typeof data === 'object' && 'records' in (data as any)) {
-      rows = (data as any).records;
+    } else if (data && typeof data === 'object') {
+      const wrapped = data as { results?: unknown; records?: unknown };
+      if (Array.isArray(wrapped.results)) {
+        rows = wrapped.results as Record<string, unknown>[];
+      } else if (Array.isArray(wrapped.records)) {
+        rows = wrapped.records as Record<string, unknown>[];
+      }
     }
 
     if (!Array.isArray(rows) || rows.length === 0) {

--- a/apps/pipeline-helper/src/ui/custom-node.ts
+++ b/apps/pipeline-helper/src/ui/custom-node.ts
@@ -22,6 +22,10 @@ const CATEGORY_COLORS: Record<NodeCategory, string> = {
 @customElement('pipeline-node-element')
 export class PipelineNodeElement extends LitElement {
   @property({ type: Object }) data!: PipelineNode;
+  // Rete passe un callback `emit` pour émettre des events (onresize, etc.) ;
+  // son type est dépendant des generics du scheme qu'on force à `any`
+  // (cf. editor.ts, type S = any).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- cf. commentaire bloc
   @property({ type: Object }) emit!: (event: any) => void;
 
   static styles = css`
@@ -250,12 +254,16 @@ export class PipelineNodeElement extends LitElement {
                       ([key, input]) => html`
                         <div class="port" data-testid="input-${key}">
                           <span
-                            style="color:${(input as any).socket === this._commandSocket
+                            style="color:${(input as ClassicPreset.Input<ClassicPreset.Socket>)
+                              .socket === this._commandSocket
                               ? '#009081'
                               : '#000091'}"
                             >&#9679;</span
                           >
-                          <span>${(input as ClassicPreset.Input<any>).label ?? key}</span>
+                          <span
+                            >${(input as ClassicPreset.Input<ClassicPreset.Socket>).label ??
+                            key}</span
+                          >
                         </div>
                       `
                     )}
@@ -265,12 +273,16 @@ export class PipelineNodeElement extends LitElement {
                       ([key, output]) => html`
                         <div class="port port--output" data-testid="output-${key}">
                           <span
-                            style="color:${(output as any).socket === this._commandSocket
+                            style="color:${(output as ClassicPreset.Output<ClassicPreset.Socket>)
+                              .socket === this._commandSocket
                               ? '#009081'
                               : '#000091'}"
                             >&#9679;</span
                           >
-                          <span>${(output as ClassicPreset.Output<any>).label ?? key}</span>
+                          <span
+                            >${(output as ClassicPreset.Output<ClassicPreset.Socket>).label ??
+                            key}</span
+                          >
                         </div>
                       `
                     )}
@@ -286,8 +298,13 @@ export class PipelineNodeElement extends LitElement {
   /** Reference to CommandSocket for color coding — injected by sockets module */
   private get _commandSocket() {
     // Lazy import to avoid circular deps: check socket name
-    const firstInput = Object.values(this.data.inputs)[0] as ClassicPreset.Input<any> | undefined;
-    if (firstInput && (firstInput.socket as any)?.name === 'command') {
+    const firstInput = Object.values(this.data.inputs)[0] as
+      | ClassicPreset.Input<ClassicPreset.Socket>
+      | undefined;
+    if (
+      firstInput &&
+      (firstInput.socket as ClassicPreset.Socket & { name?: string })?.name === 'command'
+    ) {
       return firstInput.socket;
     }
     return null;

--- a/apps/pipeline-helper/src/ui/saved-source-control.ts
+++ b/apps/pipeline-helper/src/ui/saved-source-control.ts
@@ -9,7 +9,7 @@ import {
   extractResourceIds,
 } from '@dsfr-data/shared';
 import type { Source } from '@dsfr-data/shared';
-import { SavedSourceSelector } from '../nodes/base-node.js';
+import { SavedSourceSelector, type SavedSourcePayload } from '../nodes/base-node.js';
 
 // ---------------------------------------------------------------------------
 // Connection types (lightweight — avoids coupling with sources app)
@@ -156,7 +156,7 @@ export class SavedSourceControlElement extends LitElement {
     // Check if it's a source
     const source = this._sources.find((s) => s.id === value);
     if (source) {
-      this.ctrl.onSourceSelected?.(source);
+      this.ctrl.onSourceSelected?.(source as unknown as SavedSourcePayload);
       return;
     }
 


### PR DESCRIPTION
## Summary

**Phase 5 et dernière de #45** — typage complet des 24 anys restants dans `apps/pipeline-helper/` (éditeur visuel Rete + executor + UI).

**Compteur repo : 24 → 0 warnings**. #45 peut être fermée à la merge (109 warnings au démarrage de l'issue, 0 aujourd'hui).

## Récap du chantier #45 (6 PRs)

| PR | Scope | Warnings |
|---|---|:---:|
| #114 | dashboard + monitoring | −12 |
| #115 | builder + pipeline + shared + core/utils | −16 |
| #116 | builder-carto | −13 |
| #117 | chart-renderers (builder + builder-ia) | −7 |
| #118 | packages/core small components (map, popup, world-map, app-header) | −11 |
| #119 | dsfr-data-map-layer (Leaflet intensif) | −26 |
| **#120** (cette PR) | pipeline-helper | **−24** |
| **Total** | | **−109** |

## Fichiers touchés dans cette PR

### Typage strict (15 anys éliminés)
- `main.ts` : `catch (err: any)` → `catch (err)`
- `pipeline-executor.ts` : 6 sites — `(conn as any)` → intersection typée, `data as any` → narrowing via `{ results?, records? }` + `Array.isArray`
- `base-node.ts` : nouveau type `SavedSourcePayload` exporté + `onSourceSelected?: (source: SavedSourcePayload | null) => void`
- `pipeline-nodes.ts` : import `SavedSourcePayload`, `source.provider ?? ''` pour gérer l'union avec undefined
- `saved-source-control.ts` : cast `source as unknown as SavedSourcePayload` au call-site (Source et SavedSourcePayload ont des index signatures qui ne se recouvrent pas sans passage par unknown)
- `ui/custom-node.ts` : `Input<any>` / `Output<any>` → `Input<ClassicPreset.Socket>` / `Output<ClassicPreset.Socket>` (×6 accès socket + labels)
- `editor.ts` : `(node as any).selected` → `(node as { selected?: boolean })`, `filter((c: any))` → `(c: { source: string; target: string })`, addPipe context narrow via `Partial<NodePickedEvent>`, `return null as any` → `return () => null` (contrat attend une factory)

### Eslint-disable inline justifiés (9 anys — Rete v2 generics stricts)
- `editor.ts:S type = any` : pattern existant, commentaire bloc enrichi
- `editor.ts` : `(context: any)` dans `customize.control`, `setup() as any` sur Lit/Connection presets (types Rete non narrowable avec nos custom Node classes)
- `ui/custom-node.ts:emit!: (event: any) => void` : callback Rete scheme-dependent

## Validation

- [x] `npm run typecheck` : ✅
- [x] `npm run build` (bundles core + pipeline-helper) : ✅
- [x] 35 tests pipeline-helper : ✅
- [x] `npm run lint` : **0 warnings `no-explicit-any` dans tout le repo** 🎯

🤖 Generated with [Claude Code](https://claude.com/claude-code)