### PR TITLE
docs: aligner doc sur l'épic #168 self-hostable

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ import 'dsfr-data';
 
 ### Structure des bundles
 
-Trois bundles sont disponibles selon les besoins :
+Quatre bundles sont disponibles selon les besoins :
 
 | Bundle | Contenu | Taille (gzip) |
 |--------|---------|---------------|
-| `dsfr-data.core.{esm,umd}.js` | Tous les composants sauf carte du monde | ~52 Ko |
-| `dsfr-data.world-map.{esm,umd}.js` | Composant `dsfr-data-world-map` (d3-geo) | ~30 Ko |
-| `dsfr-data.{esm,umd}.js` | Tout-en-un (core + world-map) | ~70 Ko |
+| `dsfr-data.core.{esm,umd}.js` | Tous les composants sauf carte du monde et carte interactive (inclut `dsfr-data-join`) | ~61 Ko |
+| `dsfr-data.world-map.{esm,umd}.js` | Composant `dsfr-data-world-map` (d3-geo, topojson) | ~31 Ko |
+| `dsfr-data.map.{esm,umd}.js` | `dsfr-data-map` + `dsfr-data-map-layer` (Leaflet charge dynamiquement) | ~33 Ko |
+| `dsfr-data.{esm,umd}.js` | Tout-en-un | ~97 Ko |
 
 ## Deployer la webapp
 
@@ -388,7 +389,7 @@ Le projet inclut des applications web permettant de generer le code HTML des com
 
 ## Prerequis
 
-- Node.js >= 20
+- Node.js >= 24
 - npm >= 9
 
 ## Installation

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,9 +207,11 @@ En local (`localhost:5173`), le serveur Vite agit comme proxy inverse. Les route
 
 ### 4.2 Mode production (proxy externe)
 
-En production, les requetes sont dirigees vers le proxy nginx dont l'URL est configurable via la variable d'environnement `VITE_PROXY_URL` (build time). Par defaut : `https://chartsbuilder.matge.com`.
+En production, les requetes sont dirigees vers le proxy nginx dont l'URL est configurable via la variable d'environnement `VITE_PROXY_URL` (build time). **[REQUISE au build]** — cette variable n'a pas de valeur par defaut dans la lib. Elle est injectee automatiquement par les scripts `deploy.sh` / `deploy-server.sh` a partir de `APP_DOMAIN`. Pour un build local hors scripts, la definir explicitement ou passer `DSFR_DATA_DEV_BUILD=1`.
 
 `PROXY_BASE_URL` (dans `packages/shared/src/api/proxy-config.ts`) lit `VITE_PROXY_URL` au build time et sert de source de verite unique pour l'URL du proxy. `getProxyConfig()` retourne `baseUrl: PROXY_BASE_URL`.
+
+> **Contrainte technique** : l'acces a `import.meta.env.VITE_*` doit rester **direct** dans le code source (pas d'indirection type `const _meta = import.meta as any`). Vite effectue une substitution statique des variables `import.meta.env.*` a la compilation — toute indirection empeche cette substitution et laisse la variable non resolue en production. Ce comportement a ete a l'origine d'un bug latent corrige par la PR #172 (epic #168).
 
 ### 4.3 Mode Tauri (application desktop)
 
@@ -223,7 +225,7 @@ Grist           /grist-proxy/...      <proxy>/grist-proxy/...             idem p
 Albert          /albert-proxy/...     <proxy>/albert-proxy/...            idem prod
 Tabular         /tabular-proxy/...    <proxy>/tabular-proxy/...           idem prod
 Detection       localhost:5173        (defaut)                            window.__TAURI__
