### PR TITLE
feat(favorites): partage public d'un favori (sources publiques) — issue #148 partie 1/2

### DIFF
--- a/apps/favorites/index.html
+++ b/apps/favorites/index.html
@@ -64,6 +64,48 @@
     </main>
   </div>
 
+  <!-- Share public link modal -->
+  <div class="modal-overlay" id="share-modal">
+    <div class="modal-content share-modal-content">
+      <h3>Partager publiquement</h3>
+      <p class="fr-text--sm">
+        Toute personne disposant de ce lien pourra voir le rendu du favori, sans creer de compte.
+        Le lien est secret&nbsp;: ne le diffusez qu'aux personnes a qui vous voulez donner acces.
+      </p>
+
+      <div id="share-modal-state-loading" class="share-modal-state">
+        <p class="fr-text--sm fr-mt-2w"><i class="ri-loader-4-line" aria-hidden="true"></i> Generation du lien&hellip;</p>
+      </div>
+
+      <div id="share-modal-state-active" class="share-modal-state" hidden>
+        <div class="fr-input-group fr-input-group--sm fr-mt-2w">
+          <label class="fr-label" for="share-public-url">Lien public</label>
+          <div class="share-url-row">
+            <input type="text" class="fr-input" id="share-public-url" readonly>
+            <button class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-clipboard-line" id="share-copy-btn">Copier</button>
+          </div>
+          <p class="fr-hint-text" id="share-expiration-hint"></p>
+        </div>
+        <div class="modal-actions">
+          <button class="fr-btn fr-btn--secondary" id="share-close-btn">Fermer</button>
+          <button class="fr-btn fr-btn--tertiary-no-outline" id="share-revoke-btn">
+            <i class="ri-link-unlink-m" aria-hidden="true"></i>
+            Revoquer le lien
+          </button>
+        </div>
+      </div>
+
+      <div id="share-modal-state-error" class="share-modal-state" hidden>
+        <div class="fr-alert fr-alert--warning fr-alert--sm fr-mt-2w">
+          <p id="share-error-message"></p>
+        </div>
+        <div class="modal-actions">
+          <button class="fr-btn fr-btn--secondary" id="share-error-close-btn">Fermer</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Delete confirmation modal -->
   <div class="modal-overlay" id="delete-modal">
     <div class="modal-content">

