### PR TITLE
fix(core): rend visible l'erreur de configuration "id" manquant

### DIFF
--- a/.changeset/dsfr-data-config-error-visible.md
+++ b/.changeset/dsfr-data-config-error-visible.md
@@ -1,0 +1,14 @@
+---
+'dsfr-data': patch
+---
+
+Rend visible l'erreur de configuration `id` manquant (et `source`/`left`/`right`/`on` selon le composant) sur les composants pipeline (`dsfr-data-facets`, `dsfr-data-query`, `dsfr-data-normalize`, `dsfr-data-search`, `dsfr-data-join`).
+
+Auparavant un `console.warn` silencieux laissait le développeur sans aucun signal visible quand un de ces attributs était oublié — le composant ne rendait simplement rien.
+
+Désormais :
+- `console.error` (croix rouge en DevTools) au lieu de `console.warn`
+- attribut `data-dsfr-config-error="<cause>"` posé sur l'élément (visible immédiatement dans l'inspecteur)
+- composants visuels (`dsfr-data-facets`, `dsfr-data-search`) : alerte DSFR `fr-alert--warning` rendue à la place du contenu attendu
+
+`dsfr-data-join` gagne au passage un check explicite de `id`/`left`/`right`/`on` (auparavant `return` silencieux).

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -529,6 +529,7 @@ Sortie : meme tableau avec valeurs nettoyees/renommees.
 ### Attributs
 | Attribut | Type | Defaut | Requis | Description |
 |----------|------|--------|--------|-------------|
