### PR TITLE
fix(apps): align DSFR template + enable OS dark/light (v0.7.1)

### DIFF
--- a/apps/admin/index.html
+++ b/apps/admin/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/builder-carto/index.html
+++ b/apps/builder-carto/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Generateur de cartes - dsfr-data</title>
+  <style>@view-transition{navigation:auto}app-header:not(:defined){display:block;min-height:56px}app-footer:not(:defined){display:block;min-height:48px}</style>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">

--- a/apps/builder-carto/index.html
+++ b/apps/builder-carto/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/builder-ia/index.html
+++ b/apps/builder-ia/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/builder-ia/index.html
+++ b/apps/builder-ia/index.html
@@ -267,6 +267,9 @@ Sois concis. Reponds en francais.</textarea>
     </div>
   </div>
 
+  <!-- Footer -->
+  <app-footer base-path="../../"></app-footer>
+
   <script type="module" src="src/main.ts"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
 </body>

--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -743,6 +743,9 @@
     <div class="help-popover-content" id="help-popover-content"></div>
   </div>
 
+  <!-- Footer -->
+  <app-footer base-path="../../"></app-footer>
+
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/favorites/index.html
+++ b/apps/favorites/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/grist-widgets/chart/index.html
+++ b/apps/grist-widgets/chart/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/grist-widgets/datalist/index.html
+++ b/apps/grist-widgets/datalist/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/grist-widgets/index.html
+++ b/apps/grist-widgets/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/grist-widgets/test-local.html
+++ b/apps/grist-widgets/test-local.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/monitoring/index.html
+++ b/apps/monitoring/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/pipeline-helper/index.html
+++ b/apps/pipeline-helper/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/pipeline-helper/index.html
+++ b/apps/pipeline-helper/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>dsfr-data — Flux de données</title>
+  <style>@view-transition{navigation:auto}app-header:not(:defined){display:block;min-height:56px}app-footer:not(:defined){display:block;min-height:48px}</style>
 
   <!-- DSFR CDN -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
@@ -120,5 +121,10 @@
       </div>
     </div>
   </div>
+
+  <!-- Footer -->
+  <app-footer base-path="../../"></app-footer>
+
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/sources/index.html
+++ b/apps/sources/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/apps/sources/index.html
+++ b/apps/sources/index.html
@@ -593,6 +593,10 @@
     </div>
   </div>
 
+  <!-- Footer -->
+  <app-footer base-path="../../"></app-footer>
+
   <script type="module" src="src/main.ts"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/e2e/industrie-du-futur.html
+++ b/e2e/industrie-du-futur.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/examples/exemple-france-num.html
+++ b/guide/examples/exemple-france-num.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/guide/examples/exemple-masa-v1.html
+++ b/guide/examples/exemple-masa-v1.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/guide/examples/exemple-masa-v2.html
+++ b/guide/examples/exemple-masa-v2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/guide/guide-demo-complete.html
+++ b/guide/guide-demo-complete.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemple-ODS.html
+++ b/guide/guide-exemple-ODS.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-chart-a11y.html
+++ b/guide/guide-exemples-chart-a11y.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-display.html
+++ b/guide/guide-exemples-display.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-facets.html
+++ b/guide/guide-exemples-facets.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-ghibli.html
+++ b/guide/guide-exemples-ghibli.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-insee-erfs.html
+++ b/guide/guide-exemples-insee-erfs.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-join.html
+++ b/guide/guide-exemples-join.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-maires.html
+++ b/guide/guide-exemples-maires.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-map.html
+++ b/guide/guide-exemples-map.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-normalize.html
+++ b/guide/guide-exemples-normalize.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-podium.html
+++ b/guide/guide-exemples-podium.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-query.html
+++ b/guide/guide-exemples-query.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-search.html
+++ b/guide/guide-exemples-search.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-source.html
+++ b/guide/guide-exemples-source.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-exemples-world-map.html
+++ b/guide/guide-exemples-world-map.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-grist-widgets.html
+++ b/guide/guide-grist-widgets.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide-parcours.html
+++ b/guide/guide-parcours.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/guide/guide.html
+++ b/guide/guide.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # dsfr-data
 