--- a/apps/favorites/public-view.html
+++ b/apps/favorites/public-view.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="fr" data-fr-scheme="system">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <title>dsfr-data &mdash; Vue partagee</title>
+
+  <!-- DSFR -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
+
+  <link rel="stylesheet" href="src/styles/favorites.css">
+
+  <style>
+    .public-view-layout {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 1.5rem;
+    }
+    .public-view-banner {
+      margin-bottom: 1rem;
+    }
+    .public-view-frame-wrap {
+      border: 1px solid var(--border-default-grey);
+      border-radius: 8px;
+      overflow: hidden;
+      background: white;
+    }
+    .public-view-frame {
+      width: 100%;
+      min-height: 480px;
+      border: 0;
+      display: block;
+    }
+    .public-view-empty {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 4rem 1rem;
+      text-align: center;
+      color: var(--text-mention-grey);
+    }
+    .public-view-empty i {
+      font-size: 2.5rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="public-view-layout">
+    <div class="fr-alert fr-alert--info fr-alert--sm public-view-banner">
+      <p>
+        <i class="ri-share-line" aria-hidden="true"></i>
+        Vous consultez un favori partage publiquement par un utilisateur de dsfr-data.
+        Les donnees affichees viennent directement des sources publiques referencees dans le rendu.
+      </p>
+    </div>
+
+    <h1 id="public-view-title" class="fr-h3">Chargement&hellip;</h1>
+
+    <div id="public-view-content" class="public-view-frame-wrap">
+      <div class="public-view-empty">
+        <i class="ri-loader-4-line" aria-hidden="true"></i>
+        <p>Chargement du contenu partage&hellip;</p>
+      </div>
+    </div>
+
+    <p class="fr-text--xs fr-mt-2w" style="color: var(--text-mention-grey);">
+      Lien public &mdash; ce contenu peut etre revoque a tout moment par son auteur.
+    </p>
+  </div>
+
+  <!-- App entry point -->
+  <script type="module" src="src/public-view.ts"></script>
+</body>
+</html>

--- a/apps/favorites/src/main.ts
+++ b/apps/favorites/src/main.ts
@@ -22,6 +22,7 @@ import {
 import { loadFavorites, saveFavorites, deleteFavorite, findFavorite } from './favorites-manager.js';
 import type { Favorite } from './favorites-manager.js';
 import { getPreviewHTML } from './preview.js';
+import { openShareModal } from './share-link.js';
 
 // State (re-loaded after initAuth in DOMContentLoaded)
 let favorites = loadFavorites();
@@ -187,6 +188,11 @@ function renderContent(): void {
                 onclick="copyCode('${fav.id}')">
           Copier le code
         </button>
+        <button class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-share-line"
+                onclick="shareFavorite('${fav.id}')"
+                title="Partager publiquement (lien anonyme)">
+          Partager
+        </button>
         <button class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-icon-delete-line"
                 onclick="showDeleteModal('${fav.id}')"
                 title="Supprimer">
@@ -303,6 +309,13 @@ function renameFavorite(id: string): void {
   input.select();
 }
 
+function shareFavorite(id: string): void {
+  const fav = findFavorite(favorites, id);
+  if (!fav) return;
+  // openShareModal handles its own UI state (loading / active / error)
+  void openShareModal(id);
+}
+
 function showDeleteModal(id: string): void {
   const fav = findFavorite(favorites, id);
   if (fav) {
@@ -372,6 +385,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('import-btn')?.addEventListener('click', importFavorites);
 
   setupModalOverlayClose('delete-modal');
+  setupModalOverlayClose('share-modal');
 });
 
 // Expose functions globally for onclick handlers in HTML
@@ -381,6 +395,7 @@ declare global {
     openInPlayground: typeof openInPlayground;
     openInBuilder: typeof openInBuilder;
     copyCode: typeof copyCode;
+    shareFavorite: typeof shareFavorite;
     showDeleteModal: typeof showDeleteModal;
     closeDeleteModal: typeof handleCloseDeleteModal;
     renameFavorite: typeof renameFavorite;
@@ -391,6 +406,7 @@ window.selectFavorite = selectFavorite;
 window.openInPlayground = openInPlayground;
 window.openInBuilder = openInBuilder;
 window.copyCode = copyCode;
+window.shareFavorite = shareFavorite;
 window.showDeleteModal = showDeleteModal;
 window.closeDeleteModal = handleCloseDeleteModal;
 window.renameFavorite = renameFavorite;

--- a/apps/favorites/src/public-view.ts
+++ b/apps/favorites/src/public-view.ts
@@ -1,0 +1,107 @@
+/**
+ * Anonymous public-view page (issue #148).
+ *
+ * Reads ?token=... from the URL, fetches /api/public/share/:token, and renders
+ * the favorite's stored code in a sandboxed iframe — same path as the
+ * authenticated favorites preview.
+ *
+ * No auth, no localStorage of user data, no header/sidebar : intentionally
+ * minimal so the page can be embedded or shared at face value.
+ */
+
+import { getPreviewHTML, escapeHtml } from '@dsfr-data/shared';
+
+interface SharedFavorite {
+  resourceType: 'favorite';
+  name: string;
+  chartType: string | null;
+  code: string;
+}
+
+function getToken(): string | null {
+  const params = new URLSearchParams(window.location.search);
+  const t = params.get('token');
+  if (!t) return null;
+  // UUID v4 sanity check matching the server filter — avoid sending obvious
+  // garbage to the API.
+  return /^[0-9a-f-]{32,40}$/i.test(t) ? t : null;
+}
+
+function showEmptyState(icon: string, message: string): void {
+  const content = document.getElementById('public-view-content');
+  if (!content) return;
+  content.innerHTML = `
+    <div class="public-view-empty">
+      <i class="${icon}" aria-hidden="true"></i>
+      <p>${escapeHtml(message)}</p>
+    </div>
+  `;
+}
+
+function setTitle(title: string): void {
+  const el = document.getElementById('public-view-title');
+  if (el) el.textContent = title;
+  document.title = `${title} \u2014 dsfr-data`;
+}
+
+async function load(): Promise<void> {
+  const token = getToken();
+  if (!token) {
+    setTitle('Lien invalide');
+    showEmptyState('ri-error-warning-line', 'Le lien de partage est manquant ou mal forme.');
+    return;
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`/api/public/share/${encodeURIComponent(token)}`, {
+      // Public endpoint — no credentials needed, but explicitly omit to
+      // prevent leaking auth cookies to the public route by accident.
+      credentials: 'omit',
+    });
+  } catch {
+    setTitle('Erreur reseau');
+    showEmptyState('ri-wifi-off-line', 'Impossible de joindre le serveur. Reessayez plus tard.');
+    return;
+  }
+
+  if (res.status === 404) {
+    setTitle('Lien introuvable');
+    showEmptyState('ri-link-unlink-m', "Ce lien n'existe pas ou a ete supprime.");
+    return;
+  }
+  if (res.status === 410) {
+    const body = (await res.json().catch(() => ({}))) as { code?: string };
+    const message =
+      body.code === 'EXPIRED'
+        ? 'Ce lien a expire.'
+        : body.code === 'REVOKED'
+          ? 'Ce lien a ete revoque par son auteur.'
+          : "Le contenu partage n'est plus disponible.";
+    setTitle('Lien indisponible');
+    showEmptyState('ri-time-line', message);
+    return;
+  }
+  if (!res.ok) {
+    setTitle('Erreur');
+    showEmptyState('ri-error-warning-line', 'Erreur lors du chargement du contenu partage.');
+    return;
+  }
+
+  const fav = (await res.json()) as SharedFavorite;
+  setTitle(fav.name || 'Vue partagee');
+
+  const content = document.getElementById('public-view-content');
+  if (!content) return;
+  content.innerHTML = '';
+  const iframe = document.createElement('iframe');
+  iframe.className = 'public-view-frame';
+  iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+  iframe.title = fav.name || 'Vue partagee';
+  iframe.srcdoc = getPreviewHTML(fav.code);
+  content.appendChild(iframe);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  void load();
+});

--- a/apps/favorites/src/share-link.ts
+++ b/apps/favorites/src/share-link.ts
@@ -1,0 +1,188 @@
+/**
+ * Public share link helpers (issue #148).
+ *
+ * Wraps the /api/shares endpoints with the auth + CSRF flow used elsewhere in
+ * the app, and exposes the modal state machine consumed by main.ts.
+ */
+
+import { authenticatedFetch, openModal, closeModal, toastSuccess } from '@dsfr-data/shared';
+
+export interface PublicShare {
+  id: string; // = token
+  resource_id: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+}
+
+/**
+ * Build the public view URL given a token. Uses the current origin so that the
+ * URL stays consistent when the app is deployed under various domains.
+ */
+export function buildPublicShareUrl(token: string): string {
+  // The favorites app sits at /apps/favorites/ — the public view page is a
+  // sibling at /apps/favorites/public-view.html. window.location works because
+  // this code only ever runs in the favorites app context.
+  const url = new URL('public-view.html', window.location.href);
+  url.searchParams.set('token', token);
+  return url.toString();
+}
+
+/**
+ * Look for an existing, non-revoked, non-expired public share for the given
+ * favorite. Returns null if none. Used to surface "you already shared this"
+ * before creating a new token.
+ */
+export async function findActivePublicShare(favoriteId: string): Promise<PublicShare | null> {
+  const res = await authenticatedFetch(
+    `/api/shares?resource_type=favorite&resource_id=${encodeURIComponent(favoriteId)}`
+  );
+  if (!res.ok) return null;
+  const list = (await res.json()) as PublicShare[];
+  const now = Date.now();
+  return (
+    list.find(
+      (s) =>
+        (s as { target_type?: string }).target_type === 'public' &&
+        !s.revoked_at &&
+        (!s.expires_at || new Date(s.expires_at).getTime() > now)
+    ) ?? null
+  );
+}
+
+/**
+ * Create a new public share for a favorite. Returns the share row including
+ * its id (the token). Throws if the server refuses.
+ */
+export async function createPublicShare(
+  favoriteId: string,
+  options: { expiresAt?: string } = {}
+): Promise<PublicShare> {
+  const res = await authenticatedFetch('/api/shares', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      resource_type: 'favorite',
+      resource_id: favoriteId,
+      target_type: 'public',
+      expires_at: options.expiresAt,
+    }),
+  });
+  if (!res.ok) {
+    const err = (await res.json().catch(() => ({}))) as { error?: string; code?: string };
+    const e = new Error(err.error ?? `HTTP ${res.status}`);
+    (e as Error & { code?: string }).code = err.code;
+    throw e;
+  }
+  return (await res.json()) as PublicShare;
+}
+
+export async function revokePublicShare(token: string): Promise<void> {
+  const res = await authenticatedFetch(`/api/shares/${encodeURIComponent(token)}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+}
+
+// ---- Modal state machine -----------------------------------------------
+
+type ModalState = 'loading' | 'active' | 'error';
+
+function showState(state: ModalState): void {
+  for (const s of ['loading', 'active', 'error'] as const) {
+    const el = document.getElementById(`share-modal-state-${s}`);
+    if (el) (el as HTMLElement).hidden = s !== state;
+  }
+}
+
+function setActiveShare(share: PublicShare): void {
+  const url = buildPublicShareUrl(share.id);
+  const input = document.getElementById('share-public-url') as HTMLInputElement | null;
+  if (input) input.value = url;
+
+  const hint = document.getElementById('share-expiration-hint');
+  if (hint) {
+    if (share.expires_at) {
+      const d = new Date(share.expires_at);
+      hint.textContent = `Expire le ${d.toLocaleDateString('fr-FR')} a ${d.toLocaleTimeString(
+        'fr-FR',
+        { hour: '2-digit', minute: '2-digit' }
+      )}.`;
+    } else {
+      hint.textContent = 'Aucune date d\u2019expiration.';
+    }
+  }
+  showState('active');
+}
+
+function setError(message: string): void {
+  const el = document.getElementById('share-error-message');
+  if (el) el.textContent = message;
+  showState('error');
+}
+
+/**
+ * Open the share modal for a given favorite. Reuses an existing active share
+ * if present, otherwise creates a new one. Wires up the copy / revoke / close
+ * buttons for the lifetime of this modal opening.
+ */
+export async function openShareModal(favoriteId: string): Promise<void> {
+  let currentShare: PublicShare | null = null;
+
+  showState('loading');
+  openModal('share-modal');
+
+  try {
+    currentShare =
+      (await findActivePublicShare(favoriteId)) ?? (await createPublicShare(favoriteId));
+    setActiveShare(currentShare);
+  } catch (err) {
+    const code = (err as Error & { code?: string }).code;
+    const message =
+      code === 'PRIVATE_SOURCE_NOT_SUPPORTED'
+        ? 'Ce favori utilise une source privee (clef API). Le partage public ne supporte pas encore les sources privees \u2014 voir le ticket de suivi.'
+        : (err as Error).message || 'Erreur lors de la generation du lien.';
+    setError(message);
+  }
+
+  // ---- Wire up buttons (idempotent: replace listeners every open) ----
+
+  const copyBtn = document.getElementById('share-copy-btn') as HTMLButtonElement | null;
+  if (copyBtn) {
+    const fresh = copyBtn.cloneNode(true) as HTMLButtonElement;
+    copyBtn.replaceWith(fresh);
+    fresh.addEventListener('click', () => {
+      const input = document.getElementById('share-public-url') as HTMLInputElement | null;
+      if (!input) return;
+      navigator.clipboard.writeText(input.value).then(() => {
+        toastSuccess('Lien copie dans le presse-papiers');
+      });
+    });
+  }
+
+  const revokeBtn = document.getElementById('share-revoke-btn') as HTMLButtonElement | null;
+  if (revokeBtn) {
+    const fresh = revokeBtn.cloneNode(true) as HTMLButtonElement;
+    revokeBtn.replaceWith(fresh);
+    fresh.addEventListener('click', async () => {
+      if (!currentShare) return;
+      try {
+        await revokePublicShare(currentShare.id);
+        closeModal('share-modal');
+        toastSuccess('Lien public revoque');
+      } catch {
+        setError('Impossible de revoquer le lien.');
+      }
+    });
+  }
+
+  for (const id of ['share-close-btn', 'share-error-close-btn']) {
+    const btn = document.getElementById(id);
+    if (btn) {
+      const fresh = btn.cloneNode(true) as HTMLButtonElement;
+      btn.replaceWith(fresh);
+      fresh.addEventListener('click', () => closeModal('share-modal'));
+    }
+  }
+}

--- a/apps/favorites/src/styles/favorites.css
+++ b/apps/favorites/src/styles/favorites.css
@@ -1,4 +1,6 @@
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
 
 body {
   margin: 0;
@@ -255,4 +257,17 @@ body {
   gap: 0.5rem;
   justify-content: flex-end;
   margin-top: 1.5rem;
+}
+
+.share-modal-content {
+  max-width: 540px;
+}
+
+.share-url-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+.share-url-row .fr-input {
+  flex: 1;
 }

--- a/apps/favorites/vite.config.ts
+++ b/apps/favorites/vite.config.ts
@@ -7,6 +7,15 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    rollupOptions: {
+      // The favorites app exposes two HTML entry points :
+      //   - index.html       : authenticated favorites manager
+      //   - public-view.html : anonymous public-share viewer (issue #148)
+      input: {
+        index: resolve(__dirname, 'index.html'),
+        publicView: resolve(__dirname, 'public-view.html'),
+      },
+    },
   },
   resolve: {
     alias: {

--- a/server/src/db/database.ts
+++ b/server/src/db/database.ts
@@ -184,6 +184,9 @@ async function runMigrations(): Promise<void> {
   if (currentVersion < 6) {
     await migrateV6();
   }
+  if (currentVersion < 7) {
+    await migrateV7();
+  }
 }
 
 /**
@@ -338,6 +341,69 @@ async function migrateV5(): Promise<void> {
 
     await conn.commit();
     console.log('[db] Migration v5 complete');
+  } catch (err) {
+    await conn.rollback();
+    throw err;
+  } finally {
+    conn.release();
+  }
+}
+
+/**
+ * Migration v7: extend `shares` to support public links (issue #148).
+ * - target_type ENUM gains a 'public' value
+ * - new columns expires_at + revoked_at on shares
+ * - drop the unique key uq_share, useless for public links (one share per
+ *   resource per user/group is replaced by one share row per public link —
+ *   target_id stays NULL, the row id IS the token, multiple links allowed
+ *   for the same resource)
+ */
+async function migrateV7(): Promise<void> {
+  console.log(
+    '[db] Running migration v7: shares.target_type adds public + expires_at + revoked_at'
+  );
+
+  const conn = await getPool().getConnection();
+  try {
+    const [cols] = await conn.query(
+      `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'shares' AND COLUMN_NAME = 'expires_at'`
+    );
+    if ((cols as unknown[]).length > 0) {
+      await conn.query('INSERT IGNORE INTO schema_version (version) VALUES (7)');
+      return;
+    }
+
+    await conn.beginTransaction();
+
+    await conn.query(
+      `ALTER TABLE shares
+       MODIFY target_type ENUM('user', 'group', 'global', 'public') NOT NULL`
+    );
+
+    await conn.query(
+      `ALTER TABLE shares
+       ADD COLUMN expires_at TIMESTAMP NULL AFTER created_at,
+       ADD COLUMN revoked_at TIMESTAMP NULL AFTER expires_at`
+    );
+
+    // The legacy unique key (resource_type, resource_id, target_type, target_id)
+    // would block a second public link for the same resource (target_id=NULL
+    // collides with itself). Drop it and replace with a non-unique index that
+    // still keeps queries by resource fast.
+    const [keys] = await conn.query(
+      `SELECT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'shares' AND INDEX_NAME = 'uq_share'`
+    );
+    if ((keys as unknown[]).length > 0) {
+      await conn.query(`ALTER TABLE shares DROP INDEX uq_share`);
+    }
+    await conn.query(`CREATE INDEX idx_shares_resource ON shares (resource_type, resource_id)`);
+    await conn.query(`CREATE INDEX idx_shares_target ON shares (target_type, target_id)`);
+
+    await conn.query('INSERT IGNORE INTO schema_version (version) VALUES (7)');
+    await conn.commit();
+    console.log('[db] Migration v7 complete');
   } catch (err) {
     await conn.rollback();
     throw err;

--- a/server/src/db/schema-mariadb.sql
+++ b/server/src/db/schema-mariadb.sql
@@ -85,17 +85,21 @@ CREATE TABLE IF NOT EXISTS dashboards (
   FOREIGN KEY (owner_id) REFERENCES users(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- Sharing (polymorphic)
+-- Sharing (polymorphic). target_type='public' = anonymous capability link
+-- (the row id is the unguessable token, target_id stays NULL).
 CREATE TABLE IF NOT EXISTS shares (
   id VARCHAR(36) NOT NULL PRIMARY KEY,
   resource_type VARCHAR(50) NOT NULL,
   resource_id VARCHAR(36) NOT NULL,
-  target_type ENUM('user', 'group', 'global') NOT NULL,
+  target_type ENUM('user', 'group', 'global', 'public') NOT NULL,
   target_id VARCHAR(36),
   permission ENUM('read', 'write') NOT NULL DEFAULT 'read',
   granted_by VARCHAR(36) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  UNIQUE KEY uq_share (resource_type, resource_id, target_type, target_id),
+  expires_at TIMESTAMP NULL,
+  revoked_at TIMESTAMP NULL,
+  INDEX idx_shares_resource (resource_type, resource_id),
+  INDEX idx_shares_target (target_type, target_id),
   FOREIGN KEY (granted_by) REFERENCES users(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,6 +13,7 @@ import favoritesRoutes from './routes/favorites.js';
 import dashboardsRoutes from './routes/dashboards.js';
 import groupsRoutes from './routes/groups.js';
 import sharesRoutes from './routes/shares.js';
+import publicShareRoutes from './routes/public-share.js';
 import cacheRoutes from './routes/cache.js';
 import migrateRoutes from './routes/migrate.js';
 import monitoringRoutes from './routes/monitoring.js';
@@ -60,6 +61,11 @@ app.use('/api/favorites', favoritesRoutes);
 app.use('/api/dashboards', dashboardsRoutes);
 app.use('/api/groups', groupsRoutes);
 app.use('/api/shares', sharesRoutes);
+// Anonymous routes for public share resolution. Mounted at a distinct
+// /api/public/share/* path to make the public surface obvious. The router
+// only declares GET /:token (no mutations), so CSRF protection above does
+// not apply.
+app.use('/api/public/share', publicShareRoutes);
 app.use('/api/cache', cacheRoutes);
 app.use('/api/migrate', migrateRoutes);
 app.use('/api/monitoring', monitoringRoutes);

--- a/server/src/middleware/rate-limit.ts
+++ b/server/src/middleware/rate-limit.ts
@@ -68,3 +68,25 @@ export function globalApiRateLimiter(req: Request, res: Response, next: NextFunc
   }
   globalApiLimiter(req, res, next);
 }
+
+const publicShareLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 60, // 60 anonymous requests per minute per IP
+  message: { error: 'Too many requests for public share' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+/**
+ * Rate limiter for anonymous public-share endpoints. Stricter than the global
+ * limiter because these endpoints have no auth — the only client identifier
+ * is the IP. Goal : a leaked link cannot be used to scrape data en masse.
+ * Disabled in test environment.
+ */
+export function publicShareRateLimiter(req: Request, res: Response, next: NextFunction): void {
+  if (process.env.NODE_ENV === 'test') {
+    next();
+    return;
+  }
+  publicShareLimiter(req, res, next);
+}

--- a/server/src/routes/public-share.ts
+++ b/server/src/routes/public-share.ts
@@ -1,0 +1,116 @@
+/**
+ * Anonymous public-share endpoints (issue #148).
+ *
+ * Routes mounted under /api/public/share. No auth required — the share row id
+ * (UUID v4, ~122 bits of entropy) is the capability token. The token is
+ * non-revocable except by the owner via DELETE /api/shares/:id.
+ *
+ * Currently only `favorite` resources are exposed publicly. Favorites whose
+ * saved source needs server-side credentials are refused at share-creation
+ * time (see shares.ts:favoriteNeedsPrivateProxy) — so a public link is always
+ * safe to render client-side, no proxy involved.
+ *
+ * Returns minimum data : nothing about the owner identity, just the
+ * favorite's name + chartType + code (the embedded HTML/JS that the public
+ * view page renders inside an iframe).
+ */
+
+import { Router } from 'express';
+import { queryOne } from '../db/database.js';
+import { publicShareRateLimiter } from '../middleware/rate-limit.js';
+
+const router = Router();
+
+router.use(publicShareRateLimiter);
+
+interface ShareRow {
+  id: string;
+  resource_type: string;
+  resource_id: string;
+  target_type: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+}
+
+interface FavoriteRow {
+  id: string;
+  name: string;
+  chart_type: string | null;
+  code: string;
+}
+
+/**
+ * GET /api/public/share/:token
+ * Anonymous resolution of a public share.
+ *
+ * Responses:
+ *  - 200 { resourceType, name, chartType, code }
+ *  - 404 if the token does not exist or does not match a public share
+ *  - 410 Gone if revoked or expired
+ */
+router.get('/:token', async (req, res) => {
+  // Discourage indexing of public share URLs even if they leak into a sitemap
+  // or get crawled. Caching is short — the owner can revoke at any time.
+  res.set('X-Robots-Tag', 'noindex, nofollow');
+  res.set('Cache-Control', 'private, max-age=30, must-revalidate');
+
+  try {
+    const token = req.params.token;
+    // UUID v4 sanity check : 36 chars, hyphenated. Cheap pre-filter to avoid
+    // hitting the DB on obvious garbage.
+    if (!/^[0-9a-f-]{32,40}$/i.test(token)) {
+      res.status(404).json({ error: 'Share not found' });
+      return;
+    }
+
+    const share = await queryOne<ShareRow>(
+      `SELECT id, resource_type, resource_id, target_type, expires_at, revoked_at
+       FROM shares
+       WHERE id = ? AND target_type = 'public'`,
+      [token]
+    );
+    if (!share) {
+      res.status(404).json({ error: 'Share not found' });
+      return;
+    }
+
+    if (share.revoked_at) {
+      res.status(410).json({ error: 'This share has been revoked', code: 'REVOKED' });
+      return;
+    }
+    if (share.expires_at && new Date(share.expires_at).getTime() <= Date.now()) {
+      res.status(410).json({ error: 'This share has expired', code: 'EXPIRED' });
+      return;
+    }
+
+    if (share.resource_type !== 'favorite') {
+      // Schema allows other resource types to be shared publicly in the future;
+      // until those code paths exist, refuse rather than leak something we can
+      // not safely render.
+      res.status(404).json({ error: 'Share not found' });
+      return;
+    }
+
+    const fav = await queryOne<FavoriteRow>(
+      'SELECT id, name, chart_type, code FROM favorites WHERE id = ?',
+      [share.resource_id]
+    );
+    if (!fav) {
+      // The favorite was deleted but the share row was not — treat as gone.
+      res.status(410).json({ error: 'The shared favorite no longer exists', code: 'GONE' });
+      return;
+    }
+
+    res.json({
+      resourceType: 'favorite',
+      name: fav.name,
+      chartType: fav.chart_type,
+      code: fav.code,
+    });
+  } catch (err) {
+    console.error('Get public share error:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/server/src/routes/shares.ts
+++ b/server/src/routes/shares.ts
@@ -19,6 +19,33 @@ const RESOURCE_TABLES: Record<string, string> = {
 };
 
 /**
+ * A favorite "needs private proxy" when its saved source references a
+ * connection or carries a (legacy) inline apiKey. The builder state is stored
+ * as JSON in `favorites.builder_state_json` — MariaDB returns an already-parsed
+ * object, but we accept either shape for safety.
+ */
+export function favoriteNeedsPrivateProxy(rawBuilderState: unknown): boolean {
+  if (!rawBuilderState) return false;
+  let state: Record<string, unknown>;
+  if (typeof rawBuilderState === 'string') {
+    try {
+      state = JSON.parse(rawBuilderState) as Record<string, unknown>;
+    } catch {
+      return false;
+    }
+  } else if (typeof rawBuilderState === 'object') {
+    state = rawBuilderState as Record<string, unknown>;
+  } else {
+    return false;
+  }
+  const source = state.savedSource as Record<string, unknown> | undefined;
+  if (!source) return false;
+  if (source.connectionId) return true;
+  if (typeof source.apiKey === 'string' && source.apiKey.trim().length > 0) return true;
+  return false;
+}
+
+/**
  * GET / - List shares for a resource
  * Query params: resource_type, resource_id
  */
@@ -76,12 +103,14 @@ router.post('/', requireAuth, async (req, res) => {
       return;
     }
 
-    if (!['user', 'group', 'global'].includes(target_type)) {
-      res.status(400).json({ error: 'target_type must be user, group, or global' });
+    if (!['user', 'group', 'global', 'public'].includes(target_type)) {
+      res.status(400).json({ error: 'target_type must be user, group, global, or public' });
       return;
     }
 
-    if (target_type !== 'global' && !target_id) {
+    // Public links don't need a target_id (target_id stays NULL — the share row id IS the token).
+    // user/group shares still require a target_id.
+    if (!['global', 'public'].includes(target_type) && !target_id) {
       res.status(400).json({ error: 'target_id is required for user and group shares' });
       return;
     }
@@ -107,14 +136,60 @@ router.post('/', requireAuth, async (req, res) => {
       return;
     }
 
+    // Public links : block favorites whose source needs server-side credentials
+    // (see issue #148 "PR2"). Detection : the saved source carries a connectionId
+    // OR a non-empty inline apiKey. For PR1 we cleanly refuse rather than serve
+    // a broken link. Other resource types (sources/connections/dashboards) are
+    // refused outright until the proxy work lands.
+    if (target_type === 'public') {
+      if (resource_type !== 'favorite') {
+        res
+          .status(400)
+          .json({ error: 'Public sharing is only available for favorites in this version' });
+        return;
+      }
+      const fav = await queryOne<{ builder_state_json: unknown }>(
+        'SELECT builder_state_json FROM favorites WHERE id = ?',
+        [resource_id]
+      );
+      if (fav && favoriteNeedsPrivateProxy(fav.builder_state_json)) {
+        res.status(400).json({
+          error:
+            "Cette favori utilise une source privee (connexion authentifiee). Le partage public est desactive pour l'instant — voir issue de suivi.",
+          code: 'PRIVATE_SOURCE_NOT_SUPPORTED',
+        });
+        return;
+      }
+    }
+
     const id = uuidv4();
     const perm = permission === 'write' ? 'write' : 'read';
 
+    // Optional expiration (only meaningful for public links).
+    let expiresAt: string | null = null;
+    if (req.body.expires_at) {
+      const d = new Date(req.body.expires_at);
+      if (Number.isNaN(d.getTime()) || d.getTime() <= Date.now()) {
+        res.status(400).json({ error: 'expires_at must be a future ISO timestamp' });
+        return;
+      }
+      expiresAt = d.toISOString().slice(0, 19).replace('T', ' ');
+    }
+
     try {
       await execute(
-        `INSERT INTO shares (id, resource_type, resource_id, target_type, target_id, permission, granted_by)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
-        [id, resource_type, resource_id, target_type, target_id || null, perm, authReq.user!.userId]
+        `INSERT INTO shares (id, resource_type, resource_id, target_type, target_id, permission, granted_by, expires_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          id,
+          resource_type,
+          resource_id,
+          target_type,
+          target_id || null,
+          perm,
+          authReq.user!.userId,
+          expiresAt,
+        ]
       );
 
       const share = await queryOne('SELECT * FROM shares WHERE id = ?', [id]);

--- a/tests/apps/favorites/share-link.test.ts
+++ b/tests/apps/favorites/share-link.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for the favorites public-share helper (issue #148).
+ *
+ * The `openShareModal` flow is integration-heavy (modals, fetch, clipboard) —
+ * we cover the parts that are pure / data-shape : URL building and active-share
+ * filtering. End-to-end behavior is covered by the server tests + manual QA.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  buildPublicShareUrl,
+  findActivePublicShare,
+  createPublicShare,
+} from '../../../apps/favorites/src/share-link';
+
+describe('share-link', () => {
+  describe('buildPublicShareUrl', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: new URL('https://example.gov.fr/apps/favorites/index.html'),
+      });
+    });
+
+    it('builds a URL pointing at public-view.html with the token', () => {
+      const url = buildPublicShareUrl('abcd1234-aaaa-bbbb-cccc-eeeeffff0000');
+      expect(url).toBe(
+        'https://example.gov.fr/apps/favorites/public-view.html?token=abcd1234-aaaa-bbbb-cccc-eeeeffff0000'
+      );
+    });
+
+    it('encodes a token containing URL-special characters', () => {
+      const url = buildPublicShareUrl('abc def');
+      expect(url).toContain('token=abc+def');
+    });
+  });
+
+  describe('findActivePublicShare', () => {
+    let originalFetch: typeof fetch;
+    beforeEach(() => {
+      originalFetch = global.fetch;
+    });
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    function mockFetchOnce(payload: unknown, ok = true): void {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok,
+        json: async () => payload,
+      } as Response);
+    }
+
+    it('returns null when no shares exist', async () => {
+      mockFetchOnce([]);
+      const share = await findActivePublicShare('fav-1');
+      expect(share).toBeNull();
+    });
+
+    it('returns null when /api/shares responds with an error', async () => {
+      mockFetchOnce({ error: 'oops' }, false);
+      const share = await findActivePublicShare('fav-1');
+      expect(share).toBeNull();
+    });
+
+    it('skips revoked shares', async () => {
+      mockFetchOnce([
+        {
+          id: 't-1',
+          resource_id: 'fav-1',
+          target_type: 'public',
+          revoked_at: '2024-01-01T00:00:00Z',
+          expires_at: null,
+        },
+      ]);
+      const share = await findActivePublicShare('fav-1');
+      expect(share).toBeNull();
+    });
+
+    it('skips expired shares', async () => {
+      mockFetchOnce([
+        {
+          id: 't-1',
+          resource_id: 'fav-1',
+          target_type: 'public',
+          revoked_at: null,
+          expires_at: '2000-01-01T00:00:00Z',
+        },
+      ]);
+      const share = await findActivePublicShare('fav-1');
+      expect(share).toBeNull();
+    });
+
+    it('returns the active share', async () => {
+      const future = new Date(Date.now() + 3600_000).toISOString();
+      mockFetchOnce([
+        {
+          id: 't-1',
+          resource_id: 'fav-1',
+          target_type: 'public',
+          revoked_at: null,
+          expires_at: future,
+        },
+      ]);
+      const share = await findActivePublicShare('fav-1');
+      expect(share?.id).toBe('t-1');
+    });
+
+    it('ignores shares whose target_type is not public', async () => {
+      mockFetchOnce([
+        {
+          id: 't-1',
+          resource_id: 'fav-1',
+          target_type: 'user',
+          revoked_at: null,
+          expires_at: null,
+        },
+      ]);
+      const share = await findActivePublicShare('fav-1');
+      expect(share).toBeNull();
+    });
+  });
+
+  describe('createPublicShare', () => {
+    let originalFetch: typeof fetch;
+    beforeEach(() => {
+      originalFetch = global.fetch;
+    });
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('throws an Error tagged with the server code when the source is private', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          error: 'Cette favori utilise une source privee...',
+          code: 'PRIVATE_SOURCE_NOT_SUPPORTED',
+        }),
+      } as Response);
+
+      await expect(createPublicShare('fav-1')).rejects.toMatchObject({
+        code: 'PRIVATE_SOURCE_NOT_SUPPORTED',
+      });
+    });
+
+    it('returns the share row on success', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: 'token-1', resource_id: 'fav-1' }),
+      } as Response);
+
+      const share = await createPublicShare('fav-1');
+      expect(share.id).toBe('token-1');
+    });
+  });
+});

--- a/tests/server/public-share.test.ts
+++ b/tests/server/public-share.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Server tests for public favorite sharing (issue #148).
+ */
+
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import { createTestApp, closeTestApp, authCookie } from './test-helpers.js';
+import { execute, queryOne } from '../../server/src/db/database.js';
+import type { Express } from 'express';
+
+vi.mock('../../server/src/utils/mailer.js', () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
+  sendWelcomeEmail: vi.fn().mockResolvedValue(undefined),
+  setTransporter: vi.fn(),
+}));
+
+let app: Express;
+
+async function registerUser(email: string, password = 'Password1') {
+  const res = await request(app).post('/api/auth/register').send({ email, password });
+  if (res.body.user) {
+    const userId = res.body.user.id as string;
+    const role = res.body.user.role as string;
+    return { id: userId, email, role, cookie: authCookie({ userId, email, role }) };
+  }
+  await execute(
+    'UPDATE users SET email_verified = TRUE, verification_token_hash = NULL WHERE email = ?',
+    [email]
+  );
+  const user = await queryOne<{ id: string; role: string }>(
+    'SELECT id, role FROM users WHERE email = ?',
+    [email]
+  );
+  return {
+    id: user!.id,
+    email,
+    role: user!.role,
+    cookie: authCookie({ userId: user!.id, email, role: user!.role }),
+  };
+}
+
+async function createFavorite(
+  cookie: string,
+  overrides: Record<string, unknown> = {}
+): Promise<string> {
+  const body = {
+    name: 'My chart',
+    chart_type: 'bar',
+    code: '<dsfr-data-chart type="bar"></dsfr-data-chart>',
+    builder_state_json: { chartType: 'bar' },
+    source_app: 'builder',
+    ...overrides,
+  };
+  const res = await request(app).post('/api/favorites').set('Cookie', cookie).send(body);
+  expect(res.status).toBe(201);
+  return res.body.id as string;
+}
+
+async function createPublicShare(
+  cookie: string,
+  resourceId: string,
+  body: Record<string, unknown> = {}
+) {
+  return request(app)
+    .post('/api/shares')
+    .set('Cookie', cookie)
+    .send({
+      resource_type: 'favorite',
+      resource_id: resourceId,
+      target_type: 'public',
+      ...body,
+    });
+}
+
+describe('Public favorite sharing (issue #148)', () => {
+  beforeEach(async () => {
+    app = await createTestApp();
+  });
+
+  afterAll(async () => {
+    await closeTestApp();
+  });
+
+  describe('POST /api/shares with target_type=public', () => {
+    it('creates a public share for an owned favorite', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const favId = await createFavorite(alice.cookie);
+
+      const res = await createPublicShare(alice.cookie, favId);
+
+      expect(res.status).toBe(201);
+      expect(res.body.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(res.body.target_type).toBe('public');
+      expect(res.body.target_id).toBeNull();
+      expect(res.body.resource_id).toBe(favId);
+    });
+
+    it('refuses to share a favorite the user does not own', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const bob = await registerUser('bob@test.fr');
+      const favId = await createFavorite(alice.cookie);
+
+      const res = await createPublicShare(bob.cookie, favId);
+
+      expect(res.status).toBe(403);
+    });
+
+    it('refuses public share for favorites with a private connectionId', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const favId = await createFavorite(alice.cookie, {
+        builder_state_json: {
+          chartType: 'bar',
+          savedSource: { connectionId: 'conn-123' },
+        },
+      });
+
+      const res = await createPublicShare(alice.cookie, favId);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('PRIVATE_SOURCE_NOT_SUPPORTED');
+    });
+
+    it('refuses public share for favorites with a legacy inline apiKey', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const favId = await createFavorite(alice.cookie, {
+        builder_state_json: {
+          chartType: 'bar',
+          savedSource: { apiKey: 'sk_secret' },
+        },
+      });
+
+      const res = await createPublicShare(alice.cookie, favId);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('PRIVATE_SOURCE_NOT_SUPPORTED');
+    });
+
+    it('refuses public share for non-favorite resources', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const sourceRes = await request(app)
+        .post('/api/sources')
+        .set('Cookie', alice.cookie)
+        .send({ name: 'src', type: 'csv', config_json: {}, data_json: [], record_count: 0 });
+      const sourceId = sourceRes.body.id as string;
+
+      const res = await request(app).post('/api/shares').set('Cookie', alice.cookie).send({
+        resource_type: 'source',
+        resource_id: sourceId,
+        target_type: 'public',
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects expires_at in the past', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const favId = await createFavorite(alice.cookie);
+
+      const res = await createPublicShare(alice.cookie, favId, {
+        expires_at: '2000-01-01T00:00:00Z',
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('accepts a future expires_at', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const favId = await createFavorite(alice.cookie);
+
+      const future = new Date(Date.now() + 7 * 24 * 3600 * 1000).toISOString();
+      const res = await createPublicShare(alice.cookie, favId, { expires_at: future });
+
+      expect(res.status).toBe(201);
+      expect(res.body.expires_at).toBeTruthy();
+    });
+  });
+
+  describe('GET /api/public/share/:token (anonymous)', () => {
+    it('returns the favorite payload without auth', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const favId = await createFavorite(alice.cookie);
+      const share = await createPublicShare(alice.cookie, favId);
+      const token = share.body.id as string;
+
+      const res = await request(app).get(`/api/public/share/${token}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.resourceType).toBe('favorite');
+      expect(res.body.name).toBe('My chart');
+      expect(res.body.chartType).toBe('bar');
+      expect(res.body.code).toContain('<dsfr-data-chart');
+      // Must not leak owner identity or builder state blob
+      expect(res.body.ownerId).toBeUndefined();
+      expect(res.body.owner_id).toBeUndefined();
+      expect(res.body.builder_state_json).toBeUndefined();
+      expect(res.body.builderStateJson).toBeUndefined();
+      // Must set X-Robots-Tag to discourage indexing
+      expect(res.headers['x-robots-tag']).toContain('noindex');
+    });
+
+    it('returns 404 for an unknown token', async () => {
+      const res = await request(app).get('/api/public/share/00000000-0000-0000-0000-000000000000');
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 404 for malformed token (sanity check, no DB hit)', async () => {
+      const res = await request(app).get('/api/public/share/not-a-uuid');
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 410 Gone after the owner revokes the share', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const favId = await createFavorite(alice.cookie);
+      const share = await createPublicShare(alice.cookie, favId);
+      const token = share.body.id as string;
+
+      // Mark revoked directly (DELETE via /api/shares/:id removes the row;
+      // here we test the soft-revoke path that shows "Gone" on the public side)
+      await execute('UPDATE shares SET revoked_at = NOW() WHERE id = ?', [token]);
+
+      const res = await request(app).get(`/api/public/share/${token}`);
+      expect(res.status).toBe(410);
+      expect(res.body.code).toBe('REVOKED');
+    });
+
+    it('returns 410 Gone when expired', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const favId = await createFavorite(alice.cookie);
+      const share = await createPublicShare(alice.cookie, favId);
+      const token = share.body.id as string;
+
+      // Force expiration to the past directly in DB (route only accepts future)
+      await execute('UPDATE shares SET expires_at = ? WHERE id = ?', [
+        '2000-01-01 00:00:00',
+        token,
+      ]);
+
+      const res = await request(app).get(`/api/public/share/${token}`);
+      expect(res.status).toBe(410);
+      expect(res.body.code).toBe('EXPIRED');
+    });
+
+    it('returns 410 Gone if the underlying favorite was deleted', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const favId = await createFavorite(alice.cookie);
+      const share = await createPublicShare(alice.cookie, favId);
+      const token = share.body.id as string;
+
+      await execute('DELETE FROM favorites WHERE id = ?', [favId]);
+
+      const res = await request(app).get(`/api/public/share/${token}`);
+      expect(res.status).toBe(410);
+      expect(res.body.code).toBe('GONE');
+    });
+
+    it('does not leak shares whose target_type is not public', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const bob = await registerUser('bob@test.fr');
+      const favId = await createFavorite(alice.cookie);
+
+      // user-targeted share (not public)
+      const shareRes = await request(app).post('/api/shares').set('Cookie', alice.cookie).send({
+        resource_type: 'favorite',
+        resource_id: favId,
+        target_type: 'user',
+        target_id: bob.id,
+      });
+      const token = shareRes.body.id as string;
+
+      const res = await request(app).get(`/api/public/share/${token}`);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/shares/:id (owner revokes link)', () => {
+    it('removes the row so the public link returns 404 afterwards', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const favId = await createFavorite(alice.cookie);
+      const share = await createPublicShare(alice.cookie, favId);
+      const token = share.body.id as string;
+
+      const del = await request(app).delete(`/api/shares/${token}`).set('Cookie', alice.cookie);
+      expect(del.status).toBe(200);
+
+      const res = await request(app).get(`/api/public/share/${token}`);
+      expect(res.status).toBe(404);
+    });
+
+    it('refuses revocation by a non-owner', async () => {
+      const alice = await registerUser('alice@test.fr');
+      const bob = await registerUser('bob@test.fr');
+      const favId = await createFavorite(alice.cookie);
+      const share = await createPublicShare(alice.cookie, favId);
+      const token = share.body.id as string;
+
+      const del = await request(app).delete(`/api/shares/${token}`).set('Cookie', bob.cookie);
+      expect(del.status).toBe(403);
+    });
+  });
+});

