### PR TITLE
chore(front): narrower sidemenu + fix TS rootDir warning from version import

### DIFF
--- a/.changeset/perky-yaks-tell.md
+++ b/.changeset/perky-yaks-tell.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': patch
+---
+
+**app-sidemenu** : resserrage du menu latéral du guide de `280px` à `220px`. Les libellés longs (entrées sur deux lignes) sont désormais autorisés via `white-space: normal` + `word-break: break-word` sur `.fr-sidemenu__link` et `.fr-sidemenu__btn`. Le contenu principal gagne en largeur sans tronquer les titres.

--- a/packages/core/src/components/layout/app-header.ts
+++ b/packages/core/src/components/layout/app-header.ts
@@ -2,10 +2,7 @@ import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { checkAuth, logout, onAuthChange, isDbMode, onSyncStatusChange } from '@dsfr-data/shared';
 import type { User, SyncStatus } from '@dsfr-data/shared';
-import pkg from '../../../package.json' with { type: 'json' };
-
-/** Version de la librairie `dsfr-data` — lue au build depuis packages/core/package.json. */
-const PACKAGE_VERSION: string = pkg.version;
+import { VERSION as PACKAGE_VERSION } from '../../version.js';
 
 // Side-effect import: register custom elements
 import './auth-modal.js';

--- a/packages/core/src/components/layout/app-sidemenu.ts
+++ b/packages/core/src/components/layout/app-sidemenu.ts
@@ -196,7 +196,7 @@ export class AppSidemenu extends LitElement {
 
       <style>
         .guide-sidemenu {
-          flex: 0 0 280px;
+          flex: 0 0 220px;
           position: sticky;
           top: 1rem;
           height: fit-content;
@@ -209,6 +209,14 @@ export class AppSidemenu extends LitElement {
             flex: none;
             max-height: none;
           }
+        }
+        /* Autoriser les libellés longs à s'étaler sur 2 lignes au lieu de
+           forcer une largeur de menu plus grande. */
+        .guide-sidemenu .fr-sidemenu__link,
+        .guide-sidemenu .fr-sidemenu__btn {
+          white-space: normal;
+          word-break: break-word;
+          line-height: 1.3;
         }
         .fr-sidemenu__link[aria-current='true'] {
           font-weight: 700;

--- a/packages/core/src/version.ts
+++ b/packages/core/src/version.ts
@@ -1,0 +1,7 @@
+/**
+ * Version publique de la librairie `dsfr-data`, synchronisee depuis
+ * `packages/core/package.json` par `scripts/sync-versions.ts`.
+ *
+ * Ne pas editer a la main — regenere a chaque `npm run version-packages`.
+ */
+export const VERSION = '0.6.0';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "declarationDir": "dist",
     "emitDeclarationOnly": true,
+    "rootDir": "./src",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/scripts/sync-versions.ts
+++ b/scripts/sync-versions.ts
@@ -2,6 +2,8 @@
  * Synchronise la version du package.json root vers :
  * - src-tauri/tauri.conf.json
  * - src-tauri/Cargo.toml
+ * - packages/core/src/version.ts (source TS de la version, importee par
+ *   <app-header> pour afficher "Beta {version}" sans sortir du rootDir)
  *
  * Usage : npx vite-node scripts/sync-versions.ts
  */
@@ -27,8 +29,24 @@ const oldCargoVersion = cargo.match(/^version = "(.+)"$/m)?.[1];
 cargo = cargo.replace(/^version = ".+"$/m, `version = "${version}"`);
 writeFileSync(cargoPath, cargo);
 
+// packages/core/src/version.ts — source TS de la version
+const versionTsPath = resolve(root, 'packages/core/src/version.ts');
+const oldVersionTs = readFileSync(versionTsPath, 'utf-8').match(/VERSION = '(.+)'/)?.[1];
+const versionTsContent = `/**
+ * Version publique de la librairie \`dsfr-data\`, synchronisee depuis
+ * \`packages/core/package.json\` par \`scripts/sync-versions.ts\`.
+ *
+ * Ne pas editer a la main — regenere a chaque \`npm run version-packages\`.
+ */
+export const VERSION = '${version}';
+`;
+writeFileSync(versionTsPath, versionTsContent);
+
 console.log(`Version synchronisee : ${version}`);
 if (oldTauriVersion !== version)
   console.log(`  tauri.conf.json : ${oldTauriVersion} -> ${version}`);
 if (oldCargoVersion !== version) console.log(`  Cargo.toml : ${oldCargoVersion} -> ${version}`);
-if (oldTauriVersion === version && oldCargoVersion === version) console.log('  Deja a jour.');
+if (oldVersionTs !== version)
+  console.log(`  packages/core/src/version.ts : ${oldVersionTs} -> ${version}`);
+if (oldTauriVersion === version && oldCargoVersion === version && oldVersionTs === version)
+  console.log('  Deja a jour.');


### PR DESCRIPTION
Deux petits ajustements front regroupés.

## 1. Sidemenu du guide resserré

Le `app-sidemenu` à 280px de large mangeait trop de contenu et les titres longs restaient coupés.

- `.guide-sidemenu` : `flex: 0 0 280px` → `flex: 0 0 220px`
- `.guide-sidemenu .fr-sidemenu__link, .guide-sidemenu .fr-sidemenu__btn` : `white-space: normal` + `word-break: break-word` + `line-height: 1.3` → les entrées longues passent sur 2 lignes proprement.

Changeset `patch` présent.

## 2. Fix warning TS rootDir

Le header `Beta {version}` livré dans [#125](https://github.com/bmatge/dsfr-data/pull/125) importait la version via `import pkg from '../../../package.json' with { type: 'json' }`. Ce JSON est **hors** de `./src`, ce qui faisait râler le TS server dans VS Code :

> The common source directory of 'tsconfig.json' is './src'. The 'rootDir' setting must be explicitly set to this or another path to adjust your output's file layout.

Fix :
- [`packages/core/tsconfig.json`](packages/core/tsconfig.json) : ajout explicite de `"rootDir": "./src"`.
- Nouveau [`packages/core/src/version.ts`](packages/core/src/version.ts) exporte `VERSION = '0.6.0'` (dans `rootDir`).
- [`scripts/sync-versions.ts`](scripts/sync-versions.ts) regénère ce fichier à chaque `npm run version-packages` (nouvelle ligne dans le log : `packages/core/src/version.ts : 0.5.1 -> 0.6.0`).
- `<app-header>` : `import { VERSION as PACKAGE_VERSION } from '../../version.js'` remplace l'import JSON.

## Validation

- [x] `npm run typecheck` OK
- [x] `npm run build` (biblio) OK
- [x] `npm run test:run` → 2874/2874
- [x] `npm run lint` + `format:check` OK
- [x] Plus de warning rootDir dans l'IDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)