-baseUrl         '' (relatif)          VITE_PROXY_URL ou defaut            PROXY_BASE_URL
+baseUrl         '' (relatif)          VITE_PROXY_URL [REQUISE]            PROXY_BASE_URL
 ```
 
 ---
@@ -242,13 +244,14 @@ baseUrl         '' (relatif)          VITE_PROXY_URL ou defaut            PROXY_
 
 ### 5.2 Build de la bibliotheque
 
-Le script `scripts/build-lib.ts` produit trois bundles via Vite en mode `lib` :
+Le script `scripts/build-lib.ts` produit quatre bundles via Vite en mode `lib` :
 
 | Bundle | Contenu | Taille (gzip) |
 |--------|---------|---------------|
-| `dsfr-data.core.{esm,umd}.js` | Tous les composants sauf `dsfr-data-world-map` | ~52 Ko |
-| `dsfr-data.world-map.{esm,umd}.js` | `dsfr-data-world-map` (d3-geo, topojson) | ~30 Ko |
-| `dsfr-data.{esm,umd}.js` | Tout-en-un (core + world-map) | ~70 Ko |
+| `dsfr-data.core.{esm,umd}.js` | Tous les composants sauf `dsfr-data-world-map` et `dsfr-data-map*` (inclut `dsfr-data-join`) | ~61 Ko |
+| `dsfr-data.world-map.{esm,umd}.js` | `dsfr-data-world-map` (d3-geo, topojson) | ~31 Ko |
+| `dsfr-data.map.{esm,umd}.js` | `dsfr-data-map` + `dsfr-data-map-layer` (Leaflet charge dynamiquement en chunks separes) | ~33 Ko |
+| `dsfr-data.{esm,umd}.js` | Tout-en-un | ~97 Ko |
 
 Le TopoJSON (`dist/data/world-countries-110m.json`) est charge par `fetch` a l'execution au lieu d'etre inline en base64.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequis
 
-- Node.js >= 20
+- Node.js >= 24
 - npm >= 9
 
 ## Installation
@@ -202,6 +202,14 @@ docker compose up -d --build
 
 Le conteneur utilise un volume `beacon-logs` pour persister les donnees de monitoring entre redemarrages.
 
+Pour un build local sans `.env` complet (hors des scripts `deploy.sh` / `deploy-server.sh`), utiliser le bypass :
+
+```bash
+DSFR_DATA_DEV_BUILD=1 npm run build:all
+```
+
+Voir [docs/DEPLOYMENT.md](DEPLOYMENT.md) pour la configuration complete (variables requises, scripts de deploiement, checklist securite).
+
 ## Proxy et variables d'environnement
 
 En dev, les proxys CORS sont geres par Vite (`vite.config.ts`). Aucune configuration requise.
@@ -216,10 +224,13 @@ cp .env.example .env
 | Variable | Description | Defaut |
 |----------|-------------|--------|
 | `APP_DOMAIN` | Domaine de production (Traefik) | `chartsbuilder.matge.com` |
-| `VITE_PROXY_URL` | URL du proxy CORS (build time) | `https://${APP_DOMAIN}` |
+| `VITE_PROXY_URL` | URL du proxy CORS injectee dans les bundles a la compilation. Generee automatiquement par les scripts `deploy.sh` / `deploy-server.sh` depuis `APP_DOMAIN`. **[REQUISE au build]** — pas de valeur par defaut dans la lib. | aucune |
+| `VITE_LIB_URL` | URL du JS de la lib dans le code genere : `jsdelivr`, `unpkg`, `self`, ou URL custom | `jsdelivr` |
 | `JWT_SECRET` | Cle JWT (mode serveur) | Auto-genere |
 
-`VITE_PROXY_URL` est la variable cle : elle determine l'URL du proxy, du fichier JS de la librairie, et du beacon de tracking. Elle est injectee au build time par Vite dans `PROXY_BASE_URL` (`packages/shared/src/api/proxy-config.ts`).
+`VITE_PROXY_URL` est injectee au build time par Vite dans `PROXY_BASE_URL` (`packages/shared/src/api/proxy-config.ts`), qui sert de source de verite unique pour l'URL du proxy et le beacon de tracking.
+
+`VITE_LIB_URL` est une variable distincte qui controle l'URL du JS de la bibliotheque dans le code genere par les builders (valeur `"self"` pour un self-hosting complet).
 
 ## Changesets
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -61,17 +61,25 @@ Le fichier [`.env.example`](../.env.example) liste toutes les variables. Les pri
 |---|---|---|---|
 | `APP_DOMAIN` | les 2 | Domaine public sur lequel l'app sera accessible | `chartsbuilder.matge.com` |
 | `COMPOSE_PROJECT_NAME` | les 2 | Prefix Docker (volumes, conteneurs) | nom du dossier git |