+## 0.7.1
+
+### Patch Changes
+
+- **Apps** : alignement du template DSFR sur toutes les pages de la webapp. Le footer `<app-footer>` manquait dans `builder`, `builder-ia`, `sources` et `pipeline-helper`. Le module `dsfr.module.min.js` (requis pour le menu mobile de `<app-header>` et les modales DSFR) manquait dans `sources` et `pipeline-helper`. Le style de pré-chargement `view-transition` manquait dans `pipeline-helper` et `builder-carto`. Toutes les pages partagent maintenant la même shell DSFR, sauf `grist-widgets` (exclusion légitime : widget embarqué dans Grist).
+- **Dark mode OS** : remplacement de `data-fr-theme` (attribut sans valeur, inopérant en DSFR 1.14) par `data-fr-scheme="system"` sur l'ensemble des pages HTML (apps, guide, specs, exemples). Le JS DSFR calcule désormais `data-fr-theme` automatiquement selon `prefers-color-scheme` de l'OS, activant le support natif light/dark partout.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsfr-data",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Bibliotheque de Web Components de dataviz pour sites gouvernementaux",
   "repository": {
     "type": "git",

--- a/specs/apis/generic.html
+++ b/specs/apis/generic.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/apis/grist.html
+++ b/specs/apis/grist.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/apis/insee.html
+++ b/specs/apis/insee.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/apis/opendatasoft.html
+++ b/specs/apis/opendatasoft.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/apis/tabular.html
+++ b/specs/apis/tabular.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/charts/bar-chart.html
+++ b/specs/charts/bar-chart.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/charts/gauge-chart.html
+++ b/specs/charts/gauge-chart.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/charts/index.html
+++ b/specs/charts/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/charts/line-chart.html
+++ b/specs/charts/line-chart.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/charts/map-chart.html
+++ b/specs/charts/map-chart.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/charts/pie-chart.html
+++ b/specs/charts/pie-chart.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/charts/radar-chart.html
+++ b/specs/charts/radar-chart.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/charts/scatter-chart.html
+++ b/specs/charts/scatter-chart.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-a11y.html
+++ b/specs/components/dsfr-data-a11y.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-chart.html
+++ b/specs/components/dsfr-data-chart.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-display.html
+++ b/specs/components/dsfr-data-display.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-facets.html
+++ b/specs/components/dsfr-data-facets.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-join.html
+++ b/specs/components/dsfr-data-join.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-kpi.html
+++ b/specs/components/dsfr-data-kpi.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-list.html
+++ b/specs/components/dsfr-data-list.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-map.html
+++ b/specs/components/dsfr-data-map.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-normalize.html
+++ b/specs/components/dsfr-data-normalize.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-podium.html
+++ b/specs/components/dsfr-data-podium.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-query.html
+++ b/specs/components/dsfr-data-query.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-search.html
+++ b/specs/components/dsfr-data-search.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-source.html
+++ b/specs/components/dsfr-data-source.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/components/dsfr-data-world-map.html
+++ b/specs/components/dsfr-data-world-map.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/specs/index.html
+++ b/specs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" data-fr-theme>
+<html lang="fr" data-fr-scheme="system">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.7.0"
+version = "0.7.1"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Charts Builder DSFR",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "identifier": "fr.gouv.charts-builder",
   "build": {
     "frontendDist": "../app-dist",


### PR DESCRIPTION
## Summary

Audit origine : le header / footer / mode sombre ne semblaient pas partagés de façon cohérente entre les pages de la webapp. Résultat de l'audit : header et footer **sont** déjà factorisés (`<app-header>` / `<app-footer>` dans `packages/core/src/components/layout/`), mais l'intégration était incomplète dans plusieurs apps, et l'attribut DSFR pour le thème était mal posé partout.

Trois changements, tous patch :

### 1. Alignement du template DSFR sur 5 apps (`395aebc`)
| App | Ce qui manquait |
|---|---|
| `apps/builder/index.html` | `<app-footer>` |
| `apps/builder-ia/index.html` | `<app-footer>` |
| `apps/sources/index.html` | `<app-footer>` + `dsfr.module.min.js` |
| `apps/pipeline-helper/index.html` | view-transition style + `<app-footer>` + `dsfr.module.min.js` |
| `apps/builder-carto/index.html` | view-transition style |

Sans `dsfr.module.min.js`, le menu mobile de `<app-header>` et les modales DSFR ne fonctionnaient pas (`sources`, `pipeline-helper`).

`grist-widgets` reste intentionnellement hors template (widget embarqué dans Grist).

### 2. Support light/dark OS via `data-fr-scheme="system"` (`7f51c1c`)
L'attribut `data-fr-theme` sans valeur (présent sur `<html>` dans toutes les pages) ne déclenche pas le switch de thème en DSFR 1.14 — DSFR lit `data-fr-scheme` et calcule `data-fr-theme` selon `prefers-color-scheme`. Les utilisateurs en OS dark voyaient donc toujours la UI light.

Remplacement sur 66 fichiers HTML (apps, hub, guide, specs, exemples, grist-widgets, e2e). Pas de toggle UI — on suit simplement l'OS.

### 3. Release v0.7.1 (`07701df`)
- `packages/core/package.json` : 0.7.0 → 0.7.1
- `src-tauri/tauri.conf.json` : 0.7.0 → 0.7.1
- `src-tauri/Cargo.toml` : 0.7.0 → 0.7.1
- `packages/core/CHANGELOG.md` : nouvelle entrée 0.7.1

Note : bump fait manuellement (sans `npm run version-packages` / `npx changeset version`) parce que `node_modules` n'était pas disponible dans l'environnement de travail. Aucun changeset à consommer (les modifs ne touchent pas `packages/core/src/` ni `packages/shared/`, donc le check CI changesets ne s'applique pas).

## Test plan

- [ ] Ouvrir chaque app (builder, builder-ia, sources, pipeline-helper, builder-carto) et vérifier la présence du footer DSFR en bas de page
- [ ] Sur `sources` et `pipeline-helper`, vérifier que le menu mobile (< 991px) du header s'ouvre bien, et que les modales DSFR fonctionnent
- [ ] Basculer l'OS en dark mode → toutes les pages doivent passer en sombre automatiquement (à vérifier sur hub, une app, une page guide, une spec)
- [ ] Rebasculer en light → retour au thème clair
- [ ] CI verte (lint, tests, build)
- [ ] Après merge : tag `v0.7.1` sur main, vérifier que `npm-publish.yml` et `release.yml` se déclenchent
