### PR TITLE
fix(core): inclut dsfr-data-join dans le bundle core

### DIFF
--- a/.changeset/dsfr-data-join-in-core.md
+++ b/.changeset/dsfr-data-join-in-core.md
@@ -1,0 +1,9 @@
+---
+'dsfr-data': patch
+---
+
+Inclut `dsfr-data-join` dans le bundle `dsfr-data.core.{esm,umd}.js`.
+
+Auparavant le composant n'était disponible que via le bundle complet `dsfr-data.umd.js`. Tous les autres composants pipeline (transformateurs purs : `dsfr-data-normalize`, `dsfr-data-query`...) étaient déjà dans `core` — `dsfr-data-join` était la seule exception, ce qui transformait silencieusement les `<dsfr-data-join>` en `HTMLUnknownElement` quand le code généré par le builder (qui charge `core.umd.js` par défaut) tentait de l'utiliser. Aucune erreur, aucun warning, juste un pipeline qui ne produit rien.
+
+Surcoût : ~3 KB (raw) / ~1 KB (gzip) sur le bundle core.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,12 +415,12 @@ git remote set-url --add --push origin https://github.com/mef-snum-miweb/dsfr-da
 
 Le build (`scripts/build-lib.ts`) produit 4 bundles dans `packages/core/dist/` :
 
-| Bundle | Contenu | Taille gzip |
+| Bundle | Contenu | Taille gzip (ESM) |
 |--------|---------|-------------|
-| `dsfr-data.core.{esm,umd}.js` | Tous composants sauf `dsfr-data-world-map` et `dsfr-data-map` | ~52 Ko |
-| `dsfr-data.world-map.{esm,umd}.js` | `dsfr-data-world-map` (d3-geo, topojson) | ~30 Ko |
-| `dsfr-data.map.{esm,umd}.js` | `dsfr-data-map` + `dsfr-data-map-layer` (Leaflet charge dynamiquement) | ~15 Ko |
-| `dsfr-data.{esm,umd}.js` | Tout-en-un | ~80 Ko |
+| `dsfr-data.core.{esm,umd}.js` | Tous composants sauf `dsfr-data-world-map`, `dsfr-data-map*`. **Inclut `dsfr-data-join`** (pur transformateur). | ~61 Ko |
+| `dsfr-data.world-map.{esm,umd}.js` | `dsfr-data-world-map` (d3-geo, topojson) | ~31 Ko |
+| `dsfr-data.map.{esm,umd}.js` | `dsfr-data-map` + `dsfr-data-map-layer` + popup/timeline (Leaflet charge dynamiquement en chunks separes) | ~33 Ko |
+| `dsfr-data.{esm,umd}.js` | Tout-en-un | ~97 Ko |
 
 Le code genere par les builders et le playground utilise le **core** bundle par defaut.
 Le TopoJSON (`packages/core/dist/data/world-countries-110m.json`) est charge par fetch a l'execution.

--- a/packages/core/src/index-core.ts
+++ b/packages/core/src/index-core.ts
@@ -8,6 +8,7 @@
 // Composants de donnees
 export { DsfrDataSource } from './components/dsfr-data-source.js';
 export { DsfrDataQuery } from './components/dsfr-data-query.js';
+export { DsfrDataJoin } from './components/dsfr-data-join.js';
 export { DsfrDataNormalize } from './components/dsfr-data-normalize.js';
 export { DsfrDataFacets } from './components/dsfr-data-facets.js';
 export { DsfrDataSearch } from './components/dsfr-data-search.js';


### PR DESCRIPTION
## Résumé

Fix l'issue #157 : `dsfr-data-join` était le seul composant transformateur pur **non-spatial** absent du bundle `dsfr-data.core.{esm,umd}.js`. Tous ses cousins (`dsfr-data-normalize`, `dsfr-data-query`, etc.) y étaient déjà.

**Conséquence du bug** : un `<dsfr-data-join>` dans une page qui charge `dsfr-data.core.umd.js` (ce que fait le code généré par le builder par défaut) restait silencieusement un `HTMLUnknownElement`. Aucune erreur, aucun warning, juste un pipeline vide en aval.

## Changements

- `packages/core/src/index-core.ts` : export ajouté pour `DsfrDataJoin`
- `CLAUDE.md` : tableau des bundles mis à jour (mention explicite de `dsfr-data-join` dans core + tailles gzip rafraîchies — les valeurs étaient obsolètes : core 52→61 Ko, full 80→97 Ko)
- Changeset patch

## Impact taille bundle core

| Fichier | Avant | Après | Δ |
|---|---|---|---|
| `dsfr-data.core.esm.js` (raw) | 287 KB | 292 KB | +5 KB |
| `dsfr-data.core.umd.js` (raw) | 250 KB | 253 KB | +3 KB |
| **`dsfr-data.core.umd.js` (gzip)** | **~56 KB** | **~57 KB** | **+1 KB** |

Très en-dessous du seuil de douleur, et conforme à ce qu'annonçait l'issue (~2 KB estimé).

## Test plan

- [x] `npm run build` → bundles produits OK
- [x] `npm run test:run` → **2929/2929** passants
- [x] `npm run lint` → 0 warning
- [x] `npm run typecheck` → 0 erreur
- [x] Vérification présence dans le bundle :
  - `\`dsfr-data-join\`` apparaît dans `dsfr-data.core.umd.js` (registry custom elements)
  - Logique `performJoin` (importée depuis `@dsfr-data/shared`) présente dans le core
- [ ] Test manuel : reproduire le snippet du ticket (`<script src=".../dsfr-data.core.umd.js">` + `<dsfr-data-join>` enfant) → vérifier `customElements.get('dsfr-data-join')` retourne une classe et la jointure s'exécute

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)