-| `VITE_PROXY_URL` | les 2 | URL du proxy CORS injectee dans les bundles a la build | `https://${APP_DOMAIN}` |
-| `VITE_LIB_URL` | les 2 | Source des bundles dans le code genere : `jsdelivr`, `unpkg`, `self`, ou URL custom | `jsdelivr` |
+| `VITE_PROXY_URL` | les 2 **[REQUISE au build]** | URL du proxy CORS injectee dans les bundles a la compilation. Generee automatiquement par `deploy.sh` / `deploy-server.sh` depuis `APP_DOMAIN`. Contourner avec `DSFR_DATA_DEV_BUILD=1` (la build n'echoue pas si absent). | aucune |
+| `VITE_LIB_URL` | les 2 | Source du JS de la lib dans le code genere : `jsdelivr`, `unpkg`, `self`, ou URL custom | `jsdelivr` |
+| `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` | les 2 (build only) | Proxy reseau pour les appels npm/build si le VPS est derriere un proxy d'entreprise | non configure |
 | `JWT_SECRET` | serveur | HMAC pour les tokens JWT, 32 bytes hex | auto-genere |
 | `DB_USER`, `DB_PASSWORD`, `DB_ROOT_PASSWORD` | serveur | Identifiants MariaDB | `dsfr_data` / generes |
 | `DB_NAME` | serveur | Nom de la base | `dsfr_data` |
 | `ENCRYPTION_KEY` | serveur | AES-256-GCM, 32 bytes hex (chiffrement des `connections.api_key_encrypted`) | auto-genere |
 | `CSRF_SECRET` | serveur | HMAC pour les tokens CSRF | fallback `ENCRYPTION_KEY` |
-| `SMTP_HOST`, `SMTP_PORT`, `SMTP_FROM`, `APP_URL` | serveur | Envoi d'emails de verification / reset | non configure |
+| `APP_URL` | serveur **[REQUISE en mode serveur]** | URL publique de l'app, utilisee dans les emails de verification / reset (ex. `https://mondomaine.gouv.fr`). Sans cette variable, le serveur leve une erreur au demarrage si l'envoi d'email est tente. | throw si absent et SMTP configure |
+| `SMTP_HOST`, `SMTP_PORT`, `SMTP_FROM` | serveur | Configuration SMTP pour l'envoi d'emails de verification / reset | non configure |
 | `IA_DEFAULT_TOKEN`, `IA_DEFAULT_API_URL`, `IA_DEFAULT_MODEL` | les 2 | Cle Albert partagee cote serveur (Builder IA fonctionne sans config utilisateur) | `albert-large` |
 
 **Securite** : `JWT_SECRET`, `DB_PASSWORD`, `DB_ROOT_PASSWORD`, `ENCRYPTION_KEY` sont **generes automatiquement** par `deploy-server.sh` s'ils manquent dans `.env`. Une fois generes, ne JAMAIS les changer en place : `JWT_SECRET` invalide les sessions actives, `ENCRYPTION_KEY` rend les cles API stockees illisibles. Les sauvegarder hors du serveur.
+
+**Validation des variables de build** : le script `npm run validate:build-env` verifie que les variables Vite requises (`VITE_PROXY_URL`, etc.) sont presentes avant la compilation. Les scripts `deploy.sh` / `deploy-server.sh` l'executent automatiquement et injectent `VITE_PROXY_URL` depuis `APP_DOMAIN`. Pour un build local de developpement sans `.env` complet, passer `DSFR_DATA_DEV_BUILD=1` pour contourner cette validation :
+
+```bash
+DSFR_DATA_DEV_BUILD=1 npm run build:all
+```
 
 ## Reverse proxy
 
@@ -346,4 +354,4 @@ docker compose ... exec -T mariadb sh -c 'mariadb -uroot -p"$MARIADB_ROOT_PASSWO
 
 ### Bundles `/dist/*` non-hashes : politique de cache
 
-Les bundles servis sur `https://${APP_DOMAIN}/dist/*.js` (lib `dsfr-data` self-hostee) ont des **noms stables** entre versions. Sans cache-busting, un correctif live n'etait pas servi aux visiteurs deja venus. La conf nginx les sert avec `Cache-Control: no-cache, must-revalidate` (revalidation systematique via ETag, pas de re-telechargement si inchange). Voir [`packages/core/CHANGELOG.md` v0.7.0](../packages/core/CHANGELOG.md) et [ADR-008](https://github.com/bmatge/dsfr-data/blob/main/docs/ADR/ADR-008-politique-de-cache-http-pour-bundles-non-hashes.md) (si l'ADR a ete migree dans le repo).
+Les bundles servis sur `https://${APP_DOMAIN}/dist/*.js` (lib `dsfr-data` self-hostee) ont des **noms stables** entre versions. Sans cache-busting, un correctif live n'etait pas servi aux visiteurs deja venus. La conf nginx les sert avec `Cache-Control: no-cache, must-revalidate` (revalidation systematique via ETag, pas de re-telechargement si inchange). Voir [`packages/core/CHANGELOG.md` v0.7.0](../packages/core/CHANGELOG.md) et [ADR-008](https://github.com/bmatge/dsfr-data/blob/main/docs/ADR/ADR-008-politique-de-cache-http-pour-bundles-non-hashes.md).


