### PR TITLE
feat(builder): inline section summaries + compact source row + preview polish (#24)

### DIFF
--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -672,15 +672,15 @@
             <iframe id="preview-iframe"
               sandbox="allow-scripts allow-same-origin"
               title="Apercu du graphique"
-              style="display: none; width: 100%; border: none; min-height: 400px; border-radius: 4px; background: white;">
+              style="display: none; width: 100%; height: calc(100vh - 280px); min-height: 460px; border: none; border-radius: 4px; background: white;">
             </iframe>
           </div>
         </div>
-
-        <!-- Apercu accessibilite (composant reel) -->
-        <dsfr-data-a11y id="a11y-preview" source="builder-preview"
-          no-auto-aria table download style="display: none;">
-        </dsfr-data-a11y>
+        <!--
+          Le companion dsfr-data-a11y est deja genere a l'interieur du code
+          injecte dans l'iframe (cf. generateEmbeddedA11y / generateA11yElement
+          dans ui/code-generator.ts). Pas de double dans le panel builder.
+        -->
       </div>
 
       <!-- Onglet Code -->

--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -40,9 +40,6 @@
         </button>
       </div>
 
-      <!-- STEPPER D'AVANCEMENT -->
-      <div class="progress-stepper" id="progress-stepper" role="list" aria-label="Avancement de la configuration"></div>
-
       <!-- ETAPE 1 : Source de donnees -->
       <div class="config-section" id="section-source">
         <div class="config-section-header" onclick="toggleSection('section-source')">

--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -28,7 +28,7 @@
   <!-- Header -->
   <app-header current-page="builder" base-path="../../"></app-header>
 
-  <app-layout-builder left-ratio="50">
+  <app-layout-builder left-ratio="38" min-right-width="480">
     <!-- ============================================ -->
     <!-- PANNEAU DE CONFIGURATION -->
     <!-- ============================================ -->

--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -40,6 +40,9 @@
         </button>
       </div>
 
+      <!-- STEPPER D'AVANCEMENT -->
+      <div class="progress-stepper" id="progress-stepper" role="list" aria-label="Avancement de la configuration"></div>
+
       <!-- ETAPE 1 : Source de donnees -->
       <div class="config-section" id="section-source">
         <div class="config-section-header" onclick="toggleSection('section-source')">
@@ -634,10 +637,11 @@
       </div>
 
       <!-- BOUTON GENERER -->
-      <div class="config-section">
+      <div class="config-section generate-controls">
         <button class="fr-btn fr-btn--icon-left" id="generate-btn" style="width: 100%;">
           <i class="ri-play-fill"></i> Generer le graphique
         </button>
+        <p class="generate-missing" id="generate-missing" role="status" aria-live="polite" hidden></p>
       </div>
 
     </aside>

--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -48,9 +48,16 @@
         </div>
         <div class="config-section-content">
 
-        <!-- Selection de source (grille 3 colonnes) -->
+        <!--
+          Selection de source sur une seule ligne :
+            [ select "Source"                 | #fields-status (bouton "Voir"
+                                                injecte par sources.ts)   | + Nouvelle ]
+          Le bouton "Charger" est retire : les fields sont charges
+          automatiquement dans handleSavedSourceChange() a chaque change.
+          Le nom et le compteur d'enregistrements apparaissent dans le resume
+          en tete de section (progress-indicator.ts), plus besoin de la ligne 2.
+        -->
         <div id="source-panel-saved" class="source-panel">
-          <!-- Ligne 1 : Select | Bouton | Status -->
           <div class="source-grid">
             <div class="fr-select-group fr-select-group--sm">
               <label class="fr-label" for="saved-source">Source</label>
@@ -58,19 +65,10 @@
                 <option value="">— Choisir —</option>
               </select>
             </div>
-            <button class="fr-btn fr-btn--sm fr-btn--secondary source-btn" id="load-fields-btn">
-              <i class="ri-refresh-line"></i> Charger
-            </button>
             <div class="source-status" id="fields-status" aria-live="polite"></div>
-          </div>
-
-          <!-- Ligne 2 : Info | Lien | (vide) -->
-          <div class="source-grid source-grid-row2">
-            <div id="saved-source-info" class="source-info"></div>
-            <a href="../sources/index.html" class="fr-link fr-link--sm">
+            <a href="../sources/index.html" class="fr-link fr-link--sm source-new-link">
               <i class="ri-add-line"></i> Nouvelle
             </a>
-            <div></div>
           </div>
         </div>
         </div>

--- a/apps/builder/src/main.ts
+++ b/apps/builder/src/main.ts
@@ -10,7 +10,6 @@ import {
   loadSavedSources,
   checkSelectedSource,
   handleSavedSourceChange,
-  loadFields,
   loadFavoriteState,
   initDataPreviewModal,
 } from './sources.js';
@@ -93,14 +92,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
   }
 
