### PR TITLE
chore(ci): strip nosemgrep-suppressed findings from Semgrep SARIF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,13 @@ jobs:
             --error \
             packages/core/src apps server/src scripts
 
+      - name: Strip nosemgrep-suppressed findings from SARIF
+        if: always()
+        run: |
+          jq '(.runs[].results) |= map(select((.suppressions // []) | length == 0))' \
+            semgrep.sarif > semgrep.filtered.sarif
+          mv semgrep.filtered.sarif semgrep.sarif
+
       - name: Upload Semgrep SARIF
         if: always()
         uses: github/codeql-action/upload-sarif@v4

--- a/docs/security-baseline.md
+++ b/docs/security-baseline.md
@@ -112,6 +112,13 @@ docker run --rm -v "$PWD:/src" -w /src public.ecr.aws/aquasecurity/trivy:latest 
             --error \
             <chemin1> <chemin2>
 
+      - name: Strip nosemgrep-suppressed findings from SARIF
+        if: always()
+        run: |
+          jq '(.runs[].results) |= map(select((.suppressions // []) | length == 0))' \
+            semgrep.sarif > semgrep.filtered.sarif
+          mv semgrep.filtered.sarif semgrep.sarif
+
       - name: Upload Semgrep SARIF
         if: always()
         uses: github/codeql-action/upload-sarif@v3
@@ -119,6 +126,8 @@ docker run --rm -v "$PWD:/src" -w /src public.ecr.aws/aquasecurity/trivy:latest 
           sarif_file: semgrep.sarif
           category: semgrep
 ```
+
+**Pourquoi l'étape `Strip nosemgrep-suppressed findings`** : Semgrep OSS honore les `// nosemgrep: <rule-id>` inline et marque les findings correspondants avec `"suppressions": [{"kind": "inSource"}]` dans le SARIF. Mais **GitHub Code Scanning n'interprète pas ce flag** et remonte ces findings comme alertes ouvertes. Le `jq` filtre ces findings côté workflow avant l'upload pour éviter les re-dismissals manuels récurrents. `jq` est déjà présent dans l'image `semgrep/semgrep`.
 
 `.semgrepignore` :
 ```


### PR DESCRIPTION
## Contexte

Semgrep OSS honore les directives `// nosemgrep: <rule-id>` inline : les findings correspondants sont marqués dans le SARIF avec `\"suppressions\": [{ \"kind\": \"inSource\" }]`.

**Mais GitHub Code Scanning n'interprète pas ce flag** : il remonte ces findings comme alertes ouvertes, ce qui force des dismissals manuels récurrents (cf. le batch du 2026-04-15 sur les proto-pollution-loop et les 4 alertes résiduelles dismissed le 2026-04-19, dont 2 \`missing-integrity\` sur les widgets Grist et 1 \`remote-property-injection\` dans migrate.ts).

## Fix

Ajout d'une étape `jq` entre le scan et l'upload SARIF qui filtre les résultats avec `suppressions[*]` :

\`\`\`yaml
- name: Strip nosemgrep-suppressed findings from SARIF
  if: always()
  run: |
    jq '(.runs[].results) |= map(select((.suppressions // []) | length == 0))' \
      semgrep.sarif > semgrep.filtered.sarif
    mv semgrep.filtered.sarif semgrep.sarif
\`\`\`

\`jq\` est déjà présent dans l'image \`semgrep/semgrep\` (\`/usr/bin/jq\`).

## Vérification locale

Scan global reproduit (\`packages/core/src apps server/src scripts\`) avec \`semgrep/semgrep:1.159.0\` : 19 findings, **tous** marqués \`suppressions[{kind: inSource}]\`. Après filtrage \`jq\` : 0 findings dans le SARIF (cohérent : chaque \`nosemgrep\` du repo est justifié et couvre exactement une instance).

## Impact

- Plus de re-dismissal manuel des alertes déjà couvertes par un \`// nosemgrep:\` inline.
- Les justifications restent visibles dans le code (le commentaire est toujours présent).
- Aucun masquage silencieux : un nouveau match d'une règle non justifiée remontera bien.

\`docs/security-baseline.md\` est mis à jour avec l'étape et le rationale.

## Test plan

- [x] Scan Semgrep local : 0 findings dans le SARIF après filtrage
- [ ] CI verte sur cette PR
- [ ] Vérifier après merge qu'aucune nouvelle alerte \`html.security.audit.missing-integrity\` ne re-raise sur les 2 fichiers grist-widgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)