### PR TITLE
feat(header): 'Beta {version}' badge and drop experimental warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,11 +131,6 @@
   <!-- Contenu principal -->
   <main class="fr-pb-8w" id="main-content">
     <div class="fr-container">
-      <!-- Avertissement -->
-      <div class="fr-alert fr-alert--warning fr-mt-4w">
-        <p>Cette application est experimentale, elle evolue chaque jour et peut donc se reveler tres instable le temps du developpement.</p>
-      </div>
-
       <!-- Présentation du projet -->
       <div class="fr-callout fr-my-4w">
         <p class="fr-callout__text">

--- a/packages/core/src/components/layout/app-header.ts
+++ b/packages/core/src/components/layout/app-header.ts
@@ -2,6 +2,10 @@ import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { checkAuth, logout, onAuthChange, isDbMode, onSyncStatusChange } from '@dsfr-data/shared';
 import type { User, SyncStatus } from '@dsfr-data/shared';
+import pkg from '../../../package.json' with { type: 'json' };
+
+/** Version de la librairie `dsfr-data` — lue au build depuis packages/core/package.json. */
+const PACKAGE_VERSION: string = pkg.version;
 
 // Side-effect import: register custom elements
 import './auth-modal.js';
@@ -315,7 +319,7 @@ export class AppHeader extends LitElement {
                     style="display:flex;align-items:center;gap:0.5rem;"
                   >
                     <span class="fr-badge fr-badge--sm fr-badge--warning fr-badge--no-icon"
-                      >En developpement</span
+                      >Beta ${PACKAGE_VERSION}</span
                     >
                     Création de visualisations dynamiques conformes DSFR
                   </p>


### PR DESCRIPTION
Two front-facing polish items:

1. **Header badge** — 'En developpement' → '**Beta {version}**'. The version is read at build time from [`packages/core/package.json`](packages/core/package.json) (we already have `resolveJsonModule: true` in tsconfig) and baked into every bundle that imports `<app-header>`. Once [#123](https://github.com/bmatge/dsfr-data/pull/123) lands on main, every app will display **Beta 0.6.0** without any further code change.

2. **Warning banner** — removed the `.fr-alert--warning` banner on the Hub index.html that read '*Cette application est experimentale, elle evolue chaque jour et peut donc se reveler tres instable le temps du developpement.*'. No longer accurate — the suite has a proper Beta label in the header and a stable release cadence via Changesets / npm.

## Test plan
- [x] `npm run typecheck` → OK
- [x] `npm run lint` → OK
- [x] `npm run format:check` → OK
- [x] `npm run build` (biblio) → bundles générés avec la version injectée dans le markup du header
- [x] `npm run test:run` → 2874/2874
- [ ] CI verte

🤖 Generated with [Claude Code](https://claude.com/claude-code)