### PR TITLE
fix(map-popup): lazy lookup du <template> enfant (closes #156)

### DIFF
--- a/.changeset/fix-map-popup-template-timing.md
+++ b/.changeset/fix-map-popup-template-timing.md
@@ -1,0 +1,9 @@
+---
+'dsfr-data': patch
+---
+
+fix(map-popup): `<dsfr-data-map-popup>` trouve maintenant son `<template>` enfant même quand le script de la lib est chargé dans `<head>` sans `defer`.
+
+Avant : le lookup `querySelector('template')` était fait dans `connectedCallback()`, qui est appelé par le parser HTML avant que les enfants du composant ne soient parsés. Résultat : `_templateEl` restait `null`, et le composant retombait silencieusement sur l'affichage en tableau auto (`_buildAutoTable`) sans warning. Closes #156.
+
+Maintenant : le lookup est différé au premier appel de `hasTemplate()` ou `_renderTemplate()` (typiquement au clic sur un marker), moment où le `<template>` enfant est garanti présent. Le résultat est ensuite mis en cache.

--- a/packages/core/src/components/dsfr-data-map-popup.ts
+++ b/packages/core/src/components/dsfr-data-map-popup.ts
@@ -39,6 +39,7 @@ export class DsfrDataMapPopup extends LitElement {
   private _panelEl: HTMLDivElement | null = null;
   private _modalEl: HTMLDivElement | null = null;
   private _templateEl: HTMLTemplateElement | null = null;
+  private _templateRead = false;
   /** Currently displayed record (used by close to know state) */
   _currentRecord: Record<string, unknown> | null = null;
 
@@ -49,8 +50,20 @@ export class DsfrDataMapPopup extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this._templateEl = this.querySelector('template');
+    // Note: do not query for <template> child here. When the component script
+    // is loaded in <head> without `defer`, customElements.define() runs before
+    // the body parser reaches the element, and connectedCallback fires before
+    // the <template> child is parsed. The lookup is deferred to _getTemplate(),
+    // which caches its result on first call.
     this._injectStyles();
+  }
+
+  private _getTemplate(): HTMLTemplateElement | null {
+    if (!this._templateRead) {
+      this._templateEl = this.querySelector('template');
+      this._templateRead = true;
+    }
+    return this._templateEl;
   }
 
   disconnectedCallback() {
@@ -94,7 +107,7 @@ export class DsfrDataMapPopup extends LitElement {
 
   /** Returns true if a custom template is defined */
   hasTemplate(): boolean {
-    return !!this._templateEl;
+    return !!this._getTemplate();
   }
 
   /** Close any open panel/modal */
@@ -107,11 +120,12 @@ export class DsfrDataMapPopup extends LitElement {
   // --- Template rendering ---
 
   private _renderTemplate(record: Record<string, unknown>): string {
-    if (!this._templateEl) {
+    const tpl = this._getTemplate();
+    if (!tpl) {
       return this._buildAutoTable(record);
     }
 
-    const templateHtml = this._templateEl.innerHTML;
+    const templateHtml = tpl.innerHTML;
     return templateHtml.replace(/\{\{([^}]+)\}\}/g, (_match, field: string) => {
       const value = getByPath(record, field.trim());
       return value !== undefined ? escapeHtml(String(value)) : '';

--- a/tests/dsfr-data-map.test.ts
+++ b/tests/dsfr-data-map.test.ts
@@ -482,6 +482,34 @@ describe('DsfrDataMapPopup', () => {
     it('returns false when no template child', () => {
       expect(popup.hasTemplate()).toBe(false);
     });
+
+    it('finds template added after connectedCallback (lazy lookup)', () => {
+      // Reproduces issue #156: when the component script is loaded in <head>
+      // without `defer`, customElements.define() runs before the body parser
+      // reaches the <template> child. connectedCallback fires with no children
+      // visible. The fix defers the lookup to the first call to hasTemplate()
+      // or _renderTemplate(), which happens after the parser has attached the
+      // template (typically on user interaction like a marker click).
+      const el = document.createElement('dsfr-data-map-popup');
+      document.body.appendChild(el);
+      const tpl = document.createElement('template');
+      tpl.innerHTML = '<p>{{nom}}</p>';
+      el.appendChild(tpl);
+      expect(el.hasTemplate()).toBe(true);
+      document.body.removeChild(el);
+    });
+
+    it('uses template content added after connectedCallback', () => {
+      const el = document.createElement('dsfr-data-map-popup');
+      document.body.appendChild(el);
+      const tpl = document.createElement('template');
+      tpl.innerHTML = '<p><strong>{{nom}}</strong></p>';
+      el.appendChild(tpl);
+      const html = el.getPopupHtml({ nom: 'Paris' });
+      expect(html).toContain('<strong>Paris</strong>');
+      expect(html).not.toContain('<table');
+      document.body.removeChild(el);
+    });
   });
 
   describe('Light DOM', () => {


### PR DESCRIPTION
## Summary

Fix #156 — `<dsfr-data-map-popup>` ignorait silencieusement son `<template>` enfant quand le script de la lib est chargé en `<head>` sans `defer`.

## Cause

`querySelector('template')` était exécuté dans `connectedCallback()`, qui se déclenche **avant** que le parser HTML ait attaché les enfants du composant. `_templateEl` restait `null` et le composant retombait sur l'affichage en tableau auto (`_buildAutoTable`) sans aucun warning.

## Fix

Lookup différé au premier appel de `hasTemplate()` ou `_renderTemplate()` (typiquement au clic sur un marker), avec mise en cache via `_templateRead`.

```diff
-  connectedCallback() {
-    super.connectedCallback();
-    this._templateEl = this.querySelector('template');
-    this._injectStyles();
-  }
+  connectedCallback() {
+    super.connectedCallback();
+    this._injectStyles();
+  }
+
+  private _getTemplate(): HTMLTemplateElement | null {
+    if (!this._templateRead) {
+      this._templateEl = this.querySelector('template');
+      this._templateRead = true;
+    }
+    return this._templateEl;
+  }
```

C'est l'option 1 (minimale, recommandée) de l'issue #156. Option 3 (hook `renderer`) reportée si besoin d'expressions / mapping de valeurs.

## Test plan

- [x] Test ajouté : `hasTemplate()` trouve un `<template>` ajouté **après** `connectedCallback`
- [x] Test ajouté : `_renderTemplate()` utilise bien ce template et n'invoque pas le fallback `_buildAutoTable`
- [x] Tests existants conservés (279/279 passent)
- [ ] Reproduction de l'issue confirmée résolue en environnement réel (carte IRVE SNUM-MIWEB) — à valider après merge + release

🤖 Generated with [Claude Code](https://claude.com/claude-code)