### PR DESCRIPTION
## Contexte

Suite au merge des PRs #172, #173, #174 (épic #168 — rendre dsfr-data self-hostable), aligne la documentation sur l'état réel du code.

## Corrections appliquées (12)

| # | Fichier | Correction |
|---|---------|-----------|
| 1 | `docs/DEPLOYMENT.md` | `VITE_PROXY_URL` : marquer `[REQUISE au build]`, noter génération auto depuis `APP_DOMAIN` via deploy scripts, bypass `DSFR_DATA_DEV_BUILD=1` |
| 2 | `docs/DEPLOYMENT.md` | `APP_URL` : séparée de SMTP, marquée `[REQUISE en mode serveur]`, note throw si absente avec SMTP configuré |
| 3 | `docs/DEPLOYMENT.md` | Ajout `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` (build-time only) dans la table des variables |
| 4 | `docs/DEPLOYMENT.md` | Note explicite sur `npm run validate:build-env` et le bypass `DSFR_DATA_DEV_BUILD=1` |
| 5 | `README.md` | Ajout du 4e bundle `dsfr-data.map.{esm,umd}.js` (Leaflet, `dsfr-data-map` + `dsfr-data-map-layer`) + tailles gzip alignées (~61 Ko core, ~31 Ko world-map, ~33 Ko map, ~97 Ko tout-en-un) |
| 6 | `README.md` | Node.js >= 20 → >= 24 (CI sur 24 depuis PR #171) |
| 7 | `docs/CONTRIBUTING.md` | Node.js >= 20 → >= 24 |
| 8 | `docs/CONTRIBUTING.md` | `VITE_PROXY_URL` : plus de défaut `${APP_DOMAIN}`, généré par les scripts deploy. `VITE_LIB_URL` distinguée comme variable séparée |
| 9 | `docs/CONTRIBUTING.md` | Section Docker : renvoi vers `docs/DEPLOYMENT.md` + mention `DSFR_DATA_DEV_BUILD=1` |
| 10 | `docs/ARCHITECTURE.md` | Section 4.2 et récap : supprimer le défaut `https://chartsbuilder.matge.com`, marquer `[REQUISE au build]` |
| 11 | `docs/ARCHITECTURE.md` | Note sur la contrainte `import.meta.env` direct (pas d'indirection), cause du bug latent corrigé par PR #172 |
| 12 | `docs/DEPLOYMENT.md` | Nettoyer la parenthèse provisoire `(si l'ADR a ete migree dans le repo)` autour du lien ADR-008 |

Bonus : `docs/ARCHITECTURE.md` section 5.2 mise à jour avec les 4 bundles (alignement avec les autres fichiers).

Refs #168