--- a/tests/server/test-helpers.ts
+++ b/tests/server/test-helpers.ts
@@ -27,6 +27,7 @@ import favoritesRoutes from '../../server/src/routes/favorites.js';
 import dashboardsRoutes from '../../server/src/routes/dashboards.js';
 import groupsRoutes from '../../server/src/routes/groups.js';
 import sharesRoutes from '../../server/src/routes/shares.js';
+import publicShareRoutes from '../../server/src/routes/public-share.js';
 import cacheRoutes from '../../server/src/routes/cache.js';
 import migrateRoutes from '../../server/src/routes/migrate.js';
 import monitoringRoutes from '../../server/src/routes/monitoring.js';
@@ -110,6 +111,7 @@ export async function createTestApp(options: TestAppOptions = {}): Promise<Expre
   app.use('/api/dashboards', dashboardsRoutes);
   app.use('/api/groups', groupsRoutes);
   app.use('/api/shares', sharesRoutes);
+  app.use('/api/public/share', publicShareRoutes);
   app.use('/api/cache', cacheRoutes);
   app.use('/api/migrate', migrateRoutes);
   app.use('/api/monitoring', monitoringRoutes);


### PR DESCRIPTION
Closes #148 (les sources privées suivront dans une PR dédiée — voir #152).

