### PR TITLE
build(docker): propage VITE_PROXY_URL et VITE_LIB_URL au build Docker (#168 PR-1)

### DIFF
--- a/.changeset/vite-build-args-docker.md
+++ b/.changeset/vite-build-args-docker.md
@@ -1,0 +1,11 @@
+---
+'dsfr-data': patch
+---
+
+build(docker): propage `VITE_PROXY_URL` et `VITE_LIB_URL` au build Docker via `ARG`/`ENV` (Dockerfile + Dockerfile.db) et `build.args` (docker-compose.yml + docker-compose.db.yml).
+
+Avant : ces variables étaient documentées dans `.env.example` mais n'arrivaient jamais jusqu'au build Vite à l'intérieur du conteneur. Pire, l'accès via indirection (`const _meta = import.meta as any; _meta.env?.VITE_PROXY_URL`) dans `packages/shared/src/api/proxy-config.ts` empêchait Vite de faire la substitution statique même en build local — les bundles retombaient systématiquement sur le fallback `https://chartsbuilder.matge.com`.
+
+Maintenant : `import.meta.env.VITE_PROXY_URL` est accédé directement (déclaration de type globale locale, sans coupler `@dsfr-data/shared` à Vite). Un `.env` avec `VITE_PROXY_URL=https://exemple.fr` produit un bundle où le domaine de référence est remplacé. Si la variable est absente, le fallback historique est préservé (la transformation en fail-fast est planifiée pour une future PR de l'epic #168).
+
+Premier pas concret de l'epic #168 — rendre dsfr-data self-hostable (PR-1 du plan de découpage).

--- a/.env.example
+++ b/.env.example
@@ -20,19 +20,23 @@ APP_DOMAIN=chartsbuilder.matge.com
 # URL du proxy CORS (build-time)
 # ---------------------------------------------------------------------------
 # URL de base du proxy CORS pour les appels API en production.
-# Si non defini, le fallback est https://${APP_DOMAIN}.
+# Propagee au build Docker via docker-compose `build.args` (cf. issue #168).
+# Si non definie, le fallback en dur est 'https://chartsbuilder.matge.com'
+# (le domaine de deploiement de reference — sera transforme en fail-fast
+# pour les deploiements self-hosted dans une future PR de l'epic #168).
 # En dev, cette variable est ignoree (le proxy Vite est utilise).
 # VITE_PROXY_URL=https://chartsbuilder.matge.com
 
 # ---------------------------------------------------------------------------
 # URL de la librairie JS dans le code genere (build-time)
 # ---------------------------------------------------------------------------
-# URL de base pour les bundles gouv-widgets dans le code HTML genere.
+# URL de base pour les bundles dsfr-data dans le code HTML genere (builders).
+# Propagee au build Docker via docker-compose `build.args` (cf. issue #168).
 # Valeurs speciales :
-#   "unpkg"    → https://unpkg.com/gouv-widgets/dist
-#   "jsdelivr" → https://cdn.jsdelivr.net/npm/gouv-widgets/dist
+#   "jsdelivr" (defaut si non defini) → https://cdn.jsdelivr.net/npm/dsfr-data@0/dist
+#   "unpkg"                           → https://unpkg.com/dsfr-data@0/dist
+#   "self"                            → ${VITE_PROXY_URL}/dist (self-hosted)
 # Sinon, une URL custom (ex: https://cdn.example.com/dist).
-# Si non defini, utilise ${VITE_PROXY_URL}/dist (self-hosted).
 # VITE_LIB_URL=unpkg
 
 # ---------------------------------------------------------------------------

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,18 @@ COPY apps/admin/package.json apps/admin/
 COPY apps/pipeline-helper/package.json apps/pipeline-helper/
 RUN npm ci
 COPY . .
+
+# Build-time configuration injected via `docker compose build` --build-arg
+# (or build.args dans docker-compose.yml). Vite consomme automatiquement
+# les variables `VITE_*` présentes dans l'environnement du process. Si
+# elles ne sont pas fournies, packages/shared/src/api/proxy-config.ts
+# applique son fallback historique (le domaine de référence).
+# Cf. issue #168 — PR-3 transformera ce fallback en fail-fast.
+ARG VITE_PROXY_URL=""
+ARG VITE_LIB_URL=""
+ENV VITE_PROXY_URL=$VITE_PROXY_URL \
+    VITE_LIB_URL=$VITE_LIB_URL
+
 RUN npm run build:all
 RUN node scripts/build-app.js
 

--- a/docker/Dockerfile.db
+++ b/docker/Dockerfile.db
@@ -17,6 +17,18 @@ COPY apps/pipeline-helper/package.json apps/pipeline-helper/
 COPY server/package.json server/
 RUN npm ci
 COPY . .
+
+# Build-time configuration injected via `docker compose build` --build-arg
+# (ou build.args dans docker-compose.db.yml). Vite consomme automatiquement
+# les variables `VITE_*` présentes dans l'environnement du process. Si
+# elles ne sont pas fournies, packages/shared/src/api/proxy-config.ts
+# applique son fallback historique (le domaine de référence).
+# Cf. issue #168 — PR-3 transformera ce fallback en fail-fast.
+ARG VITE_PROXY_URL=""
+ARG VITE_LIB_URL=""
+ENV VITE_PROXY_URL=$VITE_PROXY_URL \
+    VITE_LIB_URL=$VITE_LIB_URL
+
 RUN npm run build:all
 RUN node scripts/build-app.js
 

--- a/docker/docker-compose.db.yml
+++ b/docker/docker-compose.db.yml
@@ -28,6 +28,14 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.db
+      args:
+        # Propagation des variables build-time consommées par Vite.
+        # Valeurs lues depuis le `.env` du repo (`--env-file .env` côté
+        # deploy-server.sh). Si absentes, le build retombe sur le fallback
+        # historique de packages/shared/src/api/proxy-config.ts.
+        # Cf. issue #168 (PR-1).
+        VITE_PROXY_URL: ${VITE_PROXY_URL:-}
+        VITE_LIB_URL: ${VITE_LIB_URL:-}
     depends_on:
       mariadb:
         condition: service_healthy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,6 +3,14 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+      args:
+        # Propagation des variables build-time consommées par Vite.
+        # Valeurs lues depuis le `.env` du repo (`--env-file .env` côté
+        # deploy.sh / deploy-server.sh). Si absentes, le build retombe
+        # sur le fallback historique de packages/shared/src/api/proxy-config.ts.
+        # Cf. issue #168 (PR-1).
+        VITE_PROXY_URL: ${VITE_PROXY_URL:-}
+        VITE_LIB_URL: ${VITE_LIB_URL:-}
     container_name: chartsbuilder
     restart: unless-stopped
 

--- a/packages/shared/src/api/proxy-config.ts
+++ b/packages/shared/src/api/proxy-config.ts
@@ -15,11 +15,29 @@ export interface ProxyConfig {
   };
 }
 
+/**
+ * Build-time configuration injectée par Vite via `import.meta.env`.
+ *
+ * Important : les accès doivent rester **statiques** (`import.meta.env.VITE_*`)
+ * pour que Vite remplace par les valeurs littérales au bundle. Toute indirection
+ * (`const m = import.meta; m.env...`) casse la substitution → les bundles
+ * retombent silencieusement sur les fallbacks ci-dessous.
+ *
+ * Types déclarés localement plutôt que via `vite/client` pour ne pas coupler
+ * `@dsfr-data/shared` à Vite (utilisable hors environnement Vite).
+ */
+declare global {
+  interface ImportMeta {
+    readonly env?: {
+      readonly VITE_PROXY_URL?: string;
+      readonly VITE_LIB_URL?: string;
+    };
+  }
+}
+
 /** Default production proxy base URL (overridable via VITE_PROXY_URL at build time) */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const _meta = import.meta as any;
 export const PROXY_BASE_URL: string =
-  _meta.env?.VITE_PROXY_URL || 'https://chartsbuilder.matge.com';
+  import.meta.env?.VITE_PROXY_URL || 'https://chartsbuilder.matge.com';
 
 /**
  * Base URL for the dsfr-data JS library in generated code.
@@ -32,7 +50,7 @@ export const PROXY_BASE_URL: string =
  *   - Custom URL         → used as-is (e.g. "https://my-cdn.example.com/dist")
  */
 function resolveLibUrl(): string {
-  const raw: string = _meta.env?.VITE_LIB_URL || '';
+  const raw: string = import.meta.env?.VITE_LIB_URL || '';
   if (!raw || raw === 'jsdelivr') return 'https://cdn.jsdelivr.net/npm/dsfr-data@0/dist';
   if (raw === 'unpkg') return 'https://unpkg.com/dsfr-data@0/dist';
   if (raw === 'self') return `${PROXY_BASE_URL}/dist`;


### PR DESCRIPTION
## Summary

Premier pas concret de l'epic [#168](https://github.com/bmatge/dsfr-data/issues/168) (rendre dsfr-data self-hostable). Implémente **PR-1** du plan de découpage : propagation des variables `VITE_*` build-time jusqu'au build Vite à l'intérieur du conteneur Docker.

- **`docker/Dockerfile` + `docker/Dockerfile.db`** — ajoute `ARG VITE_PROXY_URL=""` et `ARG VITE_LIB_URL=""` + `ENV` correspondants juste avant `RUN npm run build:all`. Valeurs vides par défaut → pas d'invalidation de cache, pas de régression côté déploiement de référence.
- **`docker/docker-compose.yml` + `docker/docker-compose.db.yml`** — ajoute la section `build.args` qui passe `${VITE_PROXY_URL:-}` et `${VITE_LIB_URL:-}` depuis le `.env` (lu via `--env-file .env` côté `deploy.sh` / `deploy-server.sh`).
- **`packages/shared/src/api/proxy-config.ts`** — supprime le pattern d'indirection (`const _meta = import.meta as any`) qui empêchait Vite de faire la substitution statique. Sans ce fix, les `ARG` Dockerfile seraient cosmétiques : les bundles continueraient à embarquer le fallback en dur indépendamment de la valeur passée. Types `ImportMeta.env` déclarés localement (`declare global`) pour ne pas coupler `@dsfr-data/shared` à Vite (le package reste utilisable hors environnement Vite).
- **`.env.example`** — corrige les inexactitudes de doc (le fallback réel n'est pas `${APP_DOMAIN}` mais bien `https://chartsbuilder.matge.com` en dur ; le nom de package est `dsfr-data`, plus `gouv-widgets` ; le défaut de `VITE_LIB_URL` est `jsdelivr`, pas `${VITE_PROXY_URL}/dist`) et précise que ces variables sont maintenant propagées au build Docker.

## Hors périmètre de cette PR

- **Fail-fast sur variables manquantes** (P1 step 3) → planifié pour PR-3 du plan de découpage. Pour cette PR, si les variables sont absentes, le comportement actuel (fallback historique) est strictement préservé.
- Build derrière proxy HTTP sortant (P2), CSP self-hostable (P5), Node sortant (P3), docs (P4), routes nginx désactivables (P6) → PRs suivantes.

## Validation locale

- ✅ `VITE_PROXY_URL=https://example.test VITE_LIB_URL=unpkg npm run build` → bundle `packages/core/dist/dsfr-data.core.esm.js` contient `example.test` (2 occurrences), zéro `chartsbuilder.matge.com`.
- ✅ `npm run build` sans variable → fallback historique préservé (`chartsbuilder.matge.com` × 2, identique au comportement avant la PR).
- ✅ `npm run typecheck` (sur `packages/core`) : 0 erreur.
- ✅ `npm run test:run` : **2946 / 2946 tests verts** (86 fichiers).
- ✅ `npm run lint` : 0 erreur.
- ✅ `docker compose --env-file .env -f docker/docker-compose.yml [-f docker/docker-compose.db.yml] config` valide la syntaxe et expose correctement les `args.VITE_*` dans la sortie.

## Test plan

- [ ] CI verte (le job `Trivy image (chartsbuilder)` et `Trivy image (dsfr-data-db)` exercent un build Docker complet, ce qui valide les nouveaux `ARG`).
- [ ] Après merge, vérifier en prod sur `chartsbuilder.matge.com` que rien n'a changé (déploiement de référence intact).
- [ ] Le critère d'acceptation P1 step 1-2 complet (`VITE_PROXY_URL=https://exemple.fr ./docker/deploy-server.sh` produit un bundle pointant vers `exemple.fr`) sera validable une fois le `.env` adapté côté opérateur tiers — la doc dédiée arrivera en PR-5 (P4).

Refs #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)