### PR TITLE
fix(ci): SRI manquants + Gitleaks OSS pour le miroir mef-snum-miweb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,10 +184,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+      - name: Install Gitleaks (OSS binary)
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: "8.21.2"
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Gitleaks
+        run: gitleaks git --verbose --redact --exit-code 1
 
   sast:
     name: Security — SAST

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,37 @@ A la fin de chaque session de developpement avec Claude Code, suivre ce workflow
 
 Les changesets s'accumulent jusqu'a la prochaine release. Chaque release consomme tous les changesets en attente et genere une entree unique dans le CHANGELOG.
 
+## Remotes Git (miroir mef-snum-miweb)
+
+Le repo est pousse simultanement sur **deux remotes GitHub** depuis 2026-05-24 :
+- `bmatge/dsfr-data` — repo historique (fetch + push)
+- `mef-snum-miweb/dsfr-data` — miroir org MEF SNUM (push uniquement)
+
+Configuration : un seul remote `origin` avec **multi-push URLs**. Un `git push origin <branche>` envoie aux deux destinations en une seule commande.
+
+```bash
+# Inspection
+git remote -v
+# origin  https://github.com/bmatge/dsfr-data.git (fetch)
+# origin  https://github.com/bmatge/dsfr-data.git (push)
+# origin  https://github.com/mef-snum-miweb/dsfr-data.git (push)
+```
+
+Si la config est perdue (reclone, autre poste) :
+
+```bash
+git remote set-url --add --push origin https://github.com/bmatge/dsfr-data.git
+git remote set-url --add --push origin https://github.com/mef-snum-miweb/dsfr-data.git
+```
+
+**Limites** :
+- Les merges effectues directement cote GitHub (UI bmatge, bot Dependabot, Changesets release PR...) **ne se propagent pas** au miroir miweb. Le miroir n'est rafraichi qu'au prochain `git push` local. Pour resynchroniser ponctuellement apres un merge UI :
+  ```bash
+  git fetch origin && git push origin refs/remotes/origin/main:refs/heads/main
+  ```
+- Les workflows GitHub Actions tournent **aussi cote miweb** sur chaque push. Les jobs qui dependent de secrets non configures la-bas (npm token, deploy keys, Tauri release...) vont failer. A desactiver dans `Settings → Actions` du repo miweb si besoin.
+- Tags : pousser explicitement via `git push origin --tags` apres une release pour les propager.
+
 ## APIs externes utilisees
 
 - Grist : docs.getgrist.com, grist.numerique.gouv.fr

--- a/guide/examples/education-gouv-1.html
+++ b/guide/examples/education-gouv-1.html
@@ -8,14 +8,14 @@
 
   <!-- DSFR CSS -->
 
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
 
   <!-- DSFR Chart -->
 
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css">
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
 
   <!-- dsfr-data (web components) -->
 
@@ -23,7 +23,7 @@
 
   <!-- DSFR JS (interactions UI) -->
 
-  <script defer type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js"></script>
+  <script defer type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
 
 </head>
 


### PR DESCRIPTION
## Summary

Repare le CI rouge sur `main` (bmatge) et le miroir nouvellement cree `mef-snum-miweb/dsfr-data`.

- **SRI manquants** sur [guide/examples/education-gouv-1.html](guide/examples/education-gouv-1.html) : 6 tags CDN sans hash, ajoutes par le commit `47c62da` (13 mai 2026) sans passer par `npm run generate-sri`. Le job `quality > Check SRI hashes on CDN refs` failait depuis. → `npm run generate-sri` execute, hashes regeneres.
- **Gitleaks license error** sur le miroir : le wrapper `gitleaks/gitleaks-action@v2` est payant pour les organisations GitHub depuis 2022 (gratuit uniquement comptes perso). → Bascule vers le binaire OSS gitleaks v8.21.2 (MIT, gratuit partout). Scan via `gitleaks git`, la config `.gitleaks.toml` a la racine reste auto-detectee.
- **Doc miroir** ajoutee au [CLAUDE.md](CLAUDE.md) (section « Remotes Git (miroir mef-snum-miweb) ») : config multi-push, commandes de reconfig, limites connues.

A noter : un 3eme fail CI (`Security — SCA & config > npm audit — mcp-server`, `fast-uri <=3.1.1` high) est couvert par la PR Dependabot #153 deja ouverte, a merger separement.

## Test plan

- [x] `npm run check:sri` passe localement (`0 tag(s) a mettre a jour`)
- [ ] Job `quality` vert en CI
- [ ] Job `Security — Secrets` (Gitleaks OSS) vert en CI sur les 2 repos
- [ ] Apres merge : `git push origin main` propage vers miweb, run CI miweb vert

🤖 Generated with [Claude Code](https://claude.com/claude-code)