### PR TITLE
fix(docker): chown html/public + auto-fix beacon-logs volume perms

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,9 +61,13 @@ COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # IA default proxy server (serves /ia-server-config and /ia-proxy-default)
 COPY scripts/ia-default-server.js /app/scripts/ia-default-server.js
 
-# Donner à l'utilisateur `nginx` l'écriture sur les répertoires de cache,
-# de logs (beacon-logs volume) et le workspace /app (MCP + ia-default).
-RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /app \
+# Donner à l'utilisateur `nginx` l'écriture sur les répertoires que
+# l'entrypoint écrira :
+# - /var/cache/nginx  : proxy_cache_path
+# - /var/log/nginx    : access/error/beacon.log (volume nommé en runtime)
+# - /app              : MCP + ia-default workspace
+# - /usr/share/nginx/html/public : parse-beacon-logs.sh y écrit monitoring-data.json
+RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /app /usr/share/nginx/html/public \
  && chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/parse-beacon-logs.sh
 
 USER nginx

--- a/docker/Dockerfile.db
+++ b/docker/Dockerfile.db
@@ -74,8 +74,12 @@ COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # IA default proxy server (serves /ia-server-config and /ia-proxy-default)
 COPY scripts/ia-default-server.js /app/scripts/ia-default-server.js
 
-# Ownership au user `nginx` sur les répertoires que l'entrypoint écrira.
-RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /app \
+# Ownership au user `nginx` sur les répertoires que l'entrypoint écrira :
+# - /var/cache/nginx : proxy_cache_path
+# - /var/log/nginx   : access/error/beacon.log (volume nommé en runtime)
+# - /app             : Express + MCP + ia-default workspace
+# - /usr/share/nginx/html/public : parse-beacon-logs.sh y écrit monitoring-data.json
+RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /app /usr/share/nginx/html/public \
  && chmod +x /usr/local/bin/docker-entrypoint.sh /usr/local/bin/parse-beacon-logs.sh
 
 USER nginx

--- a/docker/deploy-server.sh
+++ b/docker/deploy-server.sh
@@ -49,16 +49,30 @@ else
   fi
 fi
 
-echo -e "${YELLOW}1/4${NC} Mise a jour du code..."
+echo -e "${YELLOW}1/5${NC} Mise a jour du code..."
 git pull
 
-echo -e "${YELLOW}2/4${NC} Build de l'image (sans cache)..."
+echo -e "${YELLOW}2/5${NC} Build de l'image (sans cache)..."
 $COMPOSE build --no-cache
 
-echo -e "${YELLOW}3/4${NC} Arret des conteneurs..."
+echo -e "${YELLOW}3/5${NC} Arret des conteneurs..."
 $COMPOSE down
 
-echo -e "${YELLOW}4/4${NC} Demarrage des conteneurs..."
+# Depuis PR #113, nginx tourne en non-root (uid 101). Les volumes nommes
+# crees avant ce changement ont un ownership root:root qui masque le chown
+# fait dans le Dockerfile. Idempotent : chown -R 101:101 le volume beacon-logs
+# avant `up`. Safe aussi sur un volume fresh ou un deploiement from scratch.
+echo -e "${YELLOW}4/5${NC} Fix permissions volumes nginx non-root..."
+BEACON_VOL=$(docker volume ls --format '{{.Name}}' | grep -E '(^|_)beacon-logs$' | head -1 || true)
+if [ -n "$BEACON_VOL" ]; then
+  echo "  chown -R 101:101 sur $BEACON_VOL"
+  docker run --rm -v "${BEACON_VOL}:/data" --user root alpine:3 \
+    chown -R 101:101 /data
+else
+  echo -e "  ${YELLOW}(aucun volume beacon-logs existant — sera cree au up)${NC}"
+fi
+
+echo -e "${YELLOW}5/5${NC} Demarrage des conteneurs..."
 $COMPOSE up -d
 
 echo ""


### PR DESCRIPTION
## Contexte

Après l'upgrade vers `0.6.0` en production, le conteneur nginx entrait en boucle de redémarrage avec :

```
nginx: [emerg] open() "/var/log/nginx/beacon.log" failed (13: Permission denied)
/usr/local/bin/parse-beacon-logs.sh: line 24: can't create /usr/share/nginx/html/public/monitoring-data.json: Permission denied
```

Deux bugs distincts liés au passage nginx non-root de la [PR #113](https://github.com/bmatge/dsfr-data/pull/113) :

### 1. `/usr/share/nginx/html/public` manquait du `chown`

Les deux Dockerfiles (`docker/Dockerfile` et `docker/Dockerfile.db`) font `chown -R nginx:nginx /var/cache/nginx /var/log/nginx /app` avant `USER nginx`, mais oublient `/usr/share/nginx/html/public/` où [scripts/parse-beacon-logs.sh](scripts/parse-beacon-logs.sh) écrit `monitoring-data.json`. Sous uid 101, le write fail avec `Permission denied` sur un build frais. Fix : ajouter ce path aux deux RUN.

### 2. Le volume `beacon-logs` pré-existant garde l'ownership root:root

Quand Docker monte un volume nommé pré-existant sur un chemin déjà `chown` dans l'image, **le volume écrase l'ownership du chemin**. Le volume `beacon-logs` a été créé avant le switch non-root, avec `root:root`. Sur tout déploiement upgradé, nginx uid 101 ne peut plus y écrire.

Pas résolvable côté Dockerfile. Fix : ajout d'un step idempotent dans [`docker/deploy-server.sh`](docker/deploy-server.sh) :

```bash
BEACON_VOL=$(docker volume ls --format '{{.Name}}' | grep -E '(^|_)beacon-logs$' | head -1 || true)
if [ -n "$BEACON_VOL" ]; then
  docker run --rm -v "${BEACON_VOL}:/data" --user root alpine:3 \
    chown -R 101:101 /data
fi
```

Tourne entre `compose down` et `compose up`, safe sur un volume fresh ou une instance déjà migrée, indépendant de `COMPOSE_PROJECT_NAME`.

## Validation

- [x] `bash -n docker/deploy-server.sh` → syntaxe OK
- [x] Fix manuel one-shot sur prod : `chown` du volume + restart → conteneur sain, app à nouveau accessible
- [ ] CI verte

🤖 Generated with [Claude Code](https://claude.com/claude-code)