### PR TITLE
fix(app-sidemenu): wrapping des libellés longs dans le menu du guide

### DIFF
--- a/.changeset/fix-sidemenu-wrap.md
+++ b/.changeset/fix-sidemenu-wrap.md
@@ -1,0 +1,7 @@
+---
+'dsfr-data': patch
+---
+
+fix(app-sidemenu): la contrainte `flex: 0 0 220px` était posée sur le `<nav class="guide-sidemenu">` interne au lieu du host `<app-sidemenu>`, qui est en réalité l'enfant direct du flex container `.guide-layout`. Résultat : la largeur n'était pas contrainte et les libellés longs (« Élections des chambres d'agriculture 2025 — Résultats », etc.) restaient sur une seule ligne, élargissant le menu latéral au-delà de la spec DSFR.
+
+Maintenant : les règles flex / sticky / overflow sont posées sur `app-sidemenu` directement (light DOM, donc sélecteur de tag valide), les libellés wrappent sur 2 lignes dans une colonne de 220px.

--- a/packages/core/src/components/layout/app-sidemenu.ts
+++ b/packages/core/src/components/layout/app-sidemenu.ts
@@ -195,16 +195,19 @@ export class AppSidemenu extends LitElement {
       </nav>
 
       <style>
-        .guide-sidemenu {
+        /* Le host est le flex item direct de .guide-layout : c'est lui qui
+           doit porter la contrainte de largeur, pas le <nav> interne. */
+        app-sidemenu {
           flex: 0 0 220px;
+          min-width: 0;
+          align-self: flex-start;
           position: sticky;
           top: 1rem;
-          height: fit-content;
           max-height: calc(100vh - 2rem);
           overflow-y: auto;
         }
         @media (max-width: 992px) {
-          .guide-sidemenu {
+          app-sidemenu {
             position: static;
             flex: none;
             max-height: none;


### PR DESCRIPTION
## Summary
- Bug cosmétique : dans les pages `/guide/*`, le menu latéral s'élargissait au-delà des 220px de la spec DSFR parce que les libellés longs ne passaient pas à la ligne.
- Cause : la contrainte `flex: 0 0 220px` était posée sur le `<nav class="guide-sidemenu">` interne au lieu du host `<app-sidemenu>` — or c'est le host qui est l'enfant direct du flex container `.guide-layout`.
- Fix : déplacer les règles flex / sticky / overflow sur `app-sidemenu` directement (light DOM, sélecteur de tag valide). Les libellés wrappent désormais sur 2 lignes dans une colonne de 220px.

## Test plan
- [ ] Ouvrir `/guide/guide.html` et vérifier la largeur du menu latéral (~220px)
- [ ] Vérifier que les libellés longs (« Élections des chambres d'agriculture 2025 — Résultats », « Effectifs lycées GT — Dashboard open data », « AFA – Chroniques jurisprudentielles 2021 / 2022 ») wrappent sur 2 lignes
- [ ] Vérifier le comportement sticky en scrollant
- [ ] Vérifier le mode mobile (< 992px) : menu en pleine largeur, non-sticky

🤖 Generated with [Claude Code](https://claude.com/claude-code)