### PR TITLE
docs(self-hosted): section dédiée + annotations DÉSACTIVABLE nginx (#168 PR-5)

### DIFF
--- a/.changeset/self-hosted-deployment-docs.md
+++ b/.changeset/self-hosted-deployment-docs.md
@@ -1,0 +1,18 @@
+---
+'dsfr-data': patch
+---
+
+docs(self-hosted): section dédiée + annotations DÉSACTIVABLE sur les routes nginx (closes #168 P4+P6, PR-5 du plan de découpage).
+
+Clôt l'épic [#168 (self-hostable)](https://github.com/bmatge/dsfr-data/issues/168) avec deux livrables :
+
+**`docs/DEPLOYMENT.md` — section "Configuration self-hosted"** couvrant les 3 scénarios :
+- A. Déploiement de référence (Traefik intégré, rien à configurer au-delà de `APP_DOMAIN`).
+- B. Derrière un proxy d'entreprise (`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` build + runtime — résumé des PR-2 et PR-4).
+- C. Reverse externe gérant les routes `/*-proxy/` (commenter les blocs concernés + déclarer le chemin équivalent dans le reverse externe).
+
+Le **contrat exhaustif des chemins de proxying** (`/grist-gouv-proxy/`, `/grist-proxy/`, `/albert-proxy/`, `/ia-proxy`, `/ia-server-config`, `/ia-proxy-default`, `/insee-proxy/`, `/tabular-proxy/`, `/cors-proxy`) est fourni sous forme de tableau : cible upstream, méthodes acceptées, politique de cache, headers CORS attendus, particularités (strip Origin/Referer, paires obligatoires…).
+
+**Annotations dans `docker/nginx.conf` + `docker/nginx-db.conf`** : chaque bloc `location /*-proxy/` reçoit un commentaire `DÉSACTIVABLE` (3-4 lignes) avec la cible upstream et un renvoi vers la section du contrat dans `docs/DEPLOYMENT.md`.
+
+**Références ajoutées** depuis `README.md` (paragraphe "Déployer la webapp") et `CLAUDE.md` (section "Déploiement serveur") vers la nouvelle section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,8 @@ echo "COMPOSE_PROJECT_NAME=datasource-charts-webcomponents" >> .env
 ./deploy-server.sh
 ```
 
+**Configuration self-hosted** (domaine arbitraire, proxy d'entreprise, reverse externe gerant les routes de proxying) : la procedure complete est dans [`docs/DEPLOYMENT.md` §"Configuration self-hosted"](docs/DEPLOYMENT.md#configuration-self-hosted). Elle couvre les 3 scenarios + le contrat exhaustif des chemins de proxying (`/grist-proxy/`, `/tabular-proxy/`, `/albert-proxy/`, etc.) pour qu'un operateur tiers puisse les repliquer derriere son propre reverse. Chaque bloc `location /*-proxy/` dans `docker/nginx.conf` et `nginx-db.conf` est annote `DESACTIVABLE` avec un renvoi vers cette section.
+
 ### Base de donnees MariaDB
 
 Le serveur Express utilise **MariaDB 11** via `mysql2/promise` (requetes async, pool de connexions).

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ En plus de la bibliotheque, le repo contient une webapp (Builder, Builder IA, So
 - **Statique** (nginx + localStorage) — usage individuel, aucune persistance serveur.
 - **Serveur** (nginx + Express + MariaDB) — multi-utilisateurs, auth JWT, partages, audit.
 
-Voir le **[guide de deploiement](docs/DEPLOYMENT.md)** pour les prerequis (Traefik, DNS, secrets), la configuration `.env`, les migrations de schema, la sauvegarde, le diagnostic et la checklist securite.
+Voir le **[guide de deploiement](docs/DEPLOYMENT.md)** pour les prerequis (Traefik, DNS, secrets), la configuration `.env`, les migrations de schema, la sauvegarde, le diagnostic et la checklist securite. La section [Configuration self-hosted](docs/DEPLOYMENT.md#configuration-self-hosted) couvre les trois scenarios de deploiement (reference, proxy d'entreprise, reverse externe gerant les routes `/*-proxy/`) avec le contrat exhaustif des chemins de proxying.
 
 ---
 

--- a/docker/nginx-db.conf
+++ b/docker/nginx-db.conf
@@ -60,7 +60,10 @@ server {
         proxy_cache off;
     }
 
-    # Proxy pour Grist numerique.gouv.fr (contourne CORS)
+    # Proxy CORS vers grist.numerique.gouv.fr (datasets Grist gouv).
+    # DÉSACTIVABLE : commenter ce bloc si /grist-gouv-proxy/ est routé via un
+    # reverse externe. Contrat (méthode, headers, cible) : cf.
+    # docs/DEPLOYMENT.md §"Configuration self-hosted" (#168 PR-5).
     location /grist-gouv-proxy/ {
         include /etc/nginx/conf.d/security-headers.conf;
         if ($request_method = 'OPTIONS') {
@@ -99,7 +102,10 @@ server {
         proxy_cache_bypass $request_method;
     }
 
-    # Proxy pour docs.getgrist.com (contourne CORS)
+    # Proxy CORS vers docs.getgrist.com (datasets Grist SaaS).
+    # DÉSACTIVABLE : commenter ce bloc si /grist-proxy/ est routé via un
+    # reverse externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     location /grist-proxy/ {
         include /etc/nginx/conf.d/security-headers.conf;
         if ($request_method = 'OPTIONS') {
@@ -138,7 +144,10 @@ server {
         proxy_cache_bypass $request_method;
     }
 
-    # Proxy pour Albert API (contourne CORS)
+    # Proxy CORS vers albert.api.etalab.gouv.fr (Albert IA, token client).
+    # DÉSACTIVABLE : commenter ce bloc si /albert-proxy/ est routé via un
+    # reverse externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     location /albert-proxy/ {
         include /etc/nginx/conf.d/security-headers.conf;
         if ($request_method = 'OPTIONS') {
@@ -170,7 +179,11 @@ server {
         proxy_cache_bypass 1;
     }
 
-    # Proxy generique pour APIs IA (contourne CORS + CSP)
+    # Proxy générique pour APIs IA (Albert, OpenAI, Anthropic, Gemini, Mistral…).
+    # Cible déterminée à la volée par le header X-Target-URL envoyé par le client.
+    # DÉSACTIVABLE : commenter ce bloc si /ia-proxy est routé via un reverse
+    # externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     location /ia-proxy {
         include /etc/nginx/conf.d/security-headers.conf;
         if ($request_method = 'OPTIONS') {
@@ -205,7 +218,10 @@ server {
         proxy_set_header Referer "";
     }
 
-    # Config IA serveur (retourne apiUrl + model, jamais le token)
+    # Endpoint local (127.0.0.1:3003 = scripts/ia-default-server.js) — retourne
+    # { available, apiUrl, model } sans jamais exposer le token Albert serveur.
+    # DÉSACTIVABLE : commenter ce bloc ET /ia-proxy-default (les 2 vont de pair).
+    # Contrat : cf. docs/DEPLOYMENT.md §"Configuration self-hosted" (#168 PR-5).
     location = /ia-server-config {
         include /etc/nginx/conf.d/security-headers.conf;
         proxy_pass http://127.0.0.1:3003/ia-server-config;
@@ -213,7 +229,10 @@ server {
         add_header 'Access-Control-Allow-Origin' '*' always;
     }
 
-    # Proxy IA avec token injecte cote serveur (le client n'envoie pas de token)
+    # Proxy IA avec token serveur injecté (127.0.0.1:3003 = ia-default-server.js).
+    # Le client n'envoie pas de token, c'est le serveur qui ajoute IA_DEFAULT_TOKEN.
+    # DÉSACTIVABLE : commenter ce bloc ET /ia-server-config (les 2 vont de pair).
+    # Contrat : cf. docs/DEPLOYMENT.md §"Configuration self-hosted" (#168 PR-5).
     location /ia-proxy-default {
         include /etc/nginx/conf.d/security-headers.conf;
         if ($request_method = 'OPTIONS') {
@@ -233,7 +252,10 @@ server {
         proxy_cache_bypass 1;
     }
 
-    # Proxy pour INSEE Melodi API (contourne CORS)
+    # Proxy CORS vers api.insee.fr (INSEE Melodi catalogue de données).
+    # DÉSACTIVABLE : commenter ce bloc si /insee-proxy/ est routé via un
+    # reverse externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     location /insee-proxy/ {
         include /etc/nginx/conf.d/security-headers.conf;
         if ($request_method = 'OPTIONS') {
@@ -270,7 +292,10 @@ server {
         proxy_cache_valid 200 60s;
     }
 
-    # Proxy pour Tabular API data.gouv.fr (contourne CORS)
+    # Proxy CORS vers tabular-api.data.gouv.fr (Tabular API data.gouv.fr).
+    # DÉSACTIVABLE : commenter ce bloc si /tabular-proxy/ est routé via un
+    # reverse externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     location /tabular-proxy/ {
         include /etc/nginx/conf.d/security-headers.conf;
         if ($request_method = 'OPTIONS') {
@@ -343,8 +368,11 @@ server {
     }
 
     # =================================================================
-    # Proxy CORS generique (X-Target-URL header pattern)
-    # Pour les APIs externes sans proxy dedie (ODS, etc.)
+    # Proxy CORS générique pour dsfr-data-source `use-proxy` (ODS, etc.).
+    # Cible déterminée à la volée par le header X-Target-URL.
+    # DÉSACTIVABLE : commenter ce bloc si /cors-proxy est routé via un
+    # reverse externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     # =================================================================
     location /cors-proxy {
         include /etc/nginx/conf.d/security-headers.conf;

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -40,8 +40,10 @@ server {
         add_header Access-Control-Allow-Origin "*" always;
     }
 
-    # Proxy pour Grist numerique.gouv.fr (contourne CORS)
-    # Permet l'accès cross-origin pour les sites tiers
+    # Proxy CORS vers grist.numerique.gouv.fr (datasets Grist gouv).
+    # DÉSACTIVABLE : commenter ce bloc si /grist-gouv-proxy/ est routé via un
+    # reverse externe. Contrat (méthode, headers, cible) : cf.
+    # docs/DEPLOYMENT.md §"Configuration self-hosted" (#168 PR-5).
     location /grist-gouv-proxy/ {
         include /etc/nginx/conf.d/security-headers.conf;
         # Répondre directement aux OPTIONS (Grist ne les supporte pas)
@@ -85,8 +87,10 @@ server {
         proxy_cache_bypass $request_method;
     }
 
-    # Proxy pour docs.getgrist.com (contourne CORS)
-    # Permet l'accès cross-origin pour les sites tiers
+    # Proxy CORS vers docs.getgrist.com (datasets Grist SaaS).
+    # DÉSACTIVABLE : commenter ce bloc si /grist-proxy/ est routé via un
+    # reverse externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     location /grist-proxy/ {
         include /etc/nginx/conf.d/security-headers.conf;
         # Répondre directement aux OPTIONS (Grist ne les supporte pas)
@@ -130,7 +134,10 @@ server {
         proxy_cache_bypass $request_method;
     }
 
-    # Proxy pour Albert API (contourne CORS)
+    # Proxy CORS vers albert.api.etalab.gouv.fr (Albert IA, token client).
+    # DÉSACTIVABLE : commenter ce bloc si /albert-proxy/ est routé via un
+    # reverse externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     location /albert-proxy/ {
         include /etc/nginx/conf.d/security-headers.conf;
         # Répondre directement aux OPTIONS
@@ -165,9 +172,11 @@ server {
         proxy_cache_bypass 1;
     }
 
-    # Proxy generique pour APIs IA (contourne CORS + CSP)
-    # Le client envoie un header X-Target-URL avec l'URL de l'API cible
-    # Fonctionne avec Albert, OpenAI, Anthropic, Gemini, Mistral, etc.
+    # Proxy générique pour APIs IA (Albert, OpenAI, Anthropic, Gemini, Mistral…).
+    # Cible déterminée à la volée par le header X-Target-URL envoyé par le client.
+    # DÉSACTIVABLE : commenter ce bloc si /ia-proxy est routé via un reverse
+    # externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     location /ia-proxy {
         include /etc/nginx/conf.d/security-headers.conf;
         # Preflight CORS
@@ -209,7 +218,10 @@ server {
         proxy_set_header Referer "";
     }
 
-    # Config IA serveur (retourne apiUrl + model, jamais le token)
+    # Endpoint local (127.0.0.1:3003 = scripts/ia-default-server.js) — retourne
+    # { available, apiUrl, model } sans jamais exposer le token Albert serveur.
+    # DÉSACTIVABLE : commenter ce bloc ET /ia-proxy-default (les 2 vont de pair).
+    # Contrat : cf. docs/DEPLOYMENT.md §"Configuration self-hosted" (#168 PR-5).
     location = /ia-server-config {
         include /etc/nginx/conf.d/security-headers.conf;
         proxy_pass http://127.0.0.1:3003/ia-server-config;
@@ -217,7 +229,10 @@ server {
         add_header 'Access-Control-Allow-Origin' '*' always;
     }
 
-    # Proxy IA avec token injecte cote serveur (le client n'envoie pas de token)
+    # Proxy IA avec token serveur injecté (127.0.0.1:3003 = ia-default-server.js).
+    # Le client n'envoie pas de token, c'est le serveur qui ajoute IA_DEFAULT_TOKEN.
+    # DÉSACTIVABLE : commenter ce bloc ET /ia-server-config (les 2 vont de pair).
+    # Contrat : cf. docs/DEPLOYMENT.md §"Configuration self-hosted" (#168 PR-5).
     location /ia-proxy-default {
         include /etc/nginx/conf.d/security-headers.conf;
         if ($request_method = 'OPTIONS') {
@@ -237,7 +252,10 @@ server {
         proxy_cache_bypass 1;
     }
 
-    # Proxy pour INSEE Melodi API (contourne CORS)
+    # Proxy CORS vers api.insee.fr (INSEE Melodi catalogue de données).
+    # DÉSACTIVABLE : commenter ce bloc si /insee-proxy/ est routé via un
+    # reverse externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     location /insee-proxy/ {
         include /etc/nginx/conf.d/security-headers.conf;
         # Répondre directement aux OPTIONS
@@ -279,7 +297,10 @@ server {
         proxy_cache_valid 200 60s;
     }
 
-    # Proxy pour Tabular API data.gouv.fr (contourne CORS)
+    # Proxy CORS vers tabular-api.data.gouv.fr (Tabular API data.gouv.fr).
+    # DÉSACTIVABLE : commenter ce bloc si /tabular-proxy/ est routé via un
+    # reverse externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     location /tabular-proxy/ {
         include /etc/nginx/conf.d/security-headers.conf;
         # Répondre directement aux OPTIONS
@@ -322,8 +343,11 @@ server {
         proxy_cache_valid 200 60s;
     }
 
-    # Proxy CORS generique pour dsfr-data-source use-proxy
-    # Le client envoie un header X-Target-URL avec l'URL de l'API cible
+    # Proxy CORS générique pour dsfr-data-source `use-proxy`.
+    # Cible déterminée à la volée par le header X-Target-URL envoyé par le client.
+    # DÉSACTIVABLE : commenter ce bloc si /cors-proxy est routé via un reverse
+    # externe. Contrat : cf. docs/DEPLOYMENT.md
+    # §"Configuration self-hosted" (#168 PR-5).
     location /cors-proxy {
         include /etc/nginx/conf.d/security-headers.conf;
         # Preflight CORS

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,6 +13,11 @@ Ce guide couvre le deploiement de la **webapp dsfr-data** (apps Builder, Builder
   - [Option B : Traefik](#option-b--traefik-config-fournie-en-exemple)
   - [Option C : Caddy](#option-c--caddy)
   - [Option D : nginx en frontal](#option-d--nginx-en-frontal)
+- [Configuration self-hosted](#configuration-self-hosted)
+  - [Scenario A : deploiement de reference](#scenario-a--deploiement-de-reference-traefik-integre)
+  - [Scenario B : derriere un proxy d'entreprise](#scenario-b--derriere-un-proxy-dentreprise)
+  - [Scenario C : reverse externe gerant les routes de proxying](#scenario-c--reverse-externe-gerant-les-routes-de-proxying)
+  - [Contrat des chemins de proxying](#contrat-des-chemins-de-proxying)
 - [Premier deploiement](#premier-deploiement)
   - [Mode statique](#mode-statique)
   - [Mode serveur](#mode-serveur)
@@ -155,6 +160,97 @@ server {
     }
 }
 ```
+
+## Configuration self-hosted
+
+Cette section couvre les trois scenarios de deploiement supportes, du plus simple (deploiement de reference) au plus contraint (proxy d'entreprise + reverse externe gerant les routes de proxying). L'objectif : un operateur tiers peut deployer sur un domaine arbitraire sans patcher le code source.
+
+Pre-requis communs :
+
+- `APP_DOMAIN`, `VITE_PROXY_URL` (et `APP_URL` en mode serveur) genere automatiquement par `deploy.sh` / `deploy-server.sh` depuis `APP_DOMAIN`. Cf. [Variables d'environnement](#variables-denvironnement).
+- Conteneur tourne sous l'utilisateur non-root `nginx` (uid 101).
+
+### Scenario A : deploiement de reference (Traefik integre)
+
+Le scenario par defaut. Aucune configuration particuliere requise au-dela de `APP_DOMAIN` :
+
+1. `cp .env.example .env`
+2. Editer `APP_DOMAIN=mon-domaine.example.com`
+3. `./docker/deploy.sh` (ou `deploy-server.sh` en mode serveur)
+
+Les scripts generent `VITE_PROXY_URL=https://${APP_DOMAIN}` et (mode serveur) `APP_URL=https://${APP_DOMAIN}`. Tous les chemins de proxying nginx (`/grist-proxy/`, `/tabular-proxy/`, `/albert-proxy/`, etc.) sont actifs cote conteneur. Le `docker-compose.yml` fournit des labels Traefik en exemple — adapter ou retirer selon le reverse proxy choisi (Caddy, nginx frontal, ALB…).
+
+### Scenario B : derriere un proxy d'entreprise
+
+Pour les operateurs dont le VPS n'a pas d'acces direct a Internet (proxy HTTP sortant obligatoire). Configurer les variables POSIX standard dans `.env` :
+
+```bash
+HTTP_PROXY=http://corporate.proxy.example.com:8080
+HTTPS_PROXY=http://corporate.proxy.example.com:8080
+NO_PROXY=localhost,127.0.0.1,mariadb,mailserver,.example.com
+```
+
+Ces variables sont propagees a deux niveaux :
+
+- **Build-time** (depuis [#168 PR-2](https://github.com/bmatge/dsfr-data/pull/173)) : `npm ci` et `apk add` dans le stage builder des Dockerfiles passent par le proxy.
+- **Runtime** (depuis [#168 PR-4](https://github.com/bmatge/dsfr-data/pull/178)) : les services Node embarques dans le conteneur (`scripts/ia-default-server.js` pour Albert IA, `mcp-server` pour `skills.json`) acheminent leurs appels HTTP sortants via le proxy. Implementation : `undici.EnvHttpProxyAgent` comme dispatcher global, conditionnel.
+
+**Inclure les hostnames Docker internes dans `NO_PROXY`** (`mariadb`, `mailserver`, `localhost`, `127.0.0.1`) pour preserver les communications inter-conteneurs. Sans ces entrees, le serveur Express enverrait son trafic SMTP via le proxy externe, qui ne sait pas atteindre le mailserver interne.
+
+Sans variable proxy definie, aucun dispatcher n'est installe — comportement strictement inchange. Cf. `.env.example` pour les details.
+
+### Scenario C : reverse externe gerant les routes de proxying
+
+Pour les operateurs qui preferent que leur reverse proxy d'entreprise (Traefik, nginx, HAProxy…) gere certaines routes de proxying API en frontal — par exemple parce qu'ils ont deja une politique de filtrage centralisee, du caching mutualise, ou des restrictions d'acces specifiques aux APIs externes.
+
+**Strategie** : commenter les blocs `location /*-proxy/` correspondants dans `docker/nginx.conf` et/ou `docker/nginx-db.conf`, puis declarer le chemin equivalent dans le reverse externe en respectant le [contrat des chemins de proxying](#contrat-des-chemins-de-proxying) ci-dessous.
+
+Exemple — vous voulez router `/tabular-proxy/` via votre reverse Traefik externe :
+
+```nginx
+# Dans docker/nginx.conf (et nginx-db.conf si mode serveur), commenter le bloc :
+
+# location /tabular-proxy/ {
+#     include /etc/nginx/conf.d/security-headers.conf;
+#     ...
+#     proxy_pass https://tabular-api.data.gouv.fr/;
+#     ...
+# }
+```
+
+Puis declarer dans votre reverse externe une regle qui :
+- Capture `https://${APP_DOMAIN}/tabular-proxy/*` AVANT que la requete n'atteigne le conteneur nginx.
+- Reverse-proxy vers `https://tabular-api.data.gouv.fr/*` en preservant le path apres `/tabular-proxy/`.
+- Ajoute les headers CORS (`Access-Control-Allow-Origin: *`, methods, headers — cf. tableau ci-dessous).
+- Supprime les headers `Origin` et `Referer` du forward (Tabular et certaines APIs gov rejettent les requetes browser).
+
+Les paires `/ia-server-config` + `/ia-proxy-default` doivent etre commentees ensemble — le premier annonce la disponibilite du proxy IA par defaut, le second l'execute. Commenter l'un sans l'autre laisse l'app dans un etat incoherent (UI affiche "IA disponible" mais l'appel echoue).
+
+**Tip** : les overrides specifiques a un site (compose, nginx custom) doivent passer par `docker-compose.override.yml` (gitignored) plutot que par des patches locaux des fichiers livres, sinon `git pull` les ecrasera. Cf. [issue #168](https://github.com/bmatge/dsfr-data/issues/168) pour la motivation.
+
+### Contrat des chemins de proxying
+
+Liste exhaustive des routes que les apps et widgets attendent au runtime. Si vous desactivez un bloc cote nginx (scenario C), vous devez fournir une route equivalente dans votre reverse externe respectant la signature ci-dessous.
+
+| Chemin | Cible upstream | Methodes | Cache nginx | Notes |
+|---|---|---|---|---|
+| `/grist-gouv-proxy/` | `https://grist.numerique.gouv.fr/` | GET, POST, OPTIONS | GET 60s | Strip Origin + Referer (Grist rejette le navigateur direct) |
+| `/grist-proxy/` | `https://docs.getgrist.com/` | GET, POST, OPTIONS | GET 60s | Strip Origin + Referer |
+| `/albert-proxy/` | `https://albert.api.etalab.gouv.fr/` | GET, POST, PUT, PATCH, DELETE, OPTIONS | non | Token Albert dans `Authorization` cote client |
+| `/ia-proxy` | **Dynamique** (`X-Target-URL` du client) | POST, OPTIONS | non | Strip `X-Target-URL` + `Origin` + `Referer` avant forward. Resolver DNS requis (8.8.8.8 par defaut) |
+| `/ia-server-config` | `127.0.0.1:3003/ia-server-config` | GET | non | Endpoint local (`scripts/ia-default-server.js`) — disabler implique aussi de couper `/ia-proxy-default` |
+| `/ia-proxy-default` | `127.0.0.1:3003/ia-proxy-default` | POST, OPTIONS | non | Token Albert injecte cote serveur depuis `IA_DEFAULT_TOKEN` — disabler implique aussi de couper `/ia-server-config` |
+| `/insee-proxy/` | `https://api.insee.fr/` | GET, OPTIONS | GET 60s | Catalogue Melodi — strip Origin + Referer |
+| `/tabular-proxy/` | `https://tabular-api.data.gouv.fr/` | GET, POST, OPTIONS | GET 60s | Strip Origin + Referer |
+| `/cors-proxy` | **Dynamique** (`X-Target-URL` du client) | GET, POST, PUT, DELETE, PATCH, OPTIONS | non | Strip `X-Target-URL` + `Origin` + `Referer`. Resolver DNS requis. Utilise par `dsfr-data-source use-proxy` |
+
+**Headers communs** attendus en reponse sur tous les chemins :
+- `Access-Control-Allow-Origin: *`
+- `Access-Control-Allow-Methods: <selon la table>`
+- `Access-Control-Allow-Headers: Origin, Content-Type, Accept, Authorization` (a minima ; `X-Target-URL` en plus pour `/ia-proxy` et `/cors-proxy`)
+- Pour OPTIONS preflight : `Access-Control-Max-Age: 86400`
+
+**Reference d'implementation** : voir `docker/nginx.conf` (mode statique) et `docker/nginx-db.conf` (mode serveur). Chaque bloc est annote `DESACTIVABLE` avec un renvoi vers cette section.
 
 ## Premier deploiement
 


### PR DESCRIPTION
## Contexte

Dernière PR de l'**épic #168 (rendre dsfr-data self-hostable)**. Clôt P4 (doc self-hosting) et P6 (routes nginx désactivables, option A simple). Suite à [#172](https://github.com/bmatge/dsfr-data/pull/172) (PR-1), [#173](https://github.com/bmatge/dsfr-data/pull/173) (PR-2), [#174](https://github.com/bmatge/dsfr-data/pull/174) (PR-3), [#175](https://github.com/bmatge/dsfr-data/pull/175) (alignement doc) et [#178](https://github.com/bmatge/dsfr-data/pull/178) (PR-4).

## Summary

Deux livrables :

### 1. Section "Configuration self-hosted" dans `docs/DEPLOYMENT.md`

Trois scénarios documentés, du plus simple au plus contraint :
- **A. Déploiement de référence** (Traefik intégré, `APP_DOMAIN` suffit).
- **B. Derrière un proxy d'entreprise** (`HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` build + runtime, résumé des PR-2 et PR-4).
- **C. Reverse externe gérant les routes `/*-proxy/`** (commenter les blocs nginx concernés + déclarer le chemin équivalent dans le reverse externe).

**Contrat exhaustif des 9 chemins de proxying** sous forme de tableau (cible upstream, méthodes acceptées, politique de cache, headers CORS attendus, particularités). Les opérateurs tiers peuvent répliquer le contrat derrière leur propre reverse sans lire le code source.

### 2. Annotations `DÉSACTIVABLE` dans `docker/nginx.conf` + `nginx-db.conf`

Chaque bloc `location /*-proxy/` (9 par fichier : `/grist-gouv-proxy/`, `/grist-proxy/`, `/albert-proxy/`, `/ia-proxy`, `/ia-server-config`, `/ia-proxy-default`, `/insee-proxy/`, `/tabular-proxy/`, `/cors-proxy`) reçoit un commentaire 3-4 lignes avec la cible upstream et un renvoi vers la section du contrat. Les paires `/ia-server-config` + `/ia-proxy-default` sont signalées comme indissociables.

### Références

- `README.md` (paragraphe "Déployer la webapp") — pointe vers la nouvelle section.
- `CLAUDE.md` (section "Déploiement serveur") — pointe vers la nouvelle section + mentionne les annotations DÉSACTIVABLE comme entrée pour le code.

## Test plan

- [x] Sommaire de `DEPLOYMENT.md` mis à jour avec les 4 sous-sections.
- [x] 9 commentaires `DÉSACTIVABLE` dans `nginx.conf` + 9 dans `nginx-db.conf` (vérifié par grep).
- [x] Tableau du contrat aligné sur les `proxy_pass` et `proxy_cache_*` réels des deux confs nginx.
- [ ] Validation CI complète (Trivy image valide la syntaxe nginx — les changements sont purement des commentaires `#`, risque ~nul).

## Critères d'acceptation globaux de l'épic #168

- [x] Déploiement de référence inchangé (validé en prod sur PR-3).
- [x] Déploiement tiers sur domaine arbitraire via simple `.env` + `deploy*.sh`.
- [x] Déploiement derrière proxy d'entreprise via variables POSIX standard (build + runtime).
- [x] Toute variable de config manquante échoue bruyamment (PR-3).
- [x] La doc couvre les trois scénarios (cette PR).
- [x] Pas de régression sur les tests existants.
- [x] Workflows GitHub Actions verts.

Closes #168 (épic complet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)