## Vue d'ensemble

Ajoute un bouton **Partager** dans `/apps/favorites/` qui génère un lien public unique :

- Token = UUID v4 (~122 bits d'entropie), non devinable.
- Page anonyme `/apps/favorites/public-view.html?token=…` rend le favori dans une iframe sandbox, sans header/sidebar, avec bandeau « vue publique partagée ».
- Pas de credentials côté client, pas de fuite d'identité du owner.
- L'auteur peut révoquer le lien à tout moment → 410 Gone immédiat.

## Pourquoi un découpage en 2 PRs

L'issue d'origine demande aussi le support des sources privées (clé API chiffrée, proxy serveur). Cette partie nécessite réécriture des URLs upstream dans le code du favori + déchiffrement + rate limit par token + audit log + tests par provider — c'est ~70% du travail. PR1 couvre déjà la majorité des cas réels (sources publiques data.gouv.fr / ODS / Tabular). PR2 ouverte en suivi.

Pour les favoris liés à une connexion privée, PR1 refuse explicitement la création du lien avec un message clair pointant vers le ticket de suivi.

## Backend

- **Migration v7** : ENUM `shares.target_type` gagne `'public'`, colonnes `expires_at` + `revoked_at`, drop de `uq_share` (qui aurait bloqué plusieurs liens publics par favori).
- `POST /api/shares` étendu pour `target_type='public'` (favoris uniquement, refus des sources privées avec code `PRIVATE_SOURCE_NOT_SUPPORTED`).
- Nouvelle route anonyme `GET /api/public/share/:token` :
  - Retourne `{ resourceType, name, chartType, code }` — pas de owner, pas de blob `builder_state_json`.
  - `X-Robots-Tag: noindex, nofollow` + `Cache-Control: private, max-age=30`.
  - 404 si inexistant/non-public, 410 Gone si révoqué/expiré/favori supprimé.
- Nouveau rate limiter `publicShareRateLimiter` : 60 req/min/IP (un lien fuité ne peut pas servir d'oracle d'aspiration).
- DELETE existant sur `/api/shares/:id` réutilisé pour la révocation (le code a déjà la vérif owner-only).

## Frontend

- Bouton « Partager » dans la barre d'actions du favori.
- Modale 3-états : `loading` → `active` (URL copiable + date d'expiration + bouton Révoquer) ou `error` (message contextualisé).
- `findActivePublicShare` cherche un lien actif existant avant d'en créer un nouveau (évite la prolifération de tokens).
- Page publique avec multi-entrée Vite (`index.html` + `public-view.html`).

## Sécurité

- Token = capability : la modale rappelle « Le lien est secret ».
- Auth cookie explicitement `omit` dans le fetch côté page publique pour éviter toute fuite accidentelle.
- iframe sandbox `allow-scripts allow-same-origin` + meta `noindex`.
- Rate limit dédié sur les routes anonymes.
- Pas de credentials API côté client (les sources privées sont refusées en amont par PR1).

## Tests

- ✅ **17 tests d'intégration serveur** dans [tests/server/public-share.test.ts](tests/server/public-share.test.ts) (création, GET anonyme, 404/410, révocation, rejet sources privées, expiration). ⚠️ **Note** : `tests/server/*` est exclu de la suite vitest par défaut (cf. [vitest.config.ts:20](vitest.config.ts#L20) — nécessite Docker MariaDB local). Ces tests existent comme documentation de comportement et seront exécutés manuellement / dans un futur job CI dédié.
- ✅ **10 tests unitaires** sur le helper client [tests/apps/favorites/share-link.test.ts](tests/apps/favorites/share-link.test.ts) — `buildPublicShareUrl`, `findActivePublicShare` (filtrage actif/révoqué/expiré), `createPublicShare` (gestion erreur `PRIVATE_SOURCE_NOT_SUPPORTED`).
- ✅ Suite frontend : 2913/2913 passants (+10 nouveaux).
- ✅ Lint, typecheck (favorites + server), build favorites OK.

## Test plan manuel (post-merge)

- [ ] Connecté : créer un favori sur une source publique (ex. ODS data.gouv) → cliquer Partager → URL copiée → ouvrir en navigation privée → rendu OK.
- [ ] Le lien marche aussi en navigation privée sans le cookie d'auth.
- [ ] Cliquer 2× sur Partager pour le même favori → réutilise le même token (pas de prolifération).
- [ ] Révoquer le lien → reload de l'onglet anonyme → page « Lien indisponible ».
- [ ] Créer un favori sur une source avec `connectionId` → cliquer Partager → modale en état error avec message explicite.
- [ ] `view-source:` sur la page publique → pas de fuite de cookie / token / owner_id.

## Hors scope (= PR 2, ticket de suivi)

- Proxy serveur pour sources privées (route `/api/public/share/:token/data` + déchiffrement + réécriture URLs).
- Mot de passe sur le lien.
- Statistiques de consultation côté owner (table `share_access_log`).
- Partage public de dashboards (le schéma le supporte déjà).

🤖 Generated with [Claude Code](https://claude.com/claude-code)