-  // Buttons
-  const loadFieldsBtn = document.getElementById('load-fields-btn');
-  if (loadFieldsBtn)
-    loadFieldsBtn.addEventListener('click', () => {
-      loadFields();
-      // After loadFields completes (async), update steps
-      setTimeout(updatePreviewSteps, 100);
-    });
+  // Note: le bouton "Charger" a ete retire — handleSavedSourceChange()
+  // appelle loadFields() automatiquement sur chaque changement de source.
 
   const generateBtn = document.getElementById('generate-btn');
   if (generateBtn) {

--- a/apps/builder/src/main.ts
+++ b/apps/builder/src/main.ts
@@ -103,7 +103,15 @@ document.addEventListener('DOMContentLoaded', async () => {
     });
 
   const generateBtn = document.getElementById('generate-btn');
-  if (generateBtn) generateBtn.addEventListener('click', generateChart);
+  if (generateBtn) {
+    generateBtn.addEventListener('click', async () => {
+      await generateChart();
+      // Refresh stepper so the "Generate" step ticks once the preview iframe
+      // is visible (empty-state hidden). generateChart() renders synchronously
+      // in most paths but may be async for server-side aggregations.
+      updatePreviewSteps();
+    });
+  }
 
   const copyCodeBtn = document.getElementById('copy-code-btn');
   if (copyCodeBtn) copyCodeBtn.addEventListener('click', copyCode);

--- a/apps/builder/src/sources.ts
+++ b/apps/builder/src/sources.ts
@@ -222,10 +222,14 @@ export function handleSavedSourceChange(): void {
 
   state.isSampleData = false;
 
-  // If it has local data, load fields directly
+  // If it has local data, load fields directly.
+  // Otherwise, kick off the async field fetch right away so the user does
+  // not have to click a separate "Charger" button (retire from the UI).
   if (source.data && source.data.length > 0) {
     state.localData = source.data;
     loadFieldsFromLocalData();
+  } else if (state.apiUrl) {
+    void loadFields();
   }
 }
 

--- a/apps/builder/src/state.ts
+++ b/apps/builder/src/state.ts
@@ -164,6 +164,81 @@ export interface BuilderState {
   isSampleData: boolean;
 }
 
+/** Result of computing how complete the current builder configuration is. */
+export interface Completeness {
+  /** True when a source has been loaded and fields are available. */
+  source: boolean;
+  /** True when a chart type is selected. */
+  type: boolean;
+  /** True when the mandatory fields for the selected chart type are filled. */
+  config: boolean;
+  /** True once the chart has been generated at least once (runtime-only). */
+  generate: boolean;
+  /**
+   * Human-readable labels describing what is missing for the current step.
+   * Empty when every step up to (and including) `config` is complete.
+   */
+  missing: string[];
+}
+
+/**
+ * Pure function: inspect the state and return which of the 4 "gates" (source,
+ * type, config, generate) are reached, plus a human list of what is missing.
+ *
+ * Used by the progress stepper, section indicators, empty-state checklist and
+ * the "Generate" button sub-text. Keeping it a pure function (no DOM access)
+ * makes it trivial to unit-test and safe to call on every input change.
+ *
+ * `generated` must be passed by the caller since it is not stored in `state`
+ * (it is runtime UI state tracked by the preview panel).
+ */
+export function getCompleteness(s: BuilderState, generated: boolean = false): Completeness {
+  const source = Array.isArray(s.fields) && s.fields.length > 0;
+  const type = !!s.chartType;
+
+  let config = false;
+  const missing: string[] = [];
+
+  if (!source) {
+    missing.push('une source de données');
+  }
+  if (!type) {
+    missing.push('un type de graphique');
+  }
+
+  if (source && type) {
+    switch (s.chartType) {
+      case 'datalist':
+        config = !!s.labelField;
+        if (!config) missing.push('le champ à afficher');
+        break;
+      case 'kpi':
+      case 'gauge':
+        config = !!s.valueField;
+        if (!config) missing.push('le champ numérique (valeur)');
+        break;
+      case 'map':
+        config = !!s.valueField && !!s.codeField;
+        if (!s.codeField) missing.push('le champ code (département/région)');
+        if (!s.valueField) missing.push('le champ numérique (valeur)');
+        break;
+      default:
+        config = !!s.labelField && !!s.valueField;
+        if (!s.labelField) missing.push('le champ catégorie (axe X)');
+        if (!s.valueField) missing.push('le champ numérique (axe Y)');
+        break;
+    }
+  }
+
+  return {
+    source,
+    type,
+    config,
+    generate: generated && source && type && config,
+    missing,
+  };
+}
+
 /** The singleton application state */
 export const state: BuilderState = {
   sourceType: 'saved',

--- a/apps/builder/src/styles/builder.css
+++ b/apps/builder/src/styles/builder.css
@@ -1,4 +1,6 @@
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
 body {
   margin: 0;
@@ -224,7 +226,9 @@ body {
 .config-section-content {
   overflow: hidden;
   max-height: 1000px;
-  transition: max-height 0.3s ease, padding 0.3s ease;
+  transition:
+    max-height 0.3s ease,
+    padding 0.3s ease;
 }
 
 .config-section.collapsed .config-section-content {
@@ -313,7 +317,9 @@ body {
   background: var(--background-default-grey);
   cursor: pointer;
   text-align: left;
-  transition: border-color 0.15s, background 0.15s;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
   font-family: inherit;
   font-size: 0.85rem;
 }
@@ -398,8 +404,14 @@ h3 .help-btn i {
   animation: help-fade-in 0.15s ease;
 }
 @keyframes help-fade-in {
-  from { opacity: 0; transform: translateY(4px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ─── Preview empty state steps ─── */
@@ -463,9 +475,18 @@ h3 .help-btn i {
   font-weight: 600;
 }
 
-.source-badge-grist { background: #16a34a; color: white; }
-.source-badge-manual { background: #9333ea; color: white; }
-.source-badge-api { background: #2563eb; color: white; }
+.source-badge-grist {
+  background: #16a34a;
+  color: white;
+}
+.source-badge-manual {
+  background: #9333ea;
+  color: white;
+}
+.source-badge-api {
+  background: #2563eb;
+  color: white;
+}
 
 /* KPI Cards */
 .kpi-card {
@@ -475,10 +496,18 @@ h3 .help-btn i {
   text-align: center;
   border-radius: 4px;
 }
-.kpi-card--info { border-left-color: #0063CB; }
-.kpi-card--success { border-left-color: #18753C; }
-.kpi-card--warning { border-left-color: #D64D00; }
-.kpi-card--error { border-left-color: #C9191E; }
+.kpi-card--info {
+  border-left-color: #0063cb;
+}
+.kpi-card--success {
+  border-left-color: #18753c;
+}
+.kpi-card--warning {
+  border-left-color: #d64d00;
+}
+.kpi-card--error {
+  border-left-color: #c9191e;
+}
 
 /* Gauge Card */
 .gauge-card {
@@ -487,9 +516,18 @@ h3 .help-btn i {
   text-align: center;
   border-radius: 4px;
 }
-.gauge-container { position: relative; width: 150px; margin: 0 auto; }
-.gauge-svg { width: 100%; height: auto; }
-.gauge-fill { transition: stroke-dasharray 0.5s ease; }
+.gauge-container {
+  position: relative;
+  width: 150px;
+  margin: 0 auto;
+}
+.gauge-svg {
+  width: 100%;
+  height: auto;
+}
+.gauge-fill {
+  transition: stroke-dasharray 0.5s ease;
+}
 .gauge-value {
   position: absolute;
   bottom: 10px;
@@ -622,3 +660,197 @@ h3 .help-btn i {
 }
 
 /* Responsive - les styles principaux sont dans app-layout-builder */
+
+/* ============================================================ */
+/* Progress stepper + section indicators (UX-005 #24)            */
+/* Scoped under .builder-config-panel for strong specificity.   */
+/* ============================================================ */
+
+.builder-config-panel .progress-stepper {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.25rem;
+  padding: 0.625rem 0.75rem;
+  margin: 0 0 0.75rem;
+  border-radius: 4px;
+  background: var(--background-alt-grey, #f6f6f6);
+  overflow-x: auto;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.builder-config-panel .progress-step {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 0 0 auto;
+  font-size: 0.8125rem;
+  color: var(--text-mention-grey, #666666);
+  white-space: nowrap;
+}
+
+.builder-config-panel .progress-step-circle {
+  position: relative;
+  width: 1.5rem;
+  height: 1.5rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  border: 2px solid var(--border-default-grey, #dddddd);
+  background: #ffffff;
+  color: var(--text-mention-grey, #666666);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+/*
+ * Using <span> text nodes (not <i class="ri-*">) avoids a clash with Remix
+ * Icon's global `[class^="ri-"] { display: inline-block }` rule which would
+ * otherwise keep the check mark visible on non-done steps.
+ */
+.builder-config-panel .progress-step-number {
+  display: inline-block;
+}
+.builder-config-panel .progress-step-check {
+  display: none;
+}
+
+.builder-config-panel .progress-step-label {
+  font-size: 0.8125rem;
+  line-height: 1.1;
+  font-weight: 500;
+}
+
+/* "current" — the first step not yet done. */
+.builder-config-panel .progress-step--current {
+  color: var(--text-default-grey, #3a3a3a);
+}
+.builder-config-panel .progress-step--current .progress-step-circle {
+  border-color: var(--background-action-high-blue-france, #000091);
+  color: var(--text-action-high-blue-france, #000091);
+}
+.builder-config-panel .progress-step--current .progress-step-label {
+  font-weight: 700;
+}
+
+/* "done" — pill fills blue, number hides, check appears. */
+.builder-config-panel .progress-step--done {
+  color: var(--text-default-grey, #3a3a3a);
+}
+.builder-config-panel .progress-step--done .progress-step-circle {
+  background: var(--background-action-high-blue-france, #000091);
+  border-color: var(--background-action-high-blue-france, #000091);
+  color: #ffffff;
+}
+.builder-config-panel .progress-step--done .progress-step-number {
+  display: none;
+}
+.builder-config-panel .progress-step--done .progress-step-check {
+  display: inline-block;
+}
+
+/* Collapse labels on very narrow panels to keep the stepper on one line. */
+@media (max-width: 480px) {
+  .builder-config-panel .progress-step-label {
+    display: none;
+  }
+}
+
+/* Section header status badge — ✓ or ◐ next to the <h3>. */
+.section-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  margin-left: 0.5rem;
+  padding: 0 0.25rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  line-height: 1;
+  vertical-align: baseline;
+}
+.section-status:empty {
+  display: none;
+}
+.section-status--done {
+  background: var(--background-contrast-success, #b8fec9);
+  color: var(--text-default-success, #18753c);
+}
+.section-status--partial {
+  background: var(--background-contrast-warning, #fff4b8);
+  color: var(--text-default-warning, #b34000);
+}
+.section-status--idle {
+  display: none;
+}
+
+/* Generate-controls — ready variant + contextual sub-text. */
+#generate-btn.fr-btn--ready {
+  background: var(--background-action-high-blue-france, #000091);
+  box-shadow: 0 0 0 2px rgba(0, 0, 145, 0.25);
+}
+.generate-missing {
+  margin: 0.5rem 0 0;
+  padding: 0;
+  font-size: 0.8125rem;
+  color: var(--text-default-warning, #b34000);
+  text-align: center;
+  line-height: 1.3;
+}
+.generate-missing[hidden] {
+  display: none;
+}
+
+/* Empty-state checklist — visual checkboxes that tick as user progresses. */
+.empty-state-steps li {
+  position: relative;
+  padding-left: 1.5rem;
+}
+.empty-state-steps li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.2em;
+  width: 0.95rem;
+  height: 0.95rem;
+  border: 2px solid var(--border-default-grey, #dddddd);
+  border-radius: 3px;
+  background: #ffffff;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+}
+.empty-state-steps li.done::before {
+  background: var(--background-action-high-success, #18753c);
+  border-color: var(--background-action-high-success, #18753c);
+}
+.empty-state-steps li.done::after {
+  content: '';
+  position: absolute;
+  left: 0.22rem;
+  top: 0.44em;
+  width: 0.3rem;
+  height: 0.6rem;
+  border-right: 2px solid #ffffff;
+  border-bottom: 2px solid #ffffff;
+  transform: rotate(45deg);
+}
+.empty-state-steps li.done {
+  color: var(--text-default-grey, #3a3a3a);
+  text-decoration: line-through;
+  text-decoration-color: rgba(0, 0, 0, 0.15);
+}

--- a/apps/builder/src/styles/builder.css
+++ b/apps/builder/src/styles/builder.css
@@ -662,140 +662,48 @@ h3 .help-btn i {
 /* Responsive - les styles principaux sont dans app-layout-builder */
 
 /* ============================================================ */
-/* Progress stepper + section indicators (UX-005 #24)            */
-/* Scoped under .builder-config-panel for strong specificity.   */
+/* Section summaries + generate sub-text (UX-005 #24)            */
 /* ============================================================ */
 
-.builder-config-panel .progress-stepper {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.25rem;
-  padding: 0.625rem 0.75rem;
-  margin: 0 0 0.75rem;
-  border-radius: 4px;
-  background: var(--background-alt-grey, #f6f6f6);
-  overflow-x: auto;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-
-.builder-config-panel .progress-step {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 0.4rem;
-  flex: 0 0 auto;
-  font-size: 0.8125rem;
-  color: var(--text-mention-grey, #666666);
-  white-space: nowrap;
-}
-
-.builder-config-panel .progress-step-circle {
-  position: relative;
-  width: 1.5rem;
-  height: 1.5rem;
-  flex: 0 0 auto;
-  border-radius: 50%;
-  border: 2px solid var(--border-default-grey, #dddddd);
-  background: #ffffff;
-  color: var(--text-mention-grey, #666666);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.75rem;
-  font-weight: 700;
-  line-height: 1;
-  transition:
-    background 120ms ease,
-    border-color 120ms ease,
-    color 120ms ease;
-}
-
 /*
- * Using <span> text nodes (not <i class="ri-*">) avoids a clash with Remix
- * Icon's global `[class^="ri-"] { display: inline-block }` rule which would
- * otherwise keep the check mark visible on non-done steps.
+ * Short textual summary shown next to each section header ("Manuel test",
+ * "Barres verticales", "région × population"…). Lets the user read their
+ * current choices at a glance without expanding each section.
+ * Flex-1 with ellipsis so long values stay on one line next to the caret.
  */
-.builder-config-panel .progress-step-number {
-  display: inline-block;
-}
-.builder-config-panel .progress-step-check {
-  display: none;
+.builder-config-panel .config-section-header {
+  gap: 0.5rem;
 }
 
-.builder-config-panel .progress-step-label {
+.builder-config-panel .config-section-header h3 {
+  flex: 0 0 auto;
+}
+
+.builder-config-panel .section-summary {
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: 0.8125rem;
-  line-height: 1.1;
-  font-weight: 500;
+  font-weight: 400;
+  color: var(--text-mention-grey, #666666);
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-style: italic;
 }
 
-/* "current" — the first step not yet done. */
-.builder-config-panel .progress-step--current {
-  color: var(--text-default-grey, #3a3a3a);
-}
-.builder-config-panel .progress-step--current .progress-step-circle {
-  border-color: var(--background-action-high-blue-france, #000091);
-  color: var(--text-action-high-blue-france, #000091);
-}
-.builder-config-panel .progress-step--current .progress-step-label {
-  font-weight: 700;
-}
-
-/* "done" — pill fills blue, number hides, check appears. */
-.builder-config-panel .progress-step--done {
-  color: var(--text-default-grey, #3a3a3a);
-}
-.builder-config-panel .progress-step--done .progress-step-circle {
-  background: var(--background-action-high-blue-france, #000091);
-  border-color: var(--background-action-high-blue-france, #000091);
-  color: #ffffff;
-}
-.builder-config-panel .progress-step--done .progress-step-number {
+.builder-config-panel .section-summary[hidden] {
   display: none;
 }
-.builder-config-panel .progress-step--done .progress-step-check {
-  display: inline-block;
-}
 
-/* Collapse labels on very narrow panels to keep the stepper on one line. */
-@media (max-width: 480px) {
-  .builder-config-panel .progress-step-label {
-    display: none;
-  }
-}
-
-/* Section header status badge — ✓ or ◐ next to the <h3>. */
-.section-status {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 1.25rem;
-  height: 1.25rem;
-  margin-left: 0.5rem;
-  padding: 0 0.25rem;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  font-weight: 700;
-  line-height: 1;
-  vertical-align: baseline;
-}
-.section-status:empty {
-  display: none;
-}
-.section-status--done {
-  background: var(--background-contrast-success, #b8fec9);
-  color: var(--text-default-success, #18753c);
-}
-.section-status--partial {
-  background: var(--background-contrast-warning, #fff4b8);
+.builder-config-panel .section-summary--partial {
   color: var(--text-default-warning, #b34000);
+  font-style: normal;
 }
-.section-status--idle {
-  display: none;
+
+/* Collapsed sections: slightly dim the summary so the header chrome wins. */
+.builder-config-panel .config-section.collapsed .section-summary {
+  opacity: 0.85;
 }
 
 /* Generate-controls — ready variant + contextual sub-text. */

--- a/apps/builder/src/styles/builder.css
+++ b/apps/builder/src/styles/builder.css
@@ -156,16 +156,16 @@ body {
   height: 40px;
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  min-width: 0;
 }
 
-.source-grid-row2 {
-  margin-top: 0.5rem;
+/* "+ Nouvelle" link — aligned vertically with the select. */
+.source-new-link {
+  height: 40px;
+  display: inline-flex;
   align-items: center;
-}
-
-.source-info {
-  font-size: 0.8rem;
-  color: var(--text-mention-grey);
+  white-space: nowrap;
 }
 
 /* Responsive : reduire quand le panneau est etroit */

--- a/apps/builder/src/ui/help-tooltips.ts
+++ b/apps/builder/src/ui/help-tooltips.ts
@@ -5,7 +5,7 @@
  */
 
 import { TOOLTIPS } from './help-texts.js';
-import { state } from '../state.js';
+import { updateProgress } from './progress-indicator.js';
 
 let activePopover: HTMLElement | null = null;
 let activeBtn: HTMLElement | null = null;
@@ -96,28 +96,12 @@ function hidePopover(): void {
 }
 
 /**
- * Update the preview empty state steps (checkmarks).
- * Called after state changes that affect the steps.
+ * Update the preview empty state steps (checkmarks), the top stepper,
+ * section indicators and the Generate button sub-text.
+ *
+ * Backwards-compatible alias for `updateProgress()` — many call sites across
+ * the Builder still use this name.
  */
 export function updatePreviewSteps(): void {
-  const steps = document.querySelectorAll('.empty-state-steps li');
-  if (steps.length === 0) return;
-
-  const hasSource = state.fields && state.fields.length > 0;
-  const hasType = !!state.chartType;
-  const hasConfig = (() => {
-    if (state.chartType === 'datalist') return !!state.labelField;
-    if (state.chartType === 'kpi' || state.chartType === 'gauge') return !!state.valueField;
-    return !!state.labelField && !!state.valueField;
-  })();
-
-  steps.forEach((li) => {
-    const step = (li as HTMLElement).dataset.step;
-    let done = false;
-    if (step === 'source') done = hasSource;
-    else if (step === 'type') done = hasType;
-    else if (step === 'config') done = hasConfig;
-    // 'generate' is never checked here (it's done when the chart is actually generated)
-    li.classList.toggle('done', done);
-  });
+  updateProgress();
 }

--- a/apps/builder/src/ui/progress-indicator.ts
+++ b/apps/builder/src/ui/progress-indicator.ts
@@ -52,8 +52,13 @@ function joinChecked(labels: Array<string | false>): string {
 
 /** Human-readable summary for each configurable section. */
 function buildSummaries(s: BuilderState, c: Completeness): Record<string, SectionSummary | null> {
-  // Source — show name of the loaded source (or nothing if none).
-  const sourceName = s.savedSource?.name || s.savedSource?.id || '';
+  // Source — show name (+ record count when available) of the loaded source.
+  let sourceName = '';
+  if (s.savedSource) {
+    const name = s.savedSource.name || s.savedSource.id || '';
+    const count = s.savedSource.recordCount;
+    sourceName = count ? `${name} · ${count} lignes` : name;
+  }
 
   // Type of chart — label only when a source is loaded (so the default "bar"
   // doesn't mislead before the user interacts).

--- a/apps/builder/src/ui/progress-indicator.ts
+++ b/apps/builder/src/ui/progress-indicator.ts
@@ -1,138 +1,173 @@
 /**
- * Progress indicator UI — stepper + section badges + generate button status.
+ * Progress indicator UI — section summaries + generate button status.
  *
- * Pure DOM update functions. The DOM skeleton (stepper container,
- * section-status spans, generate-missing div) lives in apps/builder/index.html.
- * These functions fill/toggle classes based on a `Completeness` object.
+ * Shows a compact text summary next to each section header (source name,
+ * chart type, fields, palette, checked options…) so the user sees their
+ * choices at a glance without expanding each section. Also keeps the
+ * Generate-button sub-text ("Il manque : X, Y") and the empty-state
+ * checklist in sync with the state.
+ *
+ * Pure DOM update functions — the skeleton lives in apps/builder/index.html.
  */
 
 import { state, getCompleteness, type BuilderState, type Completeness } from '../state.js';
 
-/** Key identifying each stepper step. Order matters (left → right). */
-type StepperKey = 'source' | 'type' | 'config' | 'generate';
+type StepKey = 'source' | 'type' | 'config' | 'generate';
 
-const STEPPER_ORDER: readonly StepperKey[] = ['source', 'type', 'config', 'generate'] as const;
-
-const STEPPER_LABELS: Record<StepperKey, string> = {
-  source: 'Source',
-  type: 'Type',
-  config: 'Configuration',
-  generate: 'Générer',
-};
-
-/** DOM ids / classes used by index.html. */
-const STEPPER_ID = 'progress-stepper';
 const GENERATE_MISSING_ID = 'generate-missing';
 const GENERATE_BTN_ID = 'generate-btn';
 
-/**
- * Returns whether the chart has been generated at least once.
- * True while the preview iframe is visible (empty-state is hidden).
- */
+const CHART_TYPE_LABELS: Record<string, string> = {
+  bar: 'Barres verticales',
+  horizontalBar: 'Barres horizontales',
+  line: 'Courbe',
+  pie: 'Camembert',
+  doughnut: 'Anneau',
+  radar: 'Radar',
+  scatter: 'Nuage de points',
+  gauge: 'Jauge',
+  kpi: 'Indicateur KPI',
+  map: 'Carte',
+  datalist: 'Tableau',
+};
+
+/** One entry per section header — value is a short text summary (may be ''). */
+interface SectionSummary {
+  /** If 'partial', render the badge in warning colors; 'done' in neutral. */
+  tone: 'done' | 'partial';
+  text: string;
+}
+
+/** Returns whether the chart has been generated at least once. */
 function isGenerated(): boolean {
   const empty = document.getElementById('empty-state');
   if (!empty) return false;
   return empty.style.display === 'none' || window.getComputedStyle(empty).display === 'none';
 }
 
-/** Render/update the 4-step horizontal stepper. */
-function renderStepper(c: Completeness): void {
-  const container = document.getElementById(STEPPER_ID);
-  if (!container) return;
-
-  // First call — inject skeleton. One pill per step, no separator bars.
-  // Using <span>✓</span> (not <i class="ri-check-line">) avoids a conflict
-  // with Remix Icon's global `[class^="ri-"] { display: inline-block }` rule
-  // which would otherwise keep the check visible on non-done steps.
-  if (!container.dataset.ready) {
-    container.innerHTML = STEPPER_ORDER.map((key, index) =>
-      `
-        <div class="progress-step" data-step="${key}" role="listitem">
-          <span class="progress-step-circle" aria-hidden="true">
-            <span class="progress-step-number">${index + 1}</span>
-            <span class="progress-step-check">✓</span>
-          </span>
-          <span class="progress-step-label">${STEPPER_LABELS[key]}</span>
-        </div>
-      `.trim()
-    ).join('');
-    container.dataset.ready = '1';
-  }
-
-  // Find the first incomplete step (becomes "current").
-  const currentKey = STEPPER_ORDER.find((k) => !c[k]) ?? null;
-
-  container.querySelectorAll<HTMLElement>('.progress-step').forEach((el) => {
-    const key = el.dataset.step as StepperKey | undefined;
-    if (!key) return;
-    const done = c[key];
-    const current = key === currentKey;
-    el.classList.toggle('progress-step--done', done);
-    el.classList.toggle('progress-step--current', current);
-    el.setAttribute('aria-current', current ? 'step' : 'false');
-    el.setAttribute(
-      'aria-label',
-      `${STEPPER_LABELS[key]}: ${done ? 'complété' : current ? 'en cours' : 'à faire'}`
-    );
-  });
+/** Join an array of checked-option labels with commas, return '' if empty. */
+function joinChecked(labels: Array<string | false>): string {
+  return labels.filter(Boolean).join(', ');
 }
 
-/**
- * Map each `.config-section-header` to a completeness signal, then toggle
- * a status span inside the header. The span is injected once on first call.
- *
- * Design: only mark a section "done" when the user has actually interacted
- * with it (non-default value). Sections that stay on their defaults show no
- * badge. This avoids the "everything looks done before you started" illusion.
- */
-function renderSectionIndicators(s: BuilderState, c: Completeness): void {
-  const titleCustomized = !!s.title && s.title !== 'Mon graphique';
-  const sourceChosen = c.source && !!s.savedSource;
+/** Human-readable summary for each configurable section. */
+function buildSummaries(s: BuilderState, c: Completeness): Record<string, SectionSummary | null> {
+  // Source — show name of the loaded source (or nothing if none).
+  const sourceName = s.savedSource?.name || s.savedSource?.id || '';
 
-  // Evaluate each section individually. "done" / "partial" / "idle".
-  const sections: Record<string, 'done' | 'partial' | 'idle'> = {
-    'section-source': sourceChosen ? 'done' : 'idle',
-    // Type: the default is "bar" so we only mark done when fields are filled
-    // for that type (otherwise the user hasn't really moved past it).
-    'section-type': c.source && c.type && c.config ? 'done' : 'idle',
-    'section-data': (() => {
-      if (!c.source || !c.type) return 'idle';
-      return c.config ? 'done' : 'partial';
-    })(),
-    'section-appearance': titleCustomized ? 'done' : 'idle',
-    'section-generation-mode': s.generationMode === 'dynamic' ? 'done' : 'idle',
-    'section-normalize': s.normalizeConfig.enabled ? 'done' : 'idle',
-    'section-facets': s.facetsConfig.enabled ? 'done' : 'idle',
-    'section-databox': s.databoxEnabled ? 'done' : 'idle',
-    // Accessibility is enabled by default — only mark done when the user
-    // has actually described the chart for screen readers.
-    'section-a11y': s.a11yDescription.trim() ? 'done' : 'idle',
+  // Type of chart — label only when a source is loaded (so the default "bar"
+  // doesn't mislead before the user interacts).
+  const typeLabel = c.source && s.chartType ? CHART_TYPE_LABELS[s.chartType] || s.chartType : '';
+
+  // Configuration — depends on chart type.
+  let configText = '';
+  let configTone: 'done' | 'partial' = 'done';
+  if (c.source && s.chartType) {
+    if (c.config) {
+      switch (s.chartType) {
+        case 'datalist':
+          configText = s.labelField;
+          break;
+        case 'kpi':
+        case 'gauge':
+          configText = s.valueField;
+          break;
+        case 'map':
+          configText = `${s.codeField} → ${s.valueField}`;
+          break;
+        default: {
+          const extra = s.extraSeries?.length || 0;
+          const main = `${s.labelField} × ${s.valueField}`;
+          configText = extra > 0 ? `${main} (+${extra} série${extra > 1 ? 's' : ''})` : main;
+        }
+      }
+    } else {
+      configText = 'à compléter';
+      configTone = 'partial';
+    }
+  }
+
+  // Appearance — palette (hide when still on DSFR default).
+  const paletteText = s.palette && s.palette !== 'default' ? s.palette : '';
+
+  // Generation mode — mention only when dynamic (non-default).
+  const genModeText = s.generationMode === 'dynamic' ? 'dynamique' : '';
+
+  // Normalize / Facets / DataBox / A11y — list checked options or count.
+  const normalizeText = s.normalizeConfig.enabled ? 'activée' : '';
+
+  const facetsText = s.facetsConfig.enabled
+    ? `${s.facetsConfig.fields.length || 0} champ${
+        (s.facetsConfig.fields.length || 0) > 1 ? 's' : ''
+      }`
+    : '';
+
+  const databoxText = s.databoxEnabled
+    ? joinChecked([
+        !!s.databoxTitle && 'titre',
+        !!s.databoxSource && 'source',
+        !!s.databoxDate && 'date',
+        s.databoxDownload && 'téléchargement',
+        s.databoxScreenshot && 'capture',
+        s.databoxFullscreen && 'plein écran',
+        !!s.databoxTrend && 'tendance',
+      ]) || 'activé'
+    : '';
+
+  const a11yText = s.a11yEnabled
+    ? joinChecked([
+        s.a11yTable && 'tableau',
+        s.a11yDownload && 'téléchargement',
+        !!s.a11yDescription.trim() && 'description',
+      ])
+    : '';
+
+  return {
+    'section-source': sourceName ? { tone: 'done', text: sourceName } : null,
+    'section-type': typeLabel ? { tone: 'done', text: typeLabel } : null,
+    'section-data': configText ? { tone: configTone, text: configText } : null,
+    'section-appearance': paletteText ? { tone: 'done', text: paletteText } : null,
+    'section-generation-mode': genModeText ? { tone: 'done', text: genModeText } : null,
+    'section-normalize': normalizeText ? { tone: 'done', text: normalizeText } : null,
+    'section-facets': facetsText ? { tone: 'done', text: facetsText } : null,
+    'section-databox': databoxText ? { tone: 'done', text: databoxText } : null,
+    'section-a11y': a11yText ? { tone: 'done', text: a11yText } : null,
   };
+}
 
-  for (const [id, status] of Object.entries(sections)) {
+/** Inject/update `.section-summary` next to each section <h3>. */
+function renderSectionSummaries(s: BuilderState, c: Completeness): void {
+  const summaries = buildSummaries(s, c);
+  for (const [id, summary] of Object.entries(summaries)) {
     const section = document.getElementById(id);
     if (!section) continue;
     const header = section.querySelector<HTMLElement>('.config-section-header');
     if (!header) continue;
 
-    let indicator = header.querySelector<HTMLElement>('.section-status');
-    if (!indicator) {
-      indicator = document.createElement('span');
-      indicator.className = 'section-status';
-      indicator.setAttribute('aria-hidden', 'true');
-      // Insert after the first <h3> (or at end of header).
+    // Legacy dot-badge from the first iteration — remove it if present.
+    header.querySelector('.section-status')?.remove();
+
+    let summaryEl = header.querySelector<HTMLElement>('.section-summary');
+    if (!summaryEl) {
+      summaryEl = document.createElement('span');
+      summaryEl.className = 'section-summary';
+      // Insert right after <h3>, before the caret icon.
       const h3 = header.querySelector('h3');
       if (h3 && h3.parentNode === header) {
-        h3.insertAdjacentElement('afterend', indicator);
+        h3.insertAdjacentElement('afterend', summaryEl);
       } else {
-        header.appendChild(indicator);
+        header.appendChild(summaryEl);
       }
     }
 
-    indicator.classList.toggle('section-status--done', status === 'done');
-    indicator.classList.toggle('section-status--partial', status === 'partial');
-    indicator.classList.toggle('section-status--idle', status === 'idle');
-    indicator.textContent = status === 'done' ? '✓' : status === 'partial' ? '◐' : '';
+    if (summary) {
+      summaryEl.textContent = summary.text;
+      summaryEl.classList.toggle('section-summary--partial', summary.tone === 'partial');
+      summaryEl.hidden = false;
+    } else {
+      summaryEl.textContent = '';
+      summaryEl.hidden = true;
+    }
   }
 }
 
@@ -144,8 +179,6 @@ function renderGenerateButton(c: Completeness): void {
 
   if (btn) {
     btn.classList.toggle('fr-btn--ready', ready);
-    // Keep it always enabled — clicking still shows an informative toast for
-    // edge cases. The visual state carries the signal.
   }
 
   if (missingEl) {
@@ -163,7 +196,7 @@ function renderGenerateButton(c: Completeness): void {
 function renderEmptyStateChecklist(c: Completeness): void {
   const steps = document.querySelectorAll<HTMLElement>('.empty-state-steps li');
   steps.forEach((li) => {
-    const step = li.dataset.step as StepperKey | undefined;
+    const step = li.dataset.step as StepKey | undefined;
     if (!step) return;
     li.classList.toggle('done', c[step]);
   });
@@ -171,14 +204,13 @@ function renderEmptyStateChecklist(c: Completeness): void {
 
 /**
  * Public API — single entry point. Recompute completeness from the current
- * state and refresh all four UI surfaces.
+ * state and refresh all three UI surfaces.
  *
  * Safe to call as often as needed (cheap DOM reads/writes, no layout thrash).
  */
 export function updateProgress(): void {
   const c = getCompleteness(state, isGenerated());
-  renderStepper(c);
-  renderSectionIndicators(state, c);
+  renderSectionSummaries(state, c);
   renderGenerateButton(c);
   renderEmptyStateChecklist(c);
 }

--- a/apps/builder/src/ui/progress-indicator.ts
+++ b/apps/builder/src/ui/progress-indicator.ts
@@ -1,0 +1,184 @@
+/**
+ * Progress indicator UI — stepper + section badges + generate button status.
+ *
+ * Pure DOM update functions. The DOM skeleton (stepper container,
+ * section-status spans, generate-missing div) lives in apps/builder/index.html.
+ * These functions fill/toggle classes based on a `Completeness` object.
+ */
+
+import { state, getCompleteness, type BuilderState, type Completeness } from '../state.js';
+
+/** Key identifying each stepper step. Order matters (left → right). */
+type StepperKey = 'source' | 'type' | 'config' | 'generate';
+
+const STEPPER_ORDER: readonly StepperKey[] = ['source', 'type', 'config', 'generate'] as const;
+
+const STEPPER_LABELS: Record<StepperKey, string> = {
+  source: 'Source',
+  type: 'Type',
+  config: 'Configuration',
+  generate: 'Générer',
+};
+
+/** DOM ids / classes used by index.html. */
+const STEPPER_ID = 'progress-stepper';
+const GENERATE_MISSING_ID = 'generate-missing';
+const GENERATE_BTN_ID = 'generate-btn';
+
+/**
+ * Returns whether the chart has been generated at least once.
+ * True while the preview iframe is visible (empty-state is hidden).
+ */
+function isGenerated(): boolean {
+  const empty = document.getElementById('empty-state');
+  if (!empty) return false;
+  return empty.style.display === 'none' || window.getComputedStyle(empty).display === 'none';
+}
+
+/** Render/update the 4-step horizontal stepper. */
+function renderStepper(c: Completeness): void {
+  const container = document.getElementById(STEPPER_ID);
+  if (!container) return;
+
+  // First call — inject skeleton. One pill per step, no separator bars.
+  // Using <span>✓</span> (not <i class="ri-check-line">) avoids a conflict
+  // with Remix Icon's global `[class^="ri-"] { display: inline-block }` rule
+  // which would otherwise keep the check visible on non-done steps.
+  if (!container.dataset.ready) {
+    container.innerHTML = STEPPER_ORDER.map((key, index) =>
+      `
+        <div class="progress-step" data-step="${key}" role="listitem">
+          <span class="progress-step-circle" aria-hidden="true">
+            <span class="progress-step-number">${index + 1}</span>
+            <span class="progress-step-check">✓</span>
+          </span>
+          <span class="progress-step-label">${STEPPER_LABELS[key]}</span>
+        </div>
+      `.trim()
+    ).join('');
+    container.dataset.ready = '1';
+  }
+
+  // Find the first incomplete step (becomes "current").
+  const currentKey = STEPPER_ORDER.find((k) => !c[k]) ?? null;
+
+  container.querySelectorAll<HTMLElement>('.progress-step').forEach((el) => {
+    const key = el.dataset.step as StepperKey | undefined;
+    if (!key) return;
+    const done = c[key];
+    const current = key === currentKey;
+    el.classList.toggle('progress-step--done', done);
+    el.classList.toggle('progress-step--current', current);
+    el.setAttribute('aria-current', current ? 'step' : 'false');
+    el.setAttribute(
+      'aria-label',
+      `${STEPPER_LABELS[key]}: ${done ? 'complété' : current ? 'en cours' : 'à faire'}`
+    );
+  });
+}
+
+/**
+ * Map each `.config-section-header` to a completeness signal, then toggle
+ * a status span inside the header. The span is injected once on first call.
+ *
+ * Design: only mark a section "done" when the user has actually interacted
+ * with it (non-default value). Sections that stay on their defaults show no
+ * badge. This avoids the "everything looks done before you started" illusion.
+ */
+function renderSectionIndicators(s: BuilderState, c: Completeness): void {
+  const titleCustomized = !!s.title && s.title !== 'Mon graphique';
+  const sourceChosen = c.source && !!s.savedSource;
+
+  // Evaluate each section individually. "done" / "partial" / "idle".
+  const sections: Record<string, 'done' | 'partial' | 'idle'> = {
+    'section-source': sourceChosen ? 'done' : 'idle',
+    // Type: the default is "bar" so we only mark done when fields are filled
+    // for that type (otherwise the user hasn't really moved past it).
+    'section-type': c.source && c.type && c.config ? 'done' : 'idle',
+    'section-data': (() => {
+      if (!c.source || !c.type) return 'idle';
+      return c.config ? 'done' : 'partial';
+    })(),
+    'section-appearance': titleCustomized ? 'done' : 'idle',
+    'section-generation-mode': s.generationMode === 'dynamic' ? 'done' : 'idle',
+    'section-normalize': s.normalizeConfig.enabled ? 'done' : 'idle',
+    'section-facets': s.facetsConfig.enabled ? 'done' : 'idle',
+    'section-databox': s.databoxEnabled ? 'done' : 'idle',
+    // Accessibility is enabled by default — only mark done when the user
+    // has actually described the chart for screen readers.
+    'section-a11y': s.a11yDescription.trim() ? 'done' : 'idle',
+  };
+
+  for (const [id, status] of Object.entries(sections)) {
+    const section = document.getElementById(id);
+    if (!section) continue;
+    const header = section.querySelector<HTMLElement>('.config-section-header');
+    if (!header) continue;
+
+    let indicator = header.querySelector<HTMLElement>('.section-status');
+    if (!indicator) {
+      indicator = document.createElement('span');
+      indicator.className = 'section-status';
+      indicator.setAttribute('aria-hidden', 'true');
+      // Insert after the first <h3> (or at end of header).
+      const h3 = header.querySelector('h3');
+      if (h3 && h3.parentNode === header) {
+        h3.insertAdjacentElement('afterend', indicator);
+      } else {
+        header.appendChild(indicator);
+      }
+    }
+
+    indicator.classList.toggle('section-status--done', status === 'done');
+    indicator.classList.toggle('section-status--partial', status === 'partial');
+    indicator.classList.toggle('section-status--idle', status === 'idle');
+    indicator.textContent = status === 'done' ? '✓' : status === 'partial' ? '◐' : '';
+  }
+}
+
+/** Update the "Generate" button state + its missing-requirements sub-text. */
+function renderGenerateButton(c: Completeness): void {
+  const btn = document.getElementById(GENERATE_BTN_ID) as HTMLButtonElement | null;
+  const missingEl = document.getElementById(GENERATE_MISSING_ID);
+  const ready = c.source && c.type && c.config;
+
+  if (btn) {
+    btn.classList.toggle('fr-btn--ready', ready);
+    // Keep it always enabled — clicking still shows an informative toast for
+    // edge cases. The visual state carries the signal.
+  }
+
+  if (missingEl) {
+    if (ready) {
+      missingEl.textContent = '';
+      missingEl.hidden = true;
+    } else {
+      missingEl.textContent = `Il manque : ${c.missing.join(', ')}.`;
+      missingEl.hidden = false;
+    }
+  }
+}
+
+/** Update the checklist inside the preview empty-state. */
+function renderEmptyStateChecklist(c: Completeness): void {
+  const steps = document.querySelectorAll<HTMLElement>('.empty-state-steps li');
+  steps.forEach((li) => {
+    const step = li.dataset.step as StepperKey | undefined;
+    if (!step) return;
+    li.classList.toggle('done', c[step]);
+  });
+}
+
+/**
+ * Public API — single entry point. Recompute completeness from the current
+ * state and refresh all four UI surfaces.
+ *
+ * Safe to call as often as needed (cheap DOM reads/writes, no layout thrash).
+ */
+export function updateProgress(): void {
+  const c = getCompleteness(state, isGenerated());
+  renderStepper(c);
+  renderSectionIndicators(state, c);
+  renderGenerateButton(c);
+  renderEmptyStateChecklist(c);
+}

--- a/packages/shared/src/templates/cdn-versions.ts
+++ b/packages/shared/src/templates/cdn-versions.ts
@@ -52,7 +52,36 @@ export function getPreviewHTML(code: string): string {
   <script type="module" src="${CDN_URLS.dsfrChartJs}"></script>
   <script type="module" src="${origin}/dist/dsfr-data.esm.js"></script>
   <style>
-    body { padding: 1rem; font-family: Marianne, arial, sans-serif; }
+    html, body {
+      margin: 0;
+      overflow-x: hidden;
+      box-sizing: border-box;
+    }
+    body {
+      padding: 1rem;
+      font-family: Marianne, arial, sans-serif;
+      max-width: 100%;
+    }
+    *, *::before, *::after { box-sizing: inherit; }
+    /*
+     * The DSFR Chart Vue components (bar-chart, line-chart, pie-chart, …)
+     * render with an internal fixed-width canvas. Force the host elements
+     * and their canvas children to fit the iframe viewport so the preview
+     * never overflows horizontally / vertically.
+     */
+    dsfr-data-chart, dsfr-data-list, dsfr-data-kpi, dsfr-data-display,
+    dsfr-data-map, dsfr-data-world-map,
+    bar-chart, line-chart, pie-chart, doughnut-chart, radar-chart,
+    scatter-chart, horizontal-bar-chart, gauge-chart, map-chart, map-chart-reg,
+    kpi-indicator {
+      display: block;
+      max-width: 100%;
+      width: 100%;
+    }
+    canvas {
+      max-width: 100% !important;
+      height: auto !important;
+    }
   </style>
 </head>
 <body>

--- a/packages/shared/src/templates/cdn-versions.ts
+++ b/packages/shared/src/templates/cdn-versions.ts
@@ -58,7 +58,7 @@ export function getPreviewHTML(code: string): string {
       box-sizing: border-box;
     }
     body {
-      padding: 1rem;
+      padding: 1.5rem clamp(1rem, 8vw, 6rem);
       font-family: Marianne, arial, sans-serif;
       max-width: 100%;
     }

--- a/tests/apps/builder/completeness.test.ts
+++ b/tests/apps/builder/completeness.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import { getCompleteness, state } from '../../../apps/builder/src/state';
+import type { BuilderState, ChartType } from '../../../apps/builder/src/state';
+
+// Deep-clone the singleton so each test gets a fresh canvas without polluting
+// the app-level state used elsewhere in the suite.
+function baseState(): BuilderState {
+  return JSON.parse(JSON.stringify(state));
+}
+
+function withFields(s: BuilderState): BuilderState {
+  s.fields = [
+    { name: 'region', type: 'string', sample: 'Île-de-France' },
+    { name: 'population', type: 'number', sample: 12000 },
+    { name: 'code', type: 'string', sample: '75' },
+  ];
+  return s;
+}
+
+describe('getCompleteness', () => {
+  describe('empty state', () => {
+    it('reports all gates as incomplete and lists both missing', () => {
+      const s = baseState();
+      s.fields = [];
+      s.chartType = '' as ChartType;
+      const c = getCompleteness(s);
+      expect(c.source).toBe(false);
+      expect(c.type).toBe(false);
+      expect(c.config).toBe(false);
+      expect(c.generate).toBe(false);
+      expect(c.missing).toContain('une source de données');
+      expect(c.missing).toContain('un type de graphique');
+    });
+  });
+
+  describe('after loading a source', () => {
+    it('unlocks `source` and keeps `config` blocked until fields are picked', () => {
+      const s = withFields(baseState());
+      s.chartType = 'bar';
+      s.labelField = '';
+      s.valueField = '';
+      const c = getCompleteness(s);
+      expect(c.source).toBe(true);
+      expect(c.type).toBe(true);
+      expect(c.config).toBe(false);
+      expect(c.missing).toEqual(['le champ catégorie (axe X)', 'le champ numérique (axe Y)']);
+    });
+  });
+
+  describe('per chart-type config rules', () => {
+    it('bar/line/pie/doughnut/horizontalBar/radar/scatter require labelField + valueField', () => {
+      for (const t of [
+        'bar',
+        'line',
+        'pie',
+        'doughnut',
+        'horizontalBar',
+        'radar',
+        'scatter',
+      ] as const) {
+        const s = withFields(baseState());
+        s.chartType = t;
+        s.labelField = 'region';
+        s.valueField = 'population';
+        expect(getCompleteness(s).config, `config for ${t}`).toBe(true);
+
+        s.valueField = '';
+        expect(getCompleteness(s).config, `missing valueField for ${t}`).toBe(false);
+      }
+    });
+
+    it('kpi and gauge require only valueField', () => {
+      for (const t of ['kpi', 'gauge'] as const) {
+        const s = withFields(baseState());
+        s.chartType = t;
+        s.labelField = '';
+        s.valueField = 'population';
+        expect(getCompleteness(s).config, `config for ${t}`).toBe(true);
+
+        s.valueField = '';
+        expect(getCompleteness(s).config, `missing valueField for ${t}`).toBe(false);
+      }
+    });
+
+    it('datalist requires only labelField', () => {
+      const s = withFields(baseState());
+      s.chartType = 'datalist';
+      s.labelField = 'region';
+      s.valueField = '';
+      expect(getCompleteness(s).config).toBe(true);
+
+      s.labelField = '';
+      expect(getCompleteness(s).config).toBe(false);
+      expect(getCompleteness(s).missing).toContain('le champ à afficher');
+    });
+
+    it('map requires codeField + valueField', () => {
+      const s = withFields(baseState());
+      s.chartType = 'map';
+      s.codeField = 'code';
+      s.valueField = 'population';
+      expect(getCompleteness(s).config).toBe(true);
+
+      s.codeField = '';
+      const c = getCompleteness(s);
+      expect(c.config).toBe(false);
+      expect(c.missing).toContain('le champ code (département/région)');
+    });
+  });
+
+  describe('`generate` gate', () => {
+    it('stays false while the chart has not been rendered', () => {
+      const s = withFields(baseState());
+      s.chartType = 'bar';
+      s.labelField = 'region';
+      s.valueField = 'population';
+      expect(getCompleteness(s, false).generate).toBe(false);
+    });
+
+    it('flips to true only when generated=true AND config is complete', () => {
+      const s = withFields(baseState());
+      s.chartType = 'bar';
+      s.labelField = 'region';
+      s.valueField = 'population';
+      expect(getCompleteness(s, true).generate).toBe(true);
+    });
+
+    it('remains false if generated=true but config is still incomplete', () => {
+      const s = withFields(baseState());
+      s.chartType = 'bar';
+      s.labelField = '';
+      expect(getCompleteness(s, true).generate).toBe(false);
+    });
+  });
+
+  describe('missing list', () => {
+    it('is empty when every gate up to `config` is satisfied', () => {
+      const s = withFields(baseState());
+      s.chartType = 'bar';
+      s.labelField = 'region';
+      s.valueField = 'population';
+      expect(getCompleteness(s).missing).toEqual([]);
+    });
+
+    it('is purely informational — does not include the "generate" step', () => {
+      const s = withFields(baseState());
+      s.chartType = 'bar';
+      s.labelField = 'region';
+      s.valueField = 'population';
+      const c = getCompleteness(s, false);
+      expect(c.generate).toBe(false);
+      expect(c.missing).not.toContain('Générer');
+      expect(c.missing).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Implémente l'UX-005 (issue #24) avec plusieurs itérations en réponse à des retours visuels successifs.

## Changements principaux

### Résumé en ligne sur chaque section (remplace l'idée stepper + badges)
Chaque header de section affiche une synthèse des choix faits, en italique grisé, à droite du titre :

| Section | Résumé |
|---|---|
| Source de données | \`Manuel test · 3 lignes\` |
| Type de graphique | \`Barres verticales\` |
| Configuration des données | \`région × population\` (ou \`à compléter\` en orange) |
| Apparence | nom de palette (caché si défaut) |
| Mode génération | \`dynamique\` (caché si embedded) |
| Normalisation | \`activée\` |
| Filtres à facettes | \`3 champs\` |
| Habillage DataBox | cases activées (\`titre, téléchargement\`) |
| Accessibilité | cases activées (\`tableau, téléchargement, description\`) |

Les sections restées sur leur défaut n'affichent rien — évite l'effet "tout est déjà OK".

### Bouton Générer contextuel
Sous le bouton : \`Il manque : le champ catégorie (axe X), le champ numérique (axe Y).\` quand la config est incomplète. Le bouton lui-même passe en classe \`.fr-btn--ready\` quand tout est en place.

### Checklist empty-state
Les 4 \`<li>\` de l'empty-state preview se cochent dynamiquement (CSS pseudo-éléments \`::before\` / \`::after\` + \`.done\` toggle).

### Section Source compactée à une seule ligne
Après retour utilisateur : \`[ select 'Source' | bouton 'Voir' dynamique | + Nouvelle ]\`. Le bouton 'Charger' a disparu — \`handleSavedSourceChange()\` appelle désormais \`loadFields()\` automatiquement au changement. Le badge + compteur d'enregistrements sont remontés dans le résumé de section.

### Preview iframe — scrollbars résolus
- Hauteur de l'iframe : \`calc(100vh - 280px); min-height: 460px\` (au lieu de \`min-height: 400px\` fixe) — absorbe tout l'espace dispo sans scroll vertical.
- Le companion \`<dsfr-data-a11y>\` dupliqué hors iframe a été retiré : celui généré dans le code iframe suffit.
- Padding horizontal du body iframe : \`clamp(1rem, 8vw, 6rem)\` — marge de ~8% de chaque côté autour du chart, adaptatif.
- CSS dans \`getPreviewHTML\` force les composants DSFR Chart Vue (\`bar-chart\`, \`line-chart\`, …) + leur \`<canvas>\` à \`max-width: 100%\` pour tuer le scroll horizontal aussi.

### Layout 38/62
\`<app-layout-builder left-ratio=\"38\" min-right-width=\"480\">\` — donne de la place au preview sans étouffer la config.

## Fonction pure exportée

\`getCompleteness(state, generated)\` dans [state.ts](apps/builder/src/state.ts) → \`{ source, type, config, generate, missing[] }\` pour les 11 types de chart. Centralise toute la logique de validation ; appelée par chaque surface UI.

## Tests

- 11 tests unitaires ciblant \`getCompleteness\` ([tests/apps/builder/completeness.test.ts](tests/apps/builder/completeness.test.ts))
- Full suite : 2874/2874 verts
- Lint OK, format OK, typecheck OK

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)