### PR TITLE
feat(builder): tri par champ libre + ordre source preserve

### DIFF
--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -69,7 +69,8 @@ Elle est distincte du code embarquable HTML (voir skills composants dsfr-data).
 | aggregation | String | non | Fonction : sum, avg, count, min, max |
 | where | String | non | Filtre pre-agregation (voir syntaxe ci-dessous) |
 | limit | Number | non | Nombre max de resultats |
-| sortOrder | String | non | Tri : "asc" ou "desc" |
+| sortOrder | String | non | Tri : "asc", "desc" ou "none" (preserve l'ordre source — utile pour mois/jours/series temporelles deja ordonnees en amont) |
+| sortField | String | non | Champ de tri. Vide = trie par valeur agregee (defaut). Mettre labelField pour tri alphabetique sur les categories. |
 | title | String | non | Titre affiche |
 | subtitle | String | non | Sous-titre affiche |
 | color | String | non | Couleur primaire hex (defaut: #000091) |
@@ -364,7 +365,7 @@ Apres agregation, les champs sont nommes automatiquement : \`champ__fonction\`
 | filter | String | \`""\` | non | Alias de where (compatibilite) |
 | group-by | String | \`""\` | non | Champs de groupement (separes par virgule) |
 | aggregate | String | \`""\` | non | Agregations : \`"champ:fonction"\` ou \`"champ:fonction:alias"\` |
-| order-by | String | \`""\` | non | Tri : \`"champ:asc"\` ou \`"champ:desc"\` |
+| order-by | String | \`""\` | non | Tri : \`"champ:asc"\` ou \`"champ:desc"\`. **Omettre cet attribut preserve l'ordre source** (ordre de premiere apparition apres group-by) — utile pour les mois en lettres, jours de la semaine, ou toute serie deja ordonnee en amont. |
 | limit | Number | \`0\` | non | Limite de resultats (0 = illimite) |
 | transform | String | \`""\` | non | Chemin JSONPath dans les donnees recues |
 | refresh | Number | \`0\` | non | Rafraichissement en secondes (0 = desactive) |

--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -257,15 +257,27 @@
         </div>
 
         <!-- Tri -->
-        <div class="fr-select-group fr-select-group--sm fr-mt-1w">
-          <label class="fr-label" for="sort-order">
-            Tri
-            <button type="button" class="help-btn" aria-label="Aide" aria-describedby="help-sort-order" data-help="sort-order"><i class="ri-question-line" aria-hidden="true"></i></button>
-          </label>
-          <select class="fr-select" id="sort-order">
-            <option value="desc">Decroissant</option>
-            <option value="asc">Croissant</option>
-          </select>
+        <div class="config-grid-2col fr-mt-1w">
+          <div class="fr-select-group fr-select-group--sm">
+            <label class="fr-label" for="sort-field">
+              Trier par
+              <button type="button" class="help-btn" aria-label="Aide" aria-describedby="help-sort-field" data-help="sort-field"><i class="ri-question-line" aria-hidden="true"></i></button>
+            </label>
+            <select class="fr-select" id="sort-field">
+              <option value="">Auto (valeur)</option>
+            </select>
+          </div>
+          <div class="fr-select-group fr-select-group--sm">
+            <label class="fr-label" for="sort-order">
+              Ordre
+              <button type="button" class="help-btn" aria-label="Aide" aria-describedby="help-sort-order" data-help="sort-order"><i class="ri-question-line" aria-hidden="true"></i></button>
+            </label>
+            <select class="fr-select" id="sort-order">
+              <option value="desc">Decroissant</option>
+              <option value="asc">Croissant</option>
+              <option value="none">Ordre source</option>
+            </select>
+          </div>
         </div>
 
         <!-- Toggle Mode Avance -->

--- a/apps/builder/src/sources-fields.ts
+++ b/apps/builder/src/sources-fields.ts
@@ -12,6 +12,7 @@ export function populateFieldSelects(): void {
   const labelSelect = document.getElementById('label-field') as HTMLSelectElement | null;
   const valueSelect = document.getElementById('value-field') as HTMLSelectElement | null;
   const codeSelect = document.getElementById('code-field') as HTMLSelectElement | null;
+  const sortFieldSelect = document.getElementById('sort-field') as HTMLSelectElement | null;
 
   if (!labelSelect || !valueSelect || !codeSelect) return;
 
@@ -19,6 +20,7 @@ export function populateFieldSelects(): void {
   labelSelect.innerHTML = '<option value="">\u2014 S\u00e9lectionner \u2014</option>';
   valueSelect.innerHTML = '<option value="">\u2014 S\u00e9lectionner \u2014</option>';
   codeSelect.innerHTML = '<option value="">\u2014 S\u00e9lectionner \u2014</option>';
+  if (sortFieldSelect) sortFieldSelect.innerHTML = '<option value="">Auto (valeur)</option>';
 
   state.fields.forEach((field) => {
     const displayText = field.displayName
@@ -41,6 +43,13 @@ export function populateFieldSelects(): void {
       optionCode.value = field.name;
       optionCode.textContent = displayText;
       codeSelect.appendChild(optionCode);
+    }
+
+    if (sortFieldSelect) {
+      const optionSort = document.createElement('option');
+      optionSort.value = field.name;
+      optionSort.textContent = displayText;
+      sortFieldSelect.appendChild(optionSort);
     }
   });
 

--- a/apps/builder/src/sources.ts
+++ b/apps/builder/src/sources.ts
@@ -630,6 +630,8 @@ export function loadFavoriteState(): void {
         if (state.codeField && codeSelect) codeSelect.value = state.codeField;
         if (state.aggregation && aggSelect) aggSelect.value = state.aggregation;
         if (state.sortOrder && sortSelect) sortSelect.value = state.sortOrder;
+        const sortFieldSelect = document.getElementById('sort-field') as HTMLSelectElement | null;
+        if (sortFieldSelect) sortFieldSelect.value = state.sortField || '';
 
         // Restore extra series (migrates old valueField2 if needed)
         restoreExtraSeriesFromState();

--- a/apps/builder/src/state.ts
+++ b/apps/builder/src/state.ts
@@ -127,6 +127,12 @@ export interface BuilderState {
   codeField: string;
   aggregation: AggregationType;
   sortOrder: SortOrder;
+  /**
+   * Field to sort by. Empty string means "auto" (sort by aggregated value for
+   * charts, by label for datalist). Set to a specific field name to sort by
+   * that field (e.g. labelField for alphabetical sort).
+   */
+  sortField: string;
   title: string;
   subtitle: string;
   palette: string;
@@ -256,6 +262,7 @@ export const state: BuilderState = {
   codeField: '',
   aggregation: 'avg',
   sortOrder: 'desc',
+  sortField: '',
   title: 'Mon graphique',
   subtitle: '',
   palette: 'default',

--- a/apps/builder/src/ui/code-generator.ts
+++ b/apps/builder/src/ui/code-generator.ts
@@ -37,6 +37,33 @@ function displayGeneratedCode(code: string): void {
 const ODS_PAGE_SIZE = 100;
 const ODS_MAX_PAGES = 10;
 
+/**
+ * Resolve the field name to use in `order-by` for dsfr-data-query.
+ * - sortOrder === 'none' → returns null (caller should skip the attribute)
+ * - sortField empty or === valueField → defaults to `defaultValueField` (the
+ *   aggregated alias, ex: "population__sum")
+ * - otherwise → returns sortField as-is (ex: labelField for alphabetical sort)
+ */
+function resolveSortField(defaultValueField: string): string | null {
+  if (state.sortOrder === 'none') return null;
+  if (!state.sortField || state.sortField === state.valueField) {
+    return defaultValueField;
+  }
+  return state.sortField;
+}
+
+/**
+ * Build the `tri="..."` attribute for dsfr-data-list.
+ * Defaults to labelField; user-chosen sortField overrides. Empty string when
+ * sortOrder === 'none' (preserve source order).
+ */
+function buildDatalistTriAttr(): string {
+  if (state.sortOrder === 'none') return '';
+  const field = state.sortField || state.labelField;
+  if (!field) return '';
+  return `\n    tri="${field}:${state.sortOrder}"`;
+}
+
 /** Generate DataBox attributes for dsfr-data-chart (dynamic mode) */
 function generateDataboxAttrs(): string {
   if (!state.databoxEnabled) return '';
@@ -439,6 +466,7 @@ export async function generateChart(): Promise<void> {
   const codeField = document.getElementById('code-field') as HTMLSelectElement | null;
   const aggregation = document.getElementById('aggregation') as HTMLSelectElement | null;
   const sortOrder = document.getElementById('sort-order') as HTMLSelectElement | null;
+  const sortField = document.getElementById('sort-field') as HTMLSelectElement | null;
 
   if (labelField) state.labelField = labelField.value;
   if (valueField) state.valueField = valueField.value;
@@ -447,6 +475,7 @@ export async function generateChart(): Promise<void> {
   state.codeField = codeField?.value || '';
   if (aggregation) state.aggregation = aggregation.value as typeof state.aggregation;
   if (sortOrder) state.sortOrder = sortOrder.value as typeof state.sortOrder;
+  if (sortField) state.sortField = sortField.value;
 
   const isKPI = state.chartType === 'kpi';
   const isGauge = state.chartType === 'gauge';
@@ -551,12 +580,18 @@ export async function generateChart(): Promise<void> {
     });
   } else {
     // Chart: group by label field — limit=200 to fetch all categories
-    params = new URLSearchParams({
+    const baseParams: Record<string, string> = {
       select: `${state.labelField}, ${valueExpression}${extraValueExpressions}`,
       group_by: state.labelField,
-      order_by: `value ${state.sortOrder}`,
       limit: '200',
-    });
+    };
+    // Skip order_by when sortOrder is 'none' (preserve source order)
+    if (state.sortOrder !== 'none') {
+      const odsSortField =
+        state.sortField && state.sortField !== state.valueField ? state.sortField : 'value';
+      baseParams.order_by = `${odsSortField} ${state.sortOrder}`;
+    }
+    params = new URLSearchParams(baseParams);
   }
 
   // Apply advanced mode filter to API request
@@ -703,12 +738,20 @@ export function generateChartFromLocalData(): void {
     return result;
   });
 
-  // Sort
-  results.sort((a, b) => {
-    return state.sortOrder === 'desc'
-      ? (b.value as number) - (a.value as number)
-      : (a.value as number) - (b.value as number);
-  });
+  // Sort (skip entirely when sortOrder === 'none' to preserve source order)
+  if (state.sortOrder !== 'none') {
+    const sortKey =
+      state.sortField && state.sortField !== state.valueField ? state.sortField : 'value';
+    const dir = state.sortOrder === 'desc' ? -1 : 1;
+    results.sort((a, b) => {
+      const va = a[sortKey];
+      const vb = b[sortKey];
+      const na = Number(va);
+      const nb = Number(vb);
+      if (!isNaN(na) && !isNaN(nb)) return (na - nb) * dir;
+      return String(va ?? '').localeCompare(String(vb ?? '')) * dir;
+    });
+  }
 
   state.data = results;
 
@@ -801,10 +844,7 @@ export function generateCodeForLocalData(): void {
   // Handle Datalist type (local data)
   if (state.chartType === 'datalist') {
     const colonnes = buildColonnesAttr();
-    const triAttr =
-      state.sortOrder !== 'none' && state.labelField
-        ? `\n    tri="${state.labelField}:${state.sortOrder}"`
-        : '';
+    const triAttr = buildDatalistTriAttr();
     const code = `<!-- Tableau genere avec dsfr-data Builder -->
 <!-- Source : ${state.savedSource?.name || 'Donnees locales'} -->
 
@@ -1063,8 +1103,9 @@ export function generateOdsQueryCode(
   // --- dsfr-data-query attributes (client-side post-processing) ---
   const qAttrs: string[] = [];
   qAttrs.push('source="chart-src"');
-  if (state.sortOrder && state.sortOrder !== 'none') {
-    qAttrs.push(`order-by="${resultValueField}:${state.sortOrder}"`);
+  const odsSortField = resolveSortField(resultValueField);
+  if (odsSortField) {
+    qAttrs.push(`order-by="${odsSortField}:${state.sortOrder}"`);
   }
 
   const queryElement = `
@@ -1156,8 +1197,9 @@ export function generateTabularQueryCode(
   }
 
   // Order by
-  if (state.sortOrder && state.sortOrder !== 'none') {
-    qAttrs.push(`order-by="${resultValueField}:${state.sortOrder}"`);
+  const tabularSortField = resolveSortField(resultValueField);
+  if (tabularSortField) {
+    qAttrs.push(`order-by="${tabularSortField}:${state.sortOrder}"`);
   }
 
   const queryElement = `
@@ -1247,8 +1289,9 @@ export function generateDsfrDataQueryCode(
   attrs.push(`aggregate="${escapeHtml(aggregateExpr)}"`);
 
   // Sort
-  if (state.sortOrder && state.sortOrder !== 'none') {
-    attrs.push(`order-by="${sortField}:${state.sortOrder}"`);
+  const dynSortField = resolveSortField(sortField);
+  if (dynSortField) {
+    attrs.push(`order-by="${dynSortField}:${state.sortOrder}"`);
   }
 
   const comment = state.advancedMode
@@ -1321,10 +1364,7 @@ export function generateDynamicCode(): void {
   // Handle Datalist type (Grist dynamic)
   if (state.chartType === 'datalist') {
     const colonnes = buildColonnesAttr();
-    const triAttr =
-      state.sortOrder !== 'none' && state.labelField
-        ? `\n    tri="${state.labelField}:${state.sortOrder}"`
-        : '';
+    const triAttr = buildDatalistTriAttr();
     const { elements: middlewareHtml, finalSourceId: datalistSource } = generateMiddlewareElements(
       'table-data',
       gristFacetsMode
@@ -1537,10 +1577,7 @@ export function generateDynamicCodeForApi(): void {
   // Handle Datalist type (API dynamic)
   if (state.chartType === 'datalist') {
     const colonnes = buildColonnesAttr();
-    const triAttr =
-      state.sortOrder !== 'none' && state.labelField
-        ? `\n    tri="${state.labelField}:${state.sortOrder}"`
-        : '';
+    const triAttr = buildDatalistTriAttr();
 
     if (provider.id === 'opendatasoft' && resourceIds?.datasetId) {
       const whereAttr =
@@ -1902,10 +1939,7 @@ loadGauge();
   // Handle Datalist type (API fetch)
   if (state.chartType === 'datalist') {
     const colonnes = buildColonnesAttr();
-    const triAttr =
-      state.sortOrder !== 'none' && state.labelField
-        ? `\n    tri="${state.labelField}:${state.sortOrder}"`
-        : '';
+    const triAttr = buildDatalistTriAttr();
     const code = `<!-- Tableau genere avec dsfr-data Builder -->
 
 <!-- Dependances CSS (DSFR) -->

--- a/apps/builder/src/ui/help-texts.ts
+++ b/apps/builder/src/ui/help-texts.ts
@@ -13,7 +13,9 @@ export const TOOLTIPS = {
   aggregation:
     'Que faire quand plusieurs lignes ont la meme etiquette\u00a0?\n\u2022 Somme\u00a0: additionne les valeurs\n\u2022 Moyenne\u00a0: calcule la moyenne\n\u2022 Comptage\u00a0: compte le nombre de lignes\n\u2022 Min / Max\u00a0: garde la plus petite ou grande valeur',
   'sort-order':
-    "Dans quel ordre afficher les resultats\u00a0: du plus grand au plus petit (decroissant) ou l'inverse (croissant).",
+    "Dans quel ordre afficher les resultats\u00a0:\n\u2022 Decroissant\u00a0: du plus grand au plus petit\n\u2022 Croissant\u00a0: du plus petit au plus grand\n\u2022 Ordre source\u00a0: ne trie pas, conserve l'ordre des donnees recues. Utile pour les mois en lettres, jours de la semaine, ou toute serie deja ordonnee a la source.",
+  'sort-field':
+    'Le champ qui sert de critere de tri.\n\u2022 Auto (defaut)\u00a0: trie par la valeur agregee (hauteur des barres, taille des parts).\n\u2022 Champ cat\u00e9gorie\u00a0: trie alphabetiquement (utile pour ranger des departements ou des noms par ordre alphabetique).',
   'advanced-mode':
     "Active des options de filtrage et de transformation. Utile pour ne garder qu'une partie des donnees (ex\u00a0: uniquement l'Ile-de-France) ou combiner plusieurs agregations.",
   'query-filter':

--- a/apps/builder/src/ui/ui-helpers.ts
+++ b/apps/builder/src/ui/ui-helpers.ts
@@ -28,6 +28,7 @@ export function getBuilderStateToSave(): Record<string, unknown> {
     codeField: state.codeField,
     aggregation: state.aggregation,
     sortOrder: state.sortOrder,
+    sortField: state.sortField,
     title: state.title,
     subtitle: state.subtitle,
     palette: state.palette,


### PR DESCRIPTION
Permet de choisir explicitement la colonne de tri (defaut: champ valeur,
ou n'importe quel champ pour un tri alphabetique) et ajoute l'option
"Ordre source" qui n'emet pas d'order-by — utile pour les mois en lettres,
jours de la semaine, ou toute serie deja ordonnee a la source.

- state.ts : ajout de sortField (vide = auto)
- index.html : nouveau select "Trier par" + option "Ordre source" dans Ordre
- code-generator.ts : helper resolveSortField/buildDatalistTriAttr applique
  aux 4 sites de generation (ODS, Tabular, dynamic generic, ODS direct)
  et a la preview interne du builder
- builder-ia/skills.ts : doc sortOrder=none et sortField

Cote lib (packages/core/) : aucune modification — dsfr-data-query
preservait deja l'ordre source quand order-by est omis (Map JS conserve
l'ordre d'insertion des cles dans le group-by).