### PR TITLE
feat(map): sovereign-only mode + osm-fr preset + third-party licenses (#27)

### DIFF
--- a/.changeset/sovereign-only-osm-fr.md
+++ b/.changeset/sovereign-only-osm-fr.md
@@ -1,0 +1,11 @@
+---
+'dsfr-data': minor
+---
+
+**dsfr-data-map** : renforcement de l'argumentaire de souveraineté numérique.
+
+- Nouvel attribut booléen `sovereign-only` qui restreint `tiles` aux seuls presets IGN (`ign-plan`, `ign-ortho`, `ign-topo`, `ign-cadastre`). Tout autre preset ou URL custom est refusé avec un avertissement console et remplacé par `ign-plan`.
+- Renommage du preset `osm` en `osm-fr` pour expliciter qu'il s'agit des serveurs de l'association OpenStreetMap France (loi 1901, hébergée en France), distincte de l'OpenStreetMap Foundation. L'alias `osm` reste accepté.
+- Export d'une fonction pure `resolveTilePreset(requested, sovereignOnly)` pour les tests et outils tiers.
+
+Ferme partiellement [#27](https://github.com/bmatge/dsfr-data/issues/27) (points 2 et 3).

--- a/THIRD-PARTY-LICENSES.md
+++ b/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,56 @@
+# Third-party licenses
+
+Ce fichier liste les licences des dépendances tierces redistribuées ou chargées dynamiquement par la bibliothèque `dsfr-data` et ses apps. Il ne vise pas à être exhaustif pour l'arbre complet des dépendances transitives — un `npm ls` ou un scan SBOM (voir `docs/security-baseline.md`) reste la source de vérité exhaustive.
+
+Le projet `dsfr-data` lui-même est distribué sous licence **MIT** (voir [`LICENSE`](./LICENSE)).
+
+## Bibliothèque `dsfr-data` (`packages/core/`)
+
+| Paquet | Version | Licence | Usage |
+|---|---|---|---|
+| [`lit`](https://lit.dev/) | ^3.1.0 | BSD-3-Clause | Framework des Web Components |
+| [`@gouvfr/dsfr-chart`](https://www.npmjs.com/package/@gouvfr/dsfr-chart) | ^2.0.4 | MIT | Composants Vue DSFR (bar/line/pie chart, map-chart) |
+| [`leaflet`](https://leafletjs.com/) | ^1.9.4 | BSD-2-Clause | Moteur de carte (chargé dynamiquement) |
+| [`leaflet.markercluster`](https://github.com/Leaflet/Leaflet.markercluster) | ^1.5.3 | MIT | Plugin clustering de markers (chargé dynamiquement) |
+| [`leaflet.heat`](https://github.com/Leaflet/Leaflet.heat) | ^0.2.0 | BSD-2-Clause | Plugin heatmap (chargé dynamiquement) |
+| [`d3-geo`](https://github.com/d3/d3-geo) | ^3.1.1 | ISC | Projection géographique pour `dsfr-data-world-map` |
+| [`topojson-client`](https://github.com/topojson/topojson-client) | ^3.1.0 | ISC | Décodage TopoJSON pour `dsfr-data-world-map` |
+| [`world-atlas`](https://github.com/topojson/world-atlas) | ^2.0.2 | ISC | Contours monde TopoJSON |
+
+Les plugins Leaflet (`leaflet.markercluster`, `leaflet.heat`) sont chargés **dynamiquement via `import()`** uniquement quand un composant `dsfr-data-map-layer` les active (attributs `cluster` ou `type="heatmap"`). Ils ne sont donc pas inclus dans le bundle `dsfr-data` distribué sur npm — leur redistribution dans vos applications dépend de votre outil de build.
+
+## Fonds de carte (runtime, non redistribués)
+
+Les presets de tuiles fournis par `dsfr-data-map` ne redistribuent aucun contenu : ils ne font que pointer vers des services publics accessibles au runtime.
+
+| Preset | Service | Souverainete | Conditions d'usage |
+|---|---|---|---|
+| `ign-plan`, `ign-ortho`, `ign-topo`, `ign-cadastre` | [Géoplateforme nationale IGN](https://geoservices.ign.fr/services-geoplateforme) | Oui (IGN, hébergée en France) | Accès sans clé API, mention de la source IGN requise (gérée automatiquement par l'attribution Leaflet) |
+| `osm-fr` (alias : `osm`) | [OpenStreetMap France](https://www.openstreetmap.fr/) (association) | Non (associatif hors État) | Accès sans clé API, respect de la [Tile Usage Policy OSM France](https://www.openstreetmap.fr/). Distinct de l'OpenStreetMap Foundation. |
+
+L'attribut `sovereign-only` du composant `<dsfr-data-map>` restreint les presets acceptés aux seules tuiles IGN.
+
+## Serveur (`server/`)
+
+Les licences des dépendances du backend Express (MariaDB, JWT, nodemailer, etc.) sont consultables via :
+
+```bash
+npm ls --workspace=dsfr-data-server --long 2>/dev/null \
+  | grep -E "^[│├└]|license"
+# ou plus lisiblement :
+npx license-checker --workspace=server
+```
+
+Toutes les dépendances directes du serveur utilisent des licences permissives (MIT, Apache-2.0, BSD, ISC).
+
+## Audits & rapports
+
+- `npm audit` (root + `mcp-server/`) est exécuté en CI via le workflow `Security — SCA & config` (voir `.github/workflows/ci.yml`).
+- Trivy scanne le système de fichiers sur chaque PR et génère un rapport SBOM-like.
+- Un rapport SCA non-bloquant (seuil `MODERATE`) est publié dans le Step Summary GitHub Actions.
+
+Pour régénérer un rapport complet de licences, utiliser :
+
+```bash
+npx license-checker --production --json > licenses-report.json
+```

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -2313,6 +2313,9 @@ Chargé via le bundle \`dsfr-data.world-map.esm.js\` (séparé du core).
       'color-map',
       'couleur categorielle',
       'couleur par valeur',
+      'souverainete',
+      'sovereign-only',
+      'osm-fr',
     ],
     content: `## dsfr-data-map + dsfr-data-map-layer — Carte interactive multi-couches
 
@@ -2340,7 +2343,8 @@ Leaflet est charge dynamiquement (pas inclus dans le bundle).
 | min-zoom | Number | \`2\` | Zoom minimum |
 | max-zoom | Number | \`18\` | Zoom maximum |
 | height | String | \`"500px"\` | Hauteur CSS (px, vh, rem). Un \`%\` est un ratio de la largeur (ex: \`"60%"\` = 60% de la largeur) |
-| tiles | String | \`"ign-plan"\` | Fond de carte : \`ign-plan\`, \`ign-ortho\`, \`ign-cadastre\`, \`osm\`, ou URL template |
+| tiles | String | \`"ign-plan"\` | Fond de carte : \`ign-plan\`, \`ign-ortho\`, \`ign-topo\`, \`ign-cadastre\`, \`osm-fr\` (alias : \`osm\`), ou URL template |
+| sovereign-only | Boolean | \`false\` | Restreint \`tiles\` aux presets IGN souverains. Tout autre preset (\`osm-fr\`) ou URL custom est refuse avec \`console.warn\` et remplace par \`ign-plan\`. |
 | no-controls | Boolean | \`false\` | Masque les controles de zoom |
 | fit-bounds | Boolean | \`false\` | Ajuste le viewport aux donnees |
 | max-bounds | String | \`""\` | Limites \`"latSW,lonSW,latNE,lonNE"\` |

--- a/packages/core/src/components/dsfr-data-map.ts
+++ b/packages/core/src/components/dsfr-data-map.ts
@@ -15,7 +15,7 @@ type LeafletMap = import('leaflet').Map;
 type LeafletTileLayer = import('leaflet').TileLayer;
 type LatLngBoundsExpression = import('leaflet').LatLngBoundsExpression;
 
-/** Tile presets — souverains, sans cle API */
+/** Tile presets — souverains (IGN) ou europeens (OSM France), sans cle API */
 const TILE_PRESETS: Record<
   string,
   { url: string; attribution: string; options?: Record<string, unknown> }
@@ -36,11 +36,53 @@ const TILE_PRESETS: Record<
     url: 'https://data.geopf.fr/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=CADASTRALPARCELS.PARCELLAIRE_EXPRESS&STYLE=normal&FORMAT=image/png&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
     attribution: '&copy; <a href="https://www.ign.fr/">IGN</a>',
   },
-  osm: {
+  'osm-fr': {
     url: 'https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png',
-    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> — serveurs <a href="https://www.openstreetmap.fr/">OSM France</a>',
   },
 };
+
+/** Alias de presets pour retrocompatibilite. */
+const TILE_ALIASES: Record<string, string> = {
+  osm: 'osm-fr',
+};
+
+/** Presets consideres comme souverains (tuiles IGN Geoplateforme, hebergees en France). */
+const SOVEREIGN_PRESETS = new Set<string>(['ign-plan', 'ign-ortho', 'ign-topo', 'ign-cadastre']);
+
+/**
+ * Resout la valeur de `tiles` en cle de preset canonique ou `null` (URL custom).
+ * Applique les alias, puis la restriction `sovereign-only` si active.
+ * Retourne aussi `warning` quand un fallback a ete applique (pour logging par l'appelant).
+ *
+ * Expose pour les tests.
+ */
+export function resolveTilePreset(
+  requested: string,
+  sovereignOnly = false
+): { key: string | null; warning?: string } {
+  const canonical = TILE_ALIASES[requested] ?? requested;
+  const isKnownPreset = canonical in TILE_PRESETS;
+
+  if (sovereignOnly && (!isKnownPreset || !SOVEREIGN_PRESETS.has(canonical))) {
+    return {
+      key: 'ign-plan',
+      warning:
+        `tiles="${requested}" non autorise en mode sovereign-only. ` +
+        `Presets souverains : ${[...SOVEREIGN_PRESETS].join(', ')}. Fallback sur "ign-plan".`,
+    };
+  }
+
+  return { key: isKnownPreset ? canonical : null };
+}
+
+/** Expose pour les tests (valeurs read-only). */
+export const __tilePresetsForTests = {
+  presets: TILE_PRESETS,
+  aliases: TILE_ALIASES,
+  sovereign: SOVEREIGN_PRESETS,
+} as const;
 
 // Lazy Leaflet module cache
 let L: typeof import('leaflet') | null = null;
@@ -80,6 +122,9 @@ export class DsfrDataMap extends LitElement {
 
   @property({ type: String })
   tiles = 'ign-plan';
+
+  @property({ type: Boolean, attribute: 'sovereign-only' })
+  sovereignOnly = false;
 
   @property({ type: Boolean, attribute: 'no-controls' })
   noControls = false;
@@ -169,7 +214,7 @@ export class DsfrDataMap extends LitElement {
     super.updated(changedProperties);
 
     if (this._leafletMap) {
-      if (changedProperties.has('tiles')) {
+      if (changedProperties.has('tiles') || changedProperties.has('sovereignOnly')) {
         this._updateTiles();
       }
       if (changedProperties.has('height') && this._container) {
@@ -384,8 +429,12 @@ export class DsfrDataMap extends LitElement {
     if (this._tileLayer) {
       this._tileLayer.remove();
     }
-    const preset = TILE_PRESETS[this.tiles];
-    if (preset) {
+
+    const { key, warning } = resolveTilePreset(this.tiles, this.sovereignOnly);
+    if (warning) console.warn(`[dsfr-data-map] ${warning}`);
+
+    if (key !== null) {
+      const preset = TILE_PRESETS[key];
       this._tileLayer = L.tileLayer(preset.url, {
         attribution: preset.attribution,
         ...preset.options,

--- a/specs/components/dsfr-data-map.html
+++ b/specs/components/dsfr-data-map.html
@@ -50,6 +50,7 @@
             <tr><td><code>max-zoom</code></td><td>Number</td><td><code>18</code></td><td>Zoom maximum autorise</td></tr>
             <tr><td><code>height</code></td><td>String</td><td><code>"500px"</code></td><td>Hauteur du conteneur. Accepte toute unite CSS (<code>px</code>, <code>vh</code>, <code>rem</code>). Un pourcentage (ex: <code>"60%"</code>) est interprete comme un ratio de la largeur (aspect-ratio responsive).</td></tr>
             <tr><td><code>tiles</code></td><td>String</td><td><code>"ign-plan"</code></td><td>Fond de carte predefini ou URL template custom</td></tr>
+            <tr><td><code>sovereign-only</code></td><td>Boolean</td><td><code>false</code></td><td>Restreint <code>tiles</code> aux presets IGN souverains. Tout autre preset (ex. <code>osm-fr</code>) ou URL custom est refuse avec un <code>console.warn</code> et remplace par <code>ign-plan</code>.</td></tr>
             <tr><td><code>no-controls</code></td><td>Boolean</td><td><code>false</code></td><td>Masque les controles de zoom Leaflet</td></tr>
             <tr><td><code>fit-bounds</code></td><td>Boolean</td><td><code>false</code></td><td>Ajuste automatiquement le viewport aux donnees</td></tr>
             <tr><td><code>max-bounds</code></td><td>String</td><td><code>""</code></td><td>Limites <code>"latSW,lonSW,latNE,lonNE"</code></td></tr>
@@ -58,17 +59,19 @@
         </table>
 
         <h3>Fonds de carte predefinis</h3>
-        <p>Tuiles souveraines, accessibles <strong>sans cle API</strong> :</p>
+        <p>Tuiles accessibles <strong>sans cle API</strong>. Les presets <code>ign-*</code> sont servis par la <a href="https://geoservices.ign.fr/services-geoplateforme">Geoplateforme nationale IGN</a> (infrastructure cartographique de l'Etat, hebergee en France). Le preset <code>osm-fr</code> est servi par l'<a href="https://www.openstreetmap.fr/">association OpenStreetMap France</a> (association loi 1901, infra hebergee en France, distincte de l'OSM Foundation).</p>
         <table class="attr-table">
-          <thead><tr><th>Preset</th><th>Source</th></tr></thead>
+          <thead><tr><th>Preset</th><th>Source</th><th>Souverain</th><th>Endpoint</th></tr></thead>
           <tbody>
-            <tr><td><code>ign-plan</code></td><td>Geoplateforme IGN — Plan IGN</td></tr>
-            <tr><td><code>ign-ortho</code></td><td>Geoplateforme IGN — Orthophoto</td></tr>
-            <tr><td><code>ign-topo</code></td><td>Geoplateforme IGN — Carte topographique (SCAN 25/100)</td></tr>
-            <tr><td><code>ign-cadastre</code></td><td>Geoplateforme IGN — Cadastre</td></tr>
-            <tr><td><code>osm</code></td><td>OpenStreetMap France</td></tr>
+            <tr><td><code>ign-plan</code></td><td>Geoplateforme IGN — Plan IGN</td><td>Oui</td><td><code>data.geopf.fr/wmts</code> (layer <code>GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2</code>)</td></tr>
+            <tr><td><code>ign-ortho</code></td><td>Geoplateforme IGN — Orthophoto</td><td>Oui</td><td><code>data.geopf.fr/wmts</code> (layer <code>ORTHOIMAGERY.ORTHOPHOTOS</code>)</td></tr>
+            <tr><td><code>ign-topo</code></td><td>Geoplateforme IGN — Carte topographique (SCAN 25/100)</td><td>Oui</td><td><code>data.geopf.fr/wmts</code> (layer <code>GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1</code>)</td></tr>
+            <tr><td><code>ign-cadastre</code></td><td>Geoplateforme IGN — Cadastre</td><td>Oui</td><td><code>data.geopf.fr/wmts</code> (layer <code>CADASTRALPARCELS.PARCELLAIRE_EXPRESS</code>)</td></tr>
+            <tr><td><code>osm-fr</code></td><td>OpenStreetMap France (association)</td><td>Non (associatif hors Etat)</td><td><code>{s}.tile.openstreetmap.fr/osmfr</code></td></tr>
           </tbody>
         </table>
+        <p class="fr-mt-2w"><strong>Mode <code>sovereign-only</code></strong> : pour les DSI qui imposent une politique "zero tiers externe non souverain", ajouter l'attribut booleen <code>sovereign-only</code> sur <code>&lt;dsfr-data-map&gt;</code> restreint les presets disponibles aux seules tuiles IGN (<code>ign-plan</code>, <code>ign-ortho</code>, <code>ign-topo</code>, <code>ign-cadastre</code>). Tout autre preset ou URL custom est refuse avec un avertissement console et remplace par <code>ign-plan</code>.</p>
+        <p><strong>Alias de retrocompatibilite</strong> : <code>tiles="osm"</code> reste accepte et pointe vers le preset <code>osm-fr</code>.</p>
 
         <!-- ============================================================ -->
         <!-- dsfr-data-map-layer -->

--- a/tests/dsfr-data-map.test.ts
+++ b/tests/dsfr-data-map.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { DsfrDataMap } from '@/components/dsfr-data-map.js';
+import {
+  DsfrDataMap,
+  resolveTilePreset,
+  __tilePresetsForTests,
+} from '@/components/dsfr-data-map.js';
 import { DsfrDataMapLayer } from '@/components/dsfr-data-map-layer.js';
 import { DsfrDataMapTimeline } from '@/components/dsfr-data-map-timeline.js';
 import { clearDataCache, dispatchDataLoaded } from '@/utils/data-bridge.js';
@@ -47,6 +51,10 @@ describe('DsfrDataMap', () => {
       expect(map.tiles).toBe('ign-plan');
     });
 
+    it('has sovereign-only false', () => {
+      expect(map.sovereignOnly).toBe(false);
+    });
+
     it('has no-controls false', () => {
       expect(map.noControls).toBe(false);
     });
@@ -78,6 +86,85 @@ describe('DsfrDataMap', () => {
     it('getLeafletLib returns null before init', () => {
       expect(map.getLeafletLib()).toBeNull();
     });
+  });
+});
+
+describe('resolveTilePreset', () => {
+  it('resout les 5 presets canoniques sans warning', () => {
+    for (const preset of ['ign-plan', 'ign-ortho', 'ign-topo', 'ign-cadastre', 'osm-fr']) {
+      const { key, warning } = resolveTilePreset(preset, false);
+      expect(key).toBe(preset);
+      expect(warning).toBeUndefined();
+    }
+  });
+
+  it('mappe l\'alias "osm" sur "osm-fr"', () => {
+    const { key, warning } = resolveTilePreset('osm', false);
+    expect(key).toBe('osm-fr');
+    expect(warning).toBeUndefined();
+  });
+
+  it('retourne null sur une URL custom (pas de warning)', () => {
+    const custom = 'https://tiles.example.com/{z}/{x}/{y}.png';
+    const { key, warning } = resolveTilePreset(custom, false);
+    expect(key).toBeNull();
+    expect(warning).toBeUndefined();
+  });
+
+  describe('sovereign-only', () => {
+    it('accepte les 4 presets IGN', () => {
+      for (const preset of ['ign-plan', 'ign-ortho', 'ign-topo', 'ign-cadastre']) {
+        const { key, warning } = resolveTilePreset(preset, true);
+        expect(key).toBe(preset);
+        expect(warning).toBeUndefined();
+      }
+    });
+
+    it('refuse osm-fr et force ign-plan avec warning', () => {
+      const { key, warning } = resolveTilePreset('osm-fr', true);
+      expect(key).toBe('ign-plan');
+      expect(warning).toMatch(/osm-fr/);
+      expect(warning).toMatch(/sovereign-only/);
+    });
+
+    it("refuse l'alias osm et force ign-plan avec warning", () => {
+      const { key, warning } = resolveTilePreset('osm', true);
+      expect(key).toBe('ign-plan');
+      expect(warning).toMatch(/osm/);
+    });
+
+    it('refuse une URL custom et force ign-plan avec warning', () => {
+      const { key, warning } = resolveTilePreset('https://tiles.example.com/{z}/{x}/{y}.png', true);
+      expect(key).toBe('ign-plan');
+      expect(warning).toMatch(/sovereign-only/);
+    });
+  });
+});
+
+describe('TILE_PRESETS', () => {
+  it('contient les 5 presets documentes (4 IGN + osm-fr)', () => {
+    const keys = Object.keys(__tilePresetsForTests.presets).sort();
+    expect(keys).toEqual(['ign-cadastre', 'ign-ortho', 'ign-plan', 'ign-topo', 'osm-fr'].sort());
+  });
+
+  it('expose 4 presets souverains (tuiles IGN)', () => {
+    const sov = [...__tilePresetsForTests.sovereign].sort();
+    expect(sov).toEqual(['ign-cadastre', 'ign-ortho', 'ign-plan', 'ign-topo']);
+  });
+
+  it("expose l'alias osm -> osm-fr", () => {
+    expect(__tilePresetsForTests.aliases).toEqual({ osm: 'osm-fr' });
+  });
+
+  it('toutes les URLs pointent vers data.geopf.fr ou openstreetmap.fr (sans cle API)', () => {
+    for (const [key, preset] of Object.entries(__tilePresetsForTests.presets)) {
+      const allowedHosts = ['data.geopf.fr', 'openstreetmap.fr'];
+      expect(
+        allowedHosts.some((host) => preset.url.includes(host)),
+        `preset ${key} doit pointer vers ${allowedHosts.join(' ou ')}`
+      ).toBe(true);
+      expect(preset.url).not.toMatch(/[?&](key|api_key|apikey)=/);
+    }
   });
 });
 
@@ -2453,7 +2540,11 @@ describe('DsfrDataMapLayer banner management', () => {
     expect(banner?.textContent).toContain('3');
 
     // happy-dom has a bug disconnecting Lit elements that contain rendered children
-    try { document.body.removeChild(parent); } catch { /* happy-dom cleanup bug */ }
+    try {
+      document.body.removeChild(parent);
+    } catch {
+      /* happy-dom cleanup bug */
+    }
   });
 
   it('does not create banner when not truncated', async () => {
@@ -2498,7 +2589,11 @@ describe('DsfrDataMapLayer banner management', () => {
     expect(banners).toHaveLength(1);
 
     // happy-dom has a bug disconnecting Lit elements that contain rendered children
-    try { document.body.removeChild(parent); } catch { /* happy-dom cleanup bug */ }
+    try {
+      document.body.removeChild(parent);
+    } catch {
+      /* happy-dom cleanup bug */
+    }
   });
 });
 


### PR DESCRIPTION
Partial fix of #27 — points 1, 2, 3 et 6 sur les 6 recommandations de l'audit souveraineté `dsfr-data-map`.

## Ce que la PR fait

### ✅ #27.2 — Rename `osm` → `osm-fr` (+ alias rétrocompat)
Le preset précédemment nommé `osm` pointe vers `{s}.tile.openstreetmap.fr/osmfr` (association OSM France, loi 1901, infra hébergée en France). Le nouveau nom `osm-fr` rend ça explicite. `tiles="osm"` reste accepté via un mapping d'alias (`TILE_ALIASES`), pas de breaking change.

### ✅ #27.3 — Attribut `sovereign-only`
Nouvel attribut booléen sur `<dsfr-data-map>`. Quand activé :
- Accepte : `ign-plan`, `ign-ortho`, `ign-topo`, `ign-cadastre`
- Refuse : `osm-fr`/`osm`, URL templates custom → `console.warn` explicite + fallback automatique sur `ign-plan`

```html
<dsfr-data-map tiles="osm-fr" sovereign-only>
  <!-- ⚠ [dsfr-data-map] tiles="osm-fr" non autorise en mode sovereign-only...
       Fallback sur "ign-plan". -->
</dsfr-data-map>
```

### ✅ #27.1 — Documentation des URLs IGN dans les specs
Le tableau des presets dans `specs/components/dsfr-data-map.html` liste maintenant pour chaque preset :
- La source éditoriale (IGN / OSM France)
- La qualification souveraine (Oui / Non)
- L'endpoint complet (`data.geopf.fr/wmts`, layer précis)

### ✅ #27.6 — Licences des plugins Leaflet
Nouveau fichier [`THIRD-PARTY-LICENSES.md`](./THIRD-PARTY-LICENSES.md) à la racine listant :
- Deps directes `packages/core/` (leaflet BSD-2, markercluster MIT, heat BSD-2, lit BSD-3, d3-geo ISC, topojson ISC, world-atlas ISC, @gouvfr/dsfr-chart MIT)
- Fonds de carte tiers (Géoplateforme IGN / OSM France — runtime, non redistribués)
- Pointers pour rapports SBOM exhaustifs

### 🔧 Bug fix annexe
Le skill builder-IA `dsfrDataMap` ne documentait pas `ign-topo` dans les valeurs acceptées de `tiles` — corrigé. Triggers enrichis (`souverainete`, `sovereign-only`, `osm-fr`).

## Non couvert dans cette PR

### ⏭️ #27.4 — Preset `ign-vecteur` → roadmap V2
Nécessite MapLibre GL JS ou `Leaflet.VectorGrid`. Changement de moteur de rendu, hors scope incrémental.

### ⏭️ #27.5 — Remplacement `public.opendatasoft.com` → `geo.api.gouv.fr`
Les 3 exemples visés (`guide/examples/exemple-masa-v1.html`, `exemple-france-num.html`, `exemple-masa-v2.html` + 2 blocs dans `specs/components/dsfr-data-map.html`) font tous du choropleth `georef-france-{region,commune,departement}` **+ champ `population`** dans le même dataset ODS. `geo.api.gouv.fr/regions` ne fournit pas la population — un remplacement 1-pour-1 casserait la pédagogie (choropleth vide). Un refactor propre nécessite un `dsfr-data-join` contours IGN + population INSEE, non trivial.

À traiter dans une PR dédiée ou laisser en "follow-up" de #27.

## Refactor de code

La logique de résolution de preset est extraite en **fonction pure** `resolveTilePreset(requested, sovereignOnly)` exportée depuis `dsfr-data-map.ts`. Appelée par `_updateTiles()`, testée unitairement (12 nouveaux tests).

Export `__tilePresetsForTests` pour tester la contrainte "aucune URL de preset ne contient de clé API" (robustesse future).

## Test plan

- [x] `npm run typecheck` → OK
- [x] `npm run lint` → OK
- [x] `npm run format:check` → OK
- [x] `npm run test:run` → **2863/2863** (319 touchant map + skills alignment)
- [x] 12 nouveaux tests unitaires ciblant `resolveTilePreset` et `TILE_PRESETS`
- [x] Changeset `minor` (`dsfr-data`)
- [ ] CI verte sur cette PR (Security — SAST doit passer sans re-raise sur les nosemgrep grâce au fix PR #121)
- [ ] Vérification manuelle : affichage specs `/specs/components/dsfr-data-map.html` (tableau souverain)

Closes partiellement #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)