### PR TITLE
chore(ci): bump Node 20 -> 24 sur workflows + Dockerfiles (closes #169)

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci
@@ -94,7 +94,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: npm audit — mcp-server
         working-directory: mcp-server
@@ -131,7 +131,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: npm audit (root, moderate+)
         id: audit_root

--- a/.github/workflows/deploy-grist-widgets.yml
+++ b/.github/workflows/deploy-grist-widgets.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/publish-repos.yml
+++ b/.github/workflows/publish-repos.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Install Rust stable

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 COPY packages/shared/package.json packages/shared/

--- a/docker/Dockerfile.db
+++ b/docker/Dockerfile.db
@@ -1,5 +1,5 @@
 # Build stage (same as base Dockerfile + server build)
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 COPY packages/shared/package.json packages/shared/

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "lint-staged": "^16.4.0",
         "playwright": "^1.58.2",
         "prettier": "^3.8.3",
+        "tsx": "^4.22.3",
         "typescript": "^5.3.0",
         "typescript-eslint": "^8.60.0",
         "vite": "^8.0.14",
@@ -9489,6 +9490,40 @@
         "node": ">=0.6.x"
       }
     },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -10387,21 +10422,6 @@
         "node": ">= 0.8"
       }
     },
-    "server/node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "server/node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -10560,25 +10580,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "server/node_modules/tsx": {
-      "version": "4.22.3",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
-      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "~0.28.0"
-      },
-      "bin": {
-        "tsx": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
       }
     },
     "server/node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "lint-staged": "^16.4.0",
     "playwright": "^1.58.2",
     "prettier": "^3.8.3",
+    "tsx": "^4.22.3",
     "typescript": "^5.3.0",
     "typescript-eslint": "^8.60.0",
     "vite": "^8.0.14",


### PR DESCRIPTION
## Summary

Closes #169. Bump de Node 20 vers Node 24 (Active LTS) sur tous les workflows GitHub Actions, les Dockerfiles, et fix du hoisting de `tsx`.

## Pourquoi Node 24 (et pas 22) ?

À mai 2026 :
- **Node 20** = EOL en avril 2026
- **Node 22** = Maintenance LTS (jusqu'à avril 2027) — pas la peine de viser ça si on bump
- **Node 24** = Active LTS depuis octobre 2025 (jusqu'à avril 2028) — *la* cible
- **Node 26** = Current (pair = LTS, mais juste sorti en avril 2026) — pas encore Active LTS

Autant aller directement sur Node 24 et gagner ~2 ans de support.

## Périmètre

- `.github/workflows/` : 8 occurrences dans 5 workflows
  - `ci.yml` (4 jobs)
  - `release.yml`
  - `changeset-release.yml`
  - `publish-repos.yml`
  - `deploy-grist-widgets.yml`
- `docker/Dockerfile` et `docker/Dockerfile.db` : `node:20-alpine` → `node:24-alpine`
- `package.json` : ajout de `tsx` dans `devDependencies` du root

## Fix tsx hoisting

Le script `build:all` du root invoque `npx tsx scripts/generate-examples-list.ts`, mais `tsx` n'était déclaré que dans `server/devDependencies`. Conséquences :

| Contexte | Comportement |
|---|---|
| Local (npm 10 + Node 22+) | `tsx` est hoisté à `node_modules/.bin/` via workspace hoisting → OK |
| `Dockerfile` (sans `server/package.json`) | `tsx` pas installé → `npx tsx` télécharge à la volée → OK |
| `Dockerfile.db` (avec `server/package.json`) | `tsx` censé être installé via workspace, mais hoisting du bin **échoue** dans Docker avec Node 22+/npm 10 → `sh: tsx: not found` → ❌ |

Le fix : déclarer `tsx` explicitement comme devDep du root (où il est utilisé), au lieu de s'appuyer sur le hoisting accidentel depuis un sub-workspace.

## Test plan

- [x] Typecheck local OK sur Node v22.19.0 (et a fortiori sur Node 24 — TypeScript supporte largement)
- [ ] CI complète verte sur cette branche (Node 24 réel)
- [ ] Image `dsfr-data-db` build avec succès (avec Node 24 + tsx en devDep root)
- [ ] Build Tauri cross-platform (workflow `release.yml`) — ne se lance que sur tag `v*`, à valider à la prochaine release
- [ ] Après merge : rouvrir / recréer la PR Dependabot lint-staged 17

🤖 Generated with [Claude Code](https://claude.com/claude-code)