+| id | String | - | oui | Identifiant unique. Sans cet attribut, dsfr-data-normalize ne se monte pas (log \`console.error\` + attribut \`data-dsfr-config-error\` sur l'element). |
 | source | String | \`""\` | oui | ID de la source a ecouter |
 | flatten | String | \`""\` | non | Cle du sous-objet a extraire au premier niveau. Utilise pour les APIs Grist, ODS v1, Airtable qui wrappent les donnees sous \`fields\`. Supporte la dot notation (\`data.attributes\`). |
 | numeric | String | \`""\` | non | Champs a forcer en nombre (virgule-separes) : \`"population, surface"\` |
@@ -669,6 +670,7 @@ Sortie : meme tableau, filtre selon les selections de l'utilisateur.
 ### Attributs
 | Attribut | Type | Defaut | Requis | Description |
 |----------|------|--------|--------|-------------|
+| id | String | - | oui | Identifiant unique. Sans cet attribut, dsfr-data-facets affiche une alerte DSFR \`fr-alert--warning\` au lieu des facettes (et pose \`data-dsfr-config-error\` pour le debug). |
 | source | String | \`""\` | oui | ID de la source a ecouter |
 | fields | String | \`""\` | non | Champs a exposer comme facettes (virgule-separes). Vide = auto-detection |
 | labels | String | \`""\` | non | Labels custom : \`"field:Label | field2:Label 2"\` (pipe-separe) |
@@ -796,6 +798,7 @@ Les compteurs de facettes se recalculent dynamiquement.
 ### Attributs
 | Attribut | Type | Defaut | Requis | Description |
 |----------|------|--------|--------|-------------|
+| id | String | - | oui | Identifiant unique. Sans cet attribut, dsfr-data-search affiche une alerte DSFR \`fr-alert--warning\` au lieu de la barre de recherche (et pose \`data-dsfr-config-error\` pour le debug). |
 | source | String | "" | oui | ID de la source a ecouter |
 | fields | String | "" | non | Champs a rechercher (virgule-separes). Vide = tous les champs |
 | placeholder | String | "Rechercher..." | non | Placeholder du champ |
@@ -2654,6 +2657,7 @@ dsfr-data-source (B)  ──────┘
 ### Attributs
 | Attribut | Type | Defaut | Requis | Description |
 |----------|------|--------|--------|-------------|
+| id | String | - | oui | Identifiant unique. Sans cet attribut, dsfr-data-join ne se monte pas (log \`console.error\` + attribut \`data-dsfr-config-error\` sur l'element). |
 | left | String | "" | oui | ID de la source gauche (source principale) |
 | right | String | "" | oui | ID de la source droite |
 | on | String | "" | oui | Cle(s) de jointure (voir formats ci-dessous) |

--- a/packages/core/src/components/dsfr-data-facets.ts
+++ b/packages/core/src/components/dsfr-data-facets.ts
@@ -16,6 +16,7 @@ import {
 import type { ApiAdapter } from '../adapters/api-adapter.js';
 import type { SourceElement } from '../utils/source-element.js';
 import { isUnsafeKey } from '@dsfr-data/shared';
+import { reportConfigError, clearConfigError } from '../utils/config-error.js';
 
 type FacetDisplayMode = 'checkbox' | 'select' | 'multiselect' | 'radio';
 
@@ -150,6 +151,10 @@ export class DsfrDataFacets extends LitElement {
   @state()
   private _liveAnnouncement = '';
 
+  /** Message d'erreur de configuration (id/source manquant) — rendu en alerte DSFR */
+  @state()
+  private _configError: string | null = null;
+
   private _unsubscribe: (() => void) | null = null;
   private _unsubscribeCommands: (() => void) | null = null;
   private _popstateHandler: (() => void) | null = null;
@@ -264,14 +269,21 @@ export class DsfrDataFacets extends LitElement {
 
   private _initialize() {
     if (!this.id) {
-      console.warn('dsfr-data-facets: attribut "id" requis pour identifier la sortie');
+      this._configError = reportConfigError(
+        this,
+        'dsfr-data-facets',
+        'attribut "id" requis pour identifier la sortie'
+      );
       return;
     }
 
     if (!this.source) {
-      console.warn('dsfr-data-facets: attribut "source" requis');
+      this._configError = reportConfigError(this, 'dsfr-data-facets', 'attribut "source" requis');
       return;
     }
+
+    this._configError = null;
+    clearConfigError(this);
 
     if (this._unsubscribe) {
       this._unsubscribe();
@@ -1085,6 +1097,17 @@ export class DsfrDataFacets extends LitElement {
   // --- Rendering ---
 
   render() {
+    if (this._configError) {
+      return html`
+        <div class="fr-alert fr-alert--warning fr-alert--sm" role="alert">
+          <p>
+            <strong>&lt;dsfr-data-facets&gt;</strong> : ${this._configError}. Le composant ne peut
+            pas s'initialiser.
+          </p>
+        </div>
+      `;
+    }
+
     if (this._rawData.length === 0 || this._facetGroups.length === 0) {
       return nothing;
     }

--- a/packages/core/src/components/dsfr-data-join.ts
+++ b/packages/core/src/components/dsfr-data-join.ts
@@ -11,6 +11,7 @@ import {
 } from '../utils/data-bridge.js';
 import { performJoin } from '@dsfr-data/shared';
 import type { JoinType } from '@dsfr-data/shared';
+import { reportConfigError, clearConfigError } from '../utils/config-error.js';
 
 type Row = Record<string, unknown>;
 
@@ -164,9 +165,24 @@ export class DsfrDataJoin extends LitElement {
   private _initialize() {
     this._cleanup();
 
-    if (!this.left || !this.right || !this.on) {
+    if (!this.id) {
+      reportConfigError(this, 'dsfr-data-join', 'attribut "id" requis pour identifier la sortie');
       return;
     }
+
+    if (!this.left || !this.right || !this.on) {
+      const missing = [!this.left && 'left', !this.right && 'right', !this.on && 'on']
+        .filter(Boolean)
+        .join(', ');
+      reportConfigError(
+        this,
+        `dsfr-data-join[${this.id}]`,
+        `attribut(s) requis manquant(s) : ${missing}`
+      );
+      return;
+    }
+
+    clearConfigError(this);
 
     this._leftData = null;
     this._rightData = null;

--- a/packages/core/src/components/dsfr-data-normalize.ts
+++ b/packages/core/src/components/dsfr-data-normalize.ts
@@ -16,6 +16,7 @@ import {
   dispatchSourceCommand,
 } from '../utils/data-bridge.js';
 import type { SourceElement } from '../utils/source-element.js';
+import { reportConfigError, clearConfigError } from '../utils/config-error.js';
 
 /**
  * <dsfr-data-normalize> - Composant de normalisation de donnees
@@ -181,14 +182,20 @@ export class DsfrDataNormalize extends LitElement {
 
   private _initialize() {
     if (!this.id) {
-      console.warn('dsfr-data-normalize: attribut "id" requis pour identifier la sortie');
+      reportConfigError(
+        this,
+        'dsfr-data-normalize',
+        'attribut "id" requis pour identifier la sortie'
+      );
       return;
     }
 
     if (!this.source) {
-      console.warn('dsfr-data-normalize: attribut "source" requis');
+      reportConfigError(this, 'dsfr-data-normalize', 'attribut "source" requis');
       return;
     }
+
+    clearConfigError(this);
 
     // Se desabonner de l'ancienne source
     if (this._unsubscribe) {

--- a/packages/core/src/components/dsfr-data-query.ts
+++ b/packages/core/src/components/dsfr-data-query.ts
@@ -17,6 +17,7 @@ import {
 } from '../utils/data-bridge.js';
 import type { AdapterCapabilities } from '../adapters/api-adapter.js';
 import type { SourceElement } from '../utils/source-element.js';
+import { reportConfigError, clearConfigError } from '../utils/config-error.js';
 
 /**
  * Operateurs de filtre supportes
@@ -288,7 +289,7 @@ export class DsfrDataQuery extends LitElement {
 
   private _initialize() {
     if (!this.id) {
-      console.warn('dsfr-data-query: attribut "id" requis pour identifier la requete');
+      reportConfigError(this, 'dsfr-data-query', 'attribut "id" requis pour identifier la requete');
       return;
     }
 
@@ -303,9 +304,11 @@ export class DsfrDataQuery extends LitElement {
     }
 
     if (!this.source) {
-      console.warn(`dsfr-data-query[${this.id}]: attribut "source" requis`);
+      reportConfigError(this, `dsfr-data-query[${this.id}]`, 'attribut "source" requis');
       return;
     }
+
+    clearConfigError(this);
 
     // Negotiate server-side delegation BEFORE subscribing to data.
     // This sends commands to dsfr-data-source so it re-fetches with the right params.

--- a/packages/core/src/components/dsfr-data-search.ts
+++ b/packages/core/src/components/dsfr-data-search.ts
@@ -13,6 +13,7 @@ import {
   setDataMeta,
 } from '../utils/data-bridge.js';
 import type { SourceElement } from '../utils/source-element.js';
+import { reportConfigError, clearConfigError } from '../utils/config-error.js';
 
 type SearchOperator = 'contains' | 'starts' | 'words';
 
@@ -113,6 +114,10 @@ export class DsfrDataSearch extends LitElement {
 
   @state()
   private _resultCount = 0;
+
+  /** Message d'erreur de configuration (id/source manquant) — rendu en alerte DSFR */
+  @state()
+  private _configError: string | null = null;
 
   private _debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private _unsubscribe: (() => void) | null = null;
@@ -224,14 +229,17 @@ export class DsfrDataSearch extends LitElement {
 
   private _initialize() {
     if (!this.id) {
-      console.warn('dsfr-data-search: attribut "id" requis');
+      this._configError = reportConfigError(this, 'dsfr-data-search', 'attribut "id" requis');
       return;
     }
 
     if (!this.source) {
-      console.warn('dsfr-data-search: attribut "source" requis');
+      this._configError = reportConfigError(this, 'dsfr-data-search', 'attribut "source" requis');
       return;
     }
+
+    this._configError = null;
+    clearConfigError(this);
 
     if (this._unsubscribe) {
       this._unsubscribe();
@@ -511,6 +519,17 @@ export class DsfrDataSearch extends LitElement {
   }
 
   render() {
+    if (this._configError) {
+      return html`
+        <div class="fr-alert fr-alert--warning fr-alert--sm" role="alert">
+          <p>
+            <strong>&lt;dsfr-data-search&gt;</strong> : ${this._configError}. Le composant ne peut
+            pas s'initialiser.
+          </p>
+        </div>
+      `;
+    }
+
     const id = this.id || 'search';
     const labelClass = this.srLabel ? 'fr-label sr-only' : 'fr-label';
 

--- a/packages/core/src/utils/config-error.ts
+++ b/packages/core/src/utils/config-error.ts
@@ -1,0 +1,31 @@
+/**
+ * Marque un composant `dsfr-data-*` comme ayant une erreur de configuration
+ * (attribut requis manquant, etc.).
+ *
+ * Effets :
+ * - `console.error(...)` (croix rouge, plus visible que `console.warn`)
+ * - pose l'attribut `data-dsfr-config-error="<message>"` sur l'element, visible
+ *   immediatement dans l'inspecteur DevTools.
+ *
+ * Les composants visuels (dsfr-data-facets, dsfr-data-search) peuvent en plus
+ * stocker le message retourne dans un `@state()` pour afficher une alerte DSFR
+ * dans leur `render()`.
+ *
+ * @param el            l'element custom concerne
+ * @param componentName ex: "dsfr-data-facets"
+ * @param message       cause lisible, ex: 'attribut "id" requis pour identifier la sortie'
+ * @returns le message (commodite pour assigner a un state)
+ */
+export function reportConfigError(el: HTMLElement, componentName: string, message: string): string {
+  el.setAttribute('data-dsfr-config-error', message);
+  console.error(`${componentName}: ${message}`);
+  return message;
+}
+
+/**
+ * Retire le marqueur d'erreur de configuration pose par `reportConfigError`.
+ * A appeler quand la configuration redevient valide.
+ */
+export function clearConfigError(el: HTMLElement): void {
+  el.removeAttribute('data-dsfr-config-error');
+}

--- a/tests/dsfr-data-facets.test.ts
+++ b/tests/dsfr-data-facets.test.ts
@@ -1588,22 +1588,55 @@ describe('DsfrDataFacets', () => {
   });
 
   describe('_initialize edge cases', () => {
-    it('warns when id is missing', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('logs error and sets data-dsfr-config-error when id is missing', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       facets.id = '';
       facets.source = 'test-source';
       (facets as any)._initialize();
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('id'));
-      warnSpy.mockRestore();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('id'));
+      expect(facets.getAttribute('data-dsfr-config-error')).toMatch(/id/);
+      expect((facets as any)._configError).toMatch(/id/);
+      errorSpy.mockRestore();
     });
 
-    it('warns when source is missing', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('logs error and sets data-dsfr-config-error when source is missing', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       facets.id = 'test-facets';
       facets.source = '';
       (facets as any)._initialize();
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('source'));
-      warnSpy.mockRestore();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('source'));
+      expect(facets.getAttribute('data-dsfr-config-error')).toMatch(/source/);
+      expect((facets as any)._configError).toMatch(/source/);
+      errorSpy.mockRestore();
+    });
+
+    it('clears data-dsfr-config-error when configuration becomes valid', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      // First: trigger error state
+      facets.id = '';
+      facets.source = '';
+      (facets as any)._initialize();
+      expect(facets.hasAttribute('data-dsfr-config-error')).toBe(true);
+      // Then: fix config
+      facets.id = 'test-facets';
+      facets.source = 'test-source';
+      (facets as any)._initialize();
+      expect(facets.hasAttribute('data-dsfr-config-error')).toBe(false);
+      expect((facets as any)._configError).toBeNull();
+      errorSpy.mockRestore();
+    });
+
+    it('renders DSFR alert when _configError is set', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      facets.id = '';
+      facets.source = 'test-source';
+      (facets as any)._initialize();
+      const result = facets.render();
+      // Lit TemplateResult — convert to string via the internal strings array
+      const html = (result as { strings?: ReadonlyArray<string> }).strings?.join('') ?? '';
+      expect(html).toContain('fr-alert');
+      expect(html).toContain('fr-alert--warning');
+      expect(html).toContain('dsfr-data-facets');
     });
   });
 

--- a/tests/dsfr-data-join.test.ts
+++ b/tests/dsfr-data-join.test.ts
@@ -611,4 +611,47 @@ describe('DsfrDataJoin', () => {
       expect(join.getError()).toBeNull();
     });
   });
+
+  describe('_initialize edge cases', () => {
+    it('logs error and sets data-dsfr-config-error when id is missing', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      // Override the default 'test-join' id set in beforeEach
+      join.id = '';
+      join.left = 'a';
+      join.right = 'b';
+      join.on = 'code';
+      (join as unknown as { _initialize(): void })._initialize();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('attribut "id" requis'));
+      expect(join.getAttribute('data-dsfr-config-error')).toMatch(/id/);
+      errorSpy.mockRestore();
+    });
+
+    it('logs error when left/right/on are missing', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      join.id = 'test-join';
+      join.left = '';
+      join.right = '';
+      join.on = '';
+      (join as unknown as { _initialize(): void })._initialize();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('left'));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('right'));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('on'));
+      expect(join.getAttribute('data-dsfr-config-error')).toMatch(/left/);
+      errorSpy.mockRestore();
+    });
+
+    it('clears data-dsfr-config-error when config becomes valid', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      join.id = '';
+      (join as unknown as { _initialize(): void })._initialize();
+      expect(join.hasAttribute('data-dsfr-config-error')).toBe(true);
+      join.id = 'test-join';
+      join.left = 'a';
+      join.right = 'b';
+      join.on = 'code';
+      (join as unknown as { _initialize(): void })._initialize();
+      expect(join.hasAttribute('data-dsfr-config-error')).toBe(false);
+      errorSpy.mockRestore();
+    });
+  });
 });

--- a/tests/dsfr-data-normalize.test.ts
+++ b/tests/dsfr-data-normalize.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { DsfrDataNormalize } from '@/components/dsfr-data-normalize.js';
 import {
   clearDataCache,
@@ -957,6 +957,40 @@ describe('DsfrDataNormalize', () => {
       expect(normalize.getEffectiveWhere()).toBe('');
 
       mockSource.remove();
+    });
+  });
+
+  describe('_initialize edge cases', () => {
+    it('logs error and sets data-dsfr-config-error when id is missing', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      normalize.source = 'test-source';
+      (normalize as unknown as { _initialize(): void })._initialize();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('attribut "id" requis'));
+      expect(normalize.getAttribute('data-dsfr-config-error')).toMatch(/id/);
+      errorSpy.mockRestore();
+    });
+
+    it('logs error and sets data-dsfr-config-error when source is missing', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      normalize.id = 'test-normalize';
+      normalize.source = '';
+      (normalize as unknown as { _initialize(): void })._initialize();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('attribut "source" requis'));
+      expect(normalize.getAttribute('data-dsfr-config-error')).toMatch(/source/);
+      errorSpy.mockRestore();
+    });
+
+    it('clears data-dsfr-config-error when config becomes valid', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      normalize.id = '';
+      normalize.source = '';
+      (normalize as unknown as { _initialize(): void })._initialize();
+      expect(normalize.hasAttribute('data-dsfr-config-error')).toBe(true);
+      normalize.id = 'test-normalize';
+      normalize.source = 'test-source';
+      (normalize as unknown as { _initialize(): void })._initialize();
+      expect(normalize.hasAttribute('data-dsfr-config-error')).toBe(false);
+      errorSpy.mockRestore();
     });
   });
 });

--- a/tests/dsfr-data-query.test.ts
+++ b/tests/dsfr-data-query.test.ts
@@ -748,31 +748,46 @@ describe('DsfrDataQuery', () => {
   });
 
   describe('_initialize edge cases', () => {
-    it('warns when no id', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('logs error and sets data-dsfr-config-error when no id', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       query.source = 'test-source';
       (query as any)._initialize();
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('attribut "id" requis'));
-      warnSpy.mockRestore();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('attribut "id" requis'));
+      expect(query.getAttribute('data-dsfr-config-error')).toMatch(/id/);
+      errorSpy.mockRestore();
     });
 
-    it('warns when no source attribute', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('logs error when no source attribute', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       query.id = 'test-query';
       query.source = '';
       (query as any)._initialize();
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('attribut "source" requis'));
-      warnSpy.mockRestore();
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('attribut "source" requis'));
+      expect(query.getAttribute('data-dsfr-config-error')).toMatch(/source/);
+      errorSpy.mockRestore();
     });
 
     it('does not initialize without source', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       query.id = 'test-query';
       query.source = '';
       (query as any)._initialize();
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('attribut "source" requis'));
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('attribut "source" requis'));
       expect((query as any)._unsubscribe).toBeNull();
-      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('clears data-dsfr-config-error when config becomes valid', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      query.id = '';
+      query.source = '';
+      (query as any)._initialize();
+      expect(query.hasAttribute('data-dsfr-config-error')).toBe(true);
+      query.id = 'test-query';
+      query.source = 'test-source';
+      (query as any)._initialize();
+      expect(query.hasAttribute('data-dsfr-config-error')).toBe(false);
+      errorSpy.mockRestore();
     });
 
     it('deprecated properties (apiType, baseUrl, etc.) do not exist on element', () => {

--- a/tests/dsfr-data-search.test.ts
+++ b/tests/dsfr-data-search.test.ts
@@ -1073,22 +1073,36 @@ describe('DsfrDataSearch', () => {
   // --- _initialize edge cases ---
 
   describe('_initialize edge cases', () => {
-    it('warns and returns if no id', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('logs error and sets data-dsfr-config-error if no id', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       search.source = 'test-source';
       search.connectedCallback();
 
-      expect(warnSpy).toHaveBeenCalledWith('dsfr-data-search: attribut "id" requis');
-      warnSpy.mockRestore();
+      expect(errorSpy).toHaveBeenCalledWith('dsfr-data-search: attribut "id" requis');
+      expect(search.getAttribute('data-dsfr-config-error')).toMatch(/id/);
+      expect((search as any)._configError).toMatch(/id/);
+      errorSpy.mockRestore();
     });
 
-    it('warns and returns if no source', () => {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    it('logs error and sets data-dsfr-config-error if no source', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       search.id = 'test-search';
       search.connectedCallback();
 
-      expect(warnSpy).toHaveBeenCalledWith('dsfr-data-search: attribut "source" requis');
-      warnSpy.mockRestore();
+      expect(errorSpy).toHaveBeenCalledWith('dsfr-data-search: attribut "source" requis');
+      expect(search.getAttribute('data-dsfr-config-error')).toMatch(/source/);
+      errorSpy.mockRestore();
+    });
+
+    it('renders DSFR alert when _configError is set', () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      search.source = 'test-source';
+      search.connectedCallback();
+      const result = search.render();
+      const html = (result as { strings?: ReadonlyArray<string> }).strings?.join('') ?? '';
+      expect(html).toContain('fr-alert');
+      expect(html).toContain('fr-alert--warning');
+      expect(html).toContain('dsfr-data-search');
     });
 
     it('unsubscribes from previous source on re-initialization', () => {

--- a/tests/utils/config-error.test.ts
+++ b/tests/utils/config-error.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { reportConfigError, clearConfigError } from '@/utils/config-error.js';
+
+describe('config-error utility', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reportConfigError sets the data-dsfr-config-error attribute', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const el = document.createElement('div');
+    reportConfigError(el, 'dsfr-data-foo', 'attribut "id" requis');
+    expect(el.getAttribute('data-dsfr-config-error')).toBe('attribut "id" requis');
+  });
+
+  it('reportConfigError logs to console.error with prefixed component name', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const el = document.createElement('div');
+    reportConfigError(el, 'dsfr-data-foo', 'attribut "id" requis');
+    expect(errorSpy).toHaveBeenCalledWith('dsfr-data-foo: attribut "id" requis');
+  });
+
+  it('reportConfigError returns the message (for storing in component state)', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const el = document.createElement('div');
+    const result = reportConfigError(el, 'dsfr-data-foo', 'attribut "source" requis');
+    expect(result).toBe('attribut "source" requis');
+  });
+
+  it('clearConfigError removes the data-dsfr-config-error attribute', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const el = document.createElement('div');
+    reportConfigError(el, 'dsfr-data-foo', 'error');
+    expect(el.hasAttribute('data-dsfr-config-error')).toBe(true);
+    clearConfigError(el);
+    expect(el.hasAttribute('data-dsfr-config-error')).toBe(false);
+  });
+
+  it('clearConfigError is a no-op when no error was set', () => {
+    const el = document.createElement('div');
+    expect(() => clearConfigError(el)).not.toThrow();
+    expect(el.hasAttribute('data-dsfr-config-error')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Résumé

Fix l'issue #161 : sur les 5 composants pipeline (`dsfr-data-facets`, `dsfr-data-query`, `dsfr-data-normalize`, `dsfr-data-search`, `dsfr-data-join`), un attribut `id` (ou `source`/`left`/`right`/`on`) oublié déclenchait uniquement un `console.warn` silencieux. Le composant ne montait rien dans le DOM, sans aucun signal visible pour le développeur.

Désormais l'erreur de configuration est **toujours détectable** :

- **`console.error`** au lieu de `console.warn` (croix rouge bien visible)
- **attribut `data-dsfr-config-error="<cause>"`** posé sur l'élément lui-même, visible immédiatement dans l'inspecteur DOM
- **alerte DSFR `fr-alert--warning`** rendue à la place du contenu attendu pour les composants visuels (`dsfr-data-facets`, `dsfr-data-search`)

Au passage, `dsfr-data-join` gagne un check explicite (`id`/`left`/`right`/`on`) — auparavant il avait un simple `return` silencieux qui rendait le diagnostic impossible.

## Fichiers touchés

- `packages/core/src/utils/config-error.ts` (nouveau) — utilitaire `reportConfigError` / `clearConfigError`
- 5 composants patchés : facets, query, normalize, search, join
- `apps/builder-ia/src/skills.ts` — ajout de la ligne `id | requis` dans les 4 tables qui ne l'avaient pas (`dsfrDataQuery` l'avait déjà)
- Tests : 1 nouveau fichier (`tests/utils/config-error.test.ts`) + tests adaptés dans les 5 fichiers composants

## Test plan

- [x] `npm run test:run` → **2944/2944** passants
- [x] `npm run lint` → 0 warning
- [x] `npm run typecheck` → 0 erreur
- [x] `npm run build` → 4 bundles produits (core/map/world-map/full), tailles inchangées
- [ ] Visuellement : créer un `<dsfr-data-facets>` sans `id` → vérifier que l'alerte DSFR s'affiche en jaune au lieu d'un blanc silencieux
- [ ] DevTools : inspecter un `<dsfr-data-query>` sans `id` → vérifier `data-dsfr-config-error="attribut \"id\" requis…"` dans le tree

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)