### PR TITLE
build: séparer PROXY_BASE_URL / PROXY_BASE_URL_EMBED / BEACON_BASE_URL (#180)

### DIFF
--- a/.changeset/split-runtime-embed-beacon.md
+++ b/.changeset/split-runtime-embed-beacon.md
@@ -1,0 +1,25 @@
+---
+'dsfr-data': minor
+---
+
+build: séparation `PROXY_BASE_URL` (runtime app) / `PROXY_BASE_URL_EMBED` (code généré) / `BEACON_BASE_URL` (télémétrie) — closes #180.
+
+Permet aux opérateurs self-hostés de découpler le domaine où l'app tourne (potentiellement interne / privé) du domaine inliné dans les widgets générés (qui doit être public et stable pour fonctionner sur des sites tiers). Et optionnellement un troisième domaine pour la collecte télémétrie.
+
+**Cascade de fallback** (aucune régression sans changement explicite côté `.env`) :
+```
+BEACON_BASE_URL = VITE_BEACON_URL || PROXY_BASE_URL_EMBED || PROXY_BASE_URL
+PROXY_BASE_URL_EMBED = VITE_PROXY_URL_EMBED || PROXY_BASE_URL
+PROXY_BASE_URL = VITE_PROXY_URL || 'https://chartsbuilder.matge.com'
+```
+
+**Répartition par usage** :
+- `PROXY_BASE_URL` (runtime) : `apps/grist-widgets`, `apps/monitoring`, `apps/sources`
+- `PROXY_BASE_URL_EMBED` (embed) : code généré par `apps/builder`, `apps/builder-ia`, `apps/builder-carto` ET adapters de `packages/core` (via `getProxyConfig()` — les adapters tournent dans le bundle lib chargé sur des sites tiers)
+- `BEACON_BASE_URL` (télémétrie) : URL bakée dans le bundle lib `packages/core/dist/dsfr-data.*.js`
+
+**Validation empirique** : avec `VITE_PROXY_URL=https://app.test VITE_PROXY_URL_EMBED=https://cdn.test VITE_BEACON_URL=https://analytics.test`, les bundles produits respectent la séparation (vérifié par grep — `cdn.test` dans le code embed, `app.test` uniquement dans les apps runtime, `analytics.test` dans le bundle lib pour le beacon).
+
+**Documentation** : nouveau Scénario D dans `docs/DEPLOYMENT.md` §"Configuration self-hosted" — "app interne + widgets publics" avec la cascade et un protocole de validation reproductible.
+
+**Infra** : Dockerfiles + docker-compose propagent les 3 variables au build. Tests : 2946/2946 ✅.

--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,37 @@ APP_DOMAIN=chartsbuilder.matge.com
 # VITE_PROXY_URL=https://chartsbuilder.matge.com
 
 # ---------------------------------------------------------------------------
+# Domaine d'embed (build-time, optionnel) -- separation app vs widgets
+# ---------------------------------------------------------------------------
+# URL de base inlinee dans le code genere par les builders (widgets destines
+# a etre colles sur un site tiers). Utile pour self-heberger l'app sur un
+# domaine interne tout en generant des widgets qui pointent vers un domaine
+# public stable (ex. CDN, instance partagee). Cf. issue #180.
+#
+# Si non defini, fallback en cascade sur VITE_PROXY_URL (= cas du deploiement
+# de reference : runtime et embed sur le meme domaine).
+#
+# Concerne : code genere par apps/builder, apps/builder-ia, apps/builder-carto.
+# Ne concerne PAS les widgets Grist (apps/grist-widgets), le monitoring, ni
+# les appels runtime de l'app -- ils restent sur VITE_PROXY_URL.
+# VITE_PROXY_URL_EMBED=https://cdn.example.com
+
+# ---------------------------------------------------------------------------
+# URL de collecte du beacon de telemetrie (build-time, optionnel)
+# ---------------------------------------------------------------------------
+# URL utilisee par le bundle lib (packages/core/dist/dsfr-data.*.js) pour
+# envoyer le beacon de telemetrie. Le bundle etant distribue sur npm/CDN et
+# charge par des sites tiers, l'URL doit pointer vers un domaine qui heberge
+# la collecte (typiquement = domaine d'embed). Cf. issue #180.
+#
+# Si non defini, fallback en cascade sur VITE_PROXY_URL_EMBED puis
+# VITE_PROXY_URL (= cas du deploiement de reference).
+#
+# Utile pour : pointer les beacons vers un domaine d'analytics distinct
+# (ex. analytics.example.com) different du domaine de l'app et de l'embed.
+# VITE_BEACON_URL=https://analytics.example.com
+
+# ---------------------------------------------------------------------------
 # URL de la librairie JS dans le code genere (build-time)
 # ---------------------------------------------------------------------------
 # URL de base pour les bundles dsfr-data dans le code HTML genere (builders).

--- a/apps/builder-carto/src/ui/code-generator.ts
+++ b/apps/builder-carto/src/ui/code-generator.ts
@@ -4,7 +4,12 @@
 import { state } from '../state.js';
 import type { LayerConfig } from '../state.js';
 import { LIB_URL } from '../state.js';
-import { detectProvider, extractResourceIds, getProvider, PROXY_BASE_URL } from '@dsfr-data/shared';
+import {
+  detectProvider,
+  extractResourceIds,
+  getProvider,
+  PROXY_BASE_URL_EMBED,
+} from '@dsfr-data/shared';
 
 function layerAttrs(layer: LayerConfig): string {
   const attrs: string[] = [];
@@ -106,7 +111,7 @@ function sourceTag(layer: LayerConfig): string {
     let gristUrl = s.apiUrl || '';
     for (const host of gristProvider.knownHosts) {
       if (s.apiUrl?.includes(host.hostname)) {
-        gristUrl = `${PROXY_BASE_URL}${host.proxyEndpoint}/api/docs/${s.documentId}/tables/${s.tableId}/records`;
+        gristUrl = `${PROXY_BASE_URL_EMBED}${host.proxyEndpoint}/api/docs/${s.documentId}/tables/${s.tableId}/records`;
         break;
       }
     }

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -10,7 +10,7 @@
  * Tests in tests/apps/builder-ia/skills.test.ts verify alignment automatically.
  */
 
-import { CDN_URLS, PROXY_BASE_URL, LIB_URL } from '@dsfr-data/shared';
+import { CDN_URLS, PROXY_BASE_URL_EMBED, LIB_URL } from '@dsfr-data/shared';
 import type { Source } from './state.js';
 
 /** A single skill definition */
@@ -456,7 +456,7 @@ Nommage automatique sans alias : \`champ__fonction\` (ex: \`population__sum\`)
 
 <!-- Grist : source + normalize + query -->
 <dsfr-data-source id="src" api-type="grist"
-  base-url="${PROXY_BASE_URL}/grist-gouv-proxy/api/docs/DOC_ID/tables/TABLE/records"
+  base-url="${PROXY_BASE_URL_EMBED}/grist-gouv-proxy/api/docs/DOC_ID/tables/TABLE/records"
   headers='{"Authorization":"Bearer API_KEY"}'>
 </dsfr-data-source>
 <dsfr-data-normalize id="flat" source="src" flatten="fields"></dsfr-data-normalize>
@@ -1602,7 +1602,7 @@ L'adapter choisit entre mode Records (filter/sort/pagination) et mode SQL (group
 
 \`\`\`html
 <dsfr-data-source id="src" api-type="grist"
-  base-url="${PROXY_BASE_URL}/grist-gouv-proxy/api/docs/DOC_ID/tables/TABLE/records"
+  base-url="${PROXY_BASE_URL_EMBED}/grist-gouv-proxy/api/docs/DOC_ID/tables/TABLE/records"
   headers='{"Authorization":"Bearer API_KEY"}'>
 </dsfr-data-source>
 <dsfr-data-query id="data" source="src"
@@ -1621,7 +1621,7 @@ L'adapter choisit entre mode Records (filter/sort/pagination) et mode SQL (group
 ### Pipeline Grist avec facettes :
 \`\`\`html
 <dsfr-data-source id="src" api-type="grist"
-  base-url="${PROXY_BASE_URL}/grist-gouv-proxy/api/docs/DOC_ID/tables/TABLE/records"
+  base-url="${PROXY_BASE_URL_EMBED}/grist-gouv-proxy/api/docs/DOC_ID/tables/TABLE/records"
   headers='{"Authorization":"Bearer API_KEY"}'>
 </dsfr-data-source>
 
@@ -2036,7 +2036,7 @@ Chaque provider a des capacites differentes pour la pagination, l'agregation et 
 **Grist** (fetch serveur + auto-flatten, aggregation via SQL) :
 \`\`\`html
 <dsfr-data-source id="src" api-type="grist"
-  base-url="${PROXY_BASE_URL}/grist-gouv-proxy/api/docs/DOC_ID/tables/TABLE/records"
+  base-url="${PROXY_BASE_URL_EMBED}/grist-gouv-proxy/api/docs/DOC_ID/tables/TABLE/records"
   headers='{"Authorization":"Bearer API_KEY"}'>
 </dsfr-data-source>
 <dsfr-data-query id="data" source="src"
@@ -2083,9 +2083,9 @@ L'adapter INSEE aplatit automatiquement les observations (dimensions + measures 
 ### Proxy CORS
 Certaines APIs externes necessitent un proxy CORS en production.
 Les URLs connues sont automatiquement proxifiees :
-- \`grist.numerique.gouv.fr\` -> \`${PROXY_BASE_URL}/grist-gouv-proxy\`
-- \`docs.getgrist.com\` -> \`${PROXY_BASE_URL}/grist-proxy\`
-- \`tabular-api.data.gouv.fr\` -> \`${PROXY_BASE_URL}/tabular-proxy\`
+- \`grist.numerique.gouv.fr\` -> \`${PROXY_BASE_URL_EMBED}/grist-gouv-proxy\`
+- \`docs.getgrist.com\` -> \`${PROXY_BASE_URL_EMBED}/grist-proxy\`
+- \`tabular-api.data.gouv.fr\` -> \`${PROXY_BASE_URL_EMBED}/tabular-proxy\`
 
 APIs avec CORS natif (pas de proxy necessaire) :
 - OpenDataSoft (\`*.opendatasoft.com\` et portails publics)

--- a/apps/builder/src/state.ts
+++ b/apps/builder/src/state.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Source } from '@dsfr-data/shared';
-export { PROXY_BASE_URL, LIB_URL } from '@dsfr-data/shared';
+export { PROXY_BASE_URL, PROXY_BASE_URL_EMBED, LIB_URL } from '@dsfr-data/shared';
 
 /** Favorites localStorage key */
 export const FAVORITES_KEY = 'dsfr-data-favorites';

--- a/apps/builder/src/ui/code-generator.ts
+++ b/apps/builder/src/ui/code-generator.ts
@@ -19,7 +19,7 @@ import {
   extractResourceIds,
   getProvider,
 } from '@dsfr-data/shared';
-import { state, type DataRecord, PROXY_BASE_URL, LIB_URL } from '../state.js';
+import { state, type DataRecord, PROXY_BASE_URL_EMBED, LIB_URL } from '../state.js';
 import { renderPreview } from './preview.js';
 import { updateAccessibleTable } from './accessible-table.js';
 
@@ -1329,7 +1329,7 @@ export function generateDynamicCode(): void {
 
   for (const host of gristProvider.knownHosts) {
     if (source.apiUrl?.includes(host.hostname)) {
-      proxyUrl = `${PROXY_BASE_URL}${host.proxyEndpoint}/api/docs/${source.documentId}/tables/${source.tableId}/records`;
+      proxyUrl = `${PROXY_BASE_URL_EMBED}${host.proxyEndpoint}/api/docs/${source.documentId}/tables/${source.tableId}/records`;
       gristHost = host.hostname;
       break;
     }
@@ -1454,7 +1454,7 @@ ${middlewareHtml}
 
   const code = `<!-- Graphique dynamique genere avec dsfr-data Builder -->
 <!-- Source : ${escapeHtml(source.name)} (chargement dynamique depuis ${gristHost}) -->
-<!-- Les donnees sont chargees via le proxy ${PROXY_BASE_URL} -->
+<!-- Les donnees sont chargees via le proxy ${PROXY_BASE_URL_EMBED} -->
 ${state.advancedMode ? '<!-- Mode avance active : filtrage et agregation via dsfr-data-query -->' : ''}
 
 <!-- Dependances CSS (DSFR) -->

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,8 +39,12 @@ COPY . .
 # applique son fallback historique (le domaine de référence).
 # Cf. issue #168 — PR-3 transformera ce fallback en fail-fast.
 ARG VITE_PROXY_URL=""
+ARG VITE_PROXY_URL_EMBED=""
+ARG VITE_BEACON_URL=""
 ARG VITE_LIB_URL=""
 ENV VITE_PROXY_URL=$VITE_PROXY_URL \
+    VITE_PROXY_URL_EMBED=$VITE_PROXY_URL_EMBED \
+    VITE_BEACON_URL=$VITE_BEACON_URL \
     VITE_LIB_URL=$VITE_LIB_URL
 
 RUN npm run build:all

--- a/docker/Dockerfile.db
+++ b/docker/Dockerfile.db
@@ -40,8 +40,12 @@ COPY . .
 # applique son fallback historique (le domaine de référence).
 # Cf. issue #168 — PR-3 transformera ce fallback en fail-fast.
 ARG VITE_PROXY_URL=""
+ARG VITE_PROXY_URL_EMBED=""
+ARG VITE_BEACON_URL=""
 ARG VITE_LIB_URL=""
 ENV VITE_PROXY_URL=$VITE_PROXY_URL \
+    VITE_PROXY_URL_EMBED=$VITE_PROXY_URL_EMBED \
+    VITE_BEACON_URL=$VITE_BEACON_URL \
     VITE_LIB_URL=$VITE_LIB_URL
 
 RUN npm run build:all

--- a/docker/docker-compose.db.yml
+++ b/docker/docker-compose.db.yml
@@ -35,6 +35,10 @@ services:
         # historique de packages/shared/src/api/proxy-config.ts.
         # Cf. issue #168 (PR-1).
         VITE_PROXY_URL: ${VITE_PROXY_URL:-}
+        # Séparation app runtime / code embed / beacon télémétrie. Fallback en
+        # cascade dans packages/shared/src/api/proxy-config.ts. Cf. issue #180.
+        VITE_PROXY_URL_EMBED: ${VITE_PROXY_URL_EMBED:-}
+        VITE_BEACON_URL: ${VITE_BEACON_URL:-}
         VITE_LIB_URL: ${VITE_LIB_URL:-}
         # Proxy HTTP sortant pour `npm ci` + `apk add` au build derrière
         # un proxy d'entreprise. Build-time uniquement (pas runtime).

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,10 @@ services:
         # sur le fallback historique de packages/shared/src/api/proxy-config.ts.
         # Cf. issue #168 (PR-1).
         VITE_PROXY_URL: ${VITE_PROXY_URL:-}
+        # Séparation app runtime / code embed / beacon télémétrie. Fallback en
+        # cascade dans packages/shared/src/api/proxy-config.ts. Cf. issue #180.
+        VITE_PROXY_URL_EMBED: ${VITE_PROXY_URL_EMBED:-}
+        VITE_BEACON_URL: ${VITE_BEACON_URL:-}
         VITE_LIB_URL: ${VITE_LIB_URL:-}
         # Proxy HTTP sortant pour `npm ci` + `apk add` au build derrière
         # un proxy d'entreprise. Build-time uniquement (pas runtime).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -17,6 +17,7 @@ Ce guide couvre le deploiement de la **webapp dsfr-data** (apps Builder, Builder
   - [Scenario A : deploiement de reference](#scenario-a--deploiement-de-reference-traefik-integre)
   - [Scenario B : derriere un proxy d'entreprise](#scenario-b--derriere-un-proxy-dentreprise)
   - [Scenario C : reverse externe gerant les routes de proxying](#scenario-c--reverse-externe-gerant-les-routes-de-proxying)
+  - [Scenario D : app interne + widgets publics (separation runtime/embed)](#scenario-d--app-interne--widgets-publics-separation-runtimeembed)
   - [Contrat des chemins de proxying](#contrat-des-chemins-de-proxying)
 - [Premier deploiement](#premier-deploiement)
   - [Mode statique](#mode-statique)
@@ -227,6 +228,52 @@ Puis declarer dans votre reverse externe une regle qui :
 Les paires `/ia-server-config` + `/ia-proxy-default` doivent etre commentees ensemble — le premier annonce la disponibilite du proxy IA par defaut, le second l'execute. Commenter l'un sans l'autre laisse l'app dans un etat incoherent (UI affiche "IA disponible" mais l'appel echoue).
 
 **Tip** : les overrides specifiques a un site (compose, nginx custom) doivent passer par `docker-compose.override.yml` (gitignored) plutot que par des patches locaux des fichiers livres, sinon `git pull` les ecrasera. Cf. [issue #168](https://github.com/bmatge/dsfr-data/issues/168) pour la motivation.
+
+### Scenario D : app interne + widgets publics (separation runtime/embed)
+
+Pour les operateurs qui veulent decoupler les trois dimensions suivantes :
+
+- **Runtime app** — domaine ou l'app tourne (peut etre interne, prive, intranet).
+- **Embed** — domaine inline dans les widgets generes (doit etre stable et accessible aux sites tiers qui embarquent les widgets).
+- **Beacon** — domaine de collecte de la telemetrie (peut etre un endpoint d'analytics distinct).
+
+Cas typique : un operateur deploie l'app sur `app.interne.example` pour ses utilisateurs internes, mais veut que les widgets generes pointent vers `cdn.public.example` pour fonctionner sur des sites tiers sans dependre de l'infra interne.
+
+**Trois variables build-time en cascade** (cf. issue [#180](https://github.com/bmatge/dsfr-data/issues/180)) :
+
+```bash
+VITE_PROXY_URL=https://app.interne.example         # runtime app -- REQUISE
+VITE_PROXY_URL_EMBED=https://cdn.public.example    # optionnelle, fallback sur VITE_PROXY_URL
+VITE_BEACON_URL=https://analytics.example.com      # optionnelle, fallback sur VITE_PROXY_URL_EMBED
+```
+
+Resolution :
+
+- `PROXY_BASE_URL = VITE_PROXY_URL || 'https://chartsbuilder.matge.com'`
+- `PROXY_BASE_URL_EMBED = VITE_PROXY_URL_EMBED || PROXY_BASE_URL`
+- `BEACON_BASE_URL = VITE_BEACON_URL || PROXY_BASE_URL_EMBED`
+
+**Aucune regression possible** sans changement explicite : si seul `VITE_PROXY_URL` est defini (cas du deploiement de reference), les trois dimensions pointent vers le meme domaine.
+
+**Repartition par usage** :
+
+| Variable | Utilisee par |
+|---|---|
+| `PROXY_BASE_URL` (runtime) | `apps/grist-widgets`, `apps/monitoring`, `apps/sources`, `getProxyConfig()` de l'app |
+| `PROXY_BASE_URL_EMBED` (embed) | Code genere par `apps/builder`, `apps/builder-ia`, `apps/builder-carto` (attribut `base-url`/`url=` des widgets) |
+| `BEACON_BASE_URL` (beacon) | URL de telemetrie bakee dans le bundle lib `packages/core/dist/dsfr-data.*.js` |
+
+**Validation** : pour verifier qu'aucune URL n'a fui dans le mauvais sens apres build, `grep` les bundles produits :
+
+```bash
+VITE_PROXY_URL=https://app.test VITE_PROXY_URL_EMBED=https://cdn.test \
+  VITE_BEACON_URL=https://analytics.test npm run build:all
+
+# Code embed des builders doit contenir cdn.test, pas app.test
+grep -r "app.test\|cdn.test" apps/builder/dist/
+# Bundle lib doit contenir analytics.test pour le beacon
+grep -r "analytics.test" packages/core/dist/
+```
 
 ### Contrat des chemins de proxying
 

--- a/packages/core/src/utils/beacon.ts
+++ b/packages/core/src/utils/beacon.ts
@@ -4,9 +4,9 @@
  * Used by the monitoring dashboard to track where widgets are deployed.
  */
 
-import { PROXY_BASE_URL } from '@dsfr-data/shared';
+import { BEACON_BASE_URL } from '@dsfr-data/shared';
 
-const BEACON_URL = `${PROXY_BASE_URL}/beacon`;
+const BEACON_URL = `${BEACON_BASE_URL}/beacon`;
 const sent = new Set<string>();
 /** Keep references to pending beacon images to prevent GC before request completes */
 const pending: HTMLImageElement[] = [];
@@ -43,9 +43,11 @@ export function sendWidgetBeacon(component: string, subtype?: string): void {
   const proto = window.location.protocol;
   if (proto !== 'http:' && proto !== 'https:') return;
 
-  // Skip in dev mode and on the app itself (only track external deployments)
+  // Skip in dev mode and on the beacon collection host itself (only track
+  // external deployments — internal pings would inflate stats with our own
+  // navigation on the app/embed domain).
   const host = window.location.hostname;
-  if (host === 'localhost' || host === '127.0.0.1' || host === new URL(PROXY_BASE_URL).hostname) {
+  if (host === 'localhost' || host === '127.0.0.1' || host === new URL(BEACON_BASE_URL).hostname) {
     return;
   }
 

--- a/packages/shared/src/api/proxy-config.ts
+++ b/packages/shared/src/api/proxy-config.ts
@@ -30,14 +30,40 @@ declare global {
   interface ImportMeta {
     readonly env?: {
       readonly VITE_PROXY_URL?: string;
+      readonly VITE_PROXY_URL_EMBED?: string;
+      readonly VITE_BEACON_URL?: string;
       readonly VITE_LIB_URL?: string;
     };
   }
 }
 
-/** Default production proxy base URL (overridable via VITE_PROXY_URL at build time) */
+/**
+ * URL de base **runtime de l'app** — utilisée par l'app elle-même pour ses
+ * propres appels (monitoring, widgets Grist consommant des données, etc.).
+ * Surchargeable via `VITE_PROXY_URL` au build. Cf. #180.
+ */
 export const PROXY_BASE_URL: string =
   import.meta.env?.VITE_PROXY_URL || 'https://chartsbuilder.matge.com';
+
+/**
+ * URL de base **inlinée dans le code généré** par les builders (widgets
+ * destinés à être collés sur un site tiers). Permet à un opérateur de
+ * self-héberger l'app sur un domaine interne tout en générant des widgets
+ * qui pointent vers un domaine public stable.
+ * Surchargeable via `VITE_PROXY_URL_EMBED` au build, fallback sur
+ * `PROXY_BASE_URL` (= cas du déploiement de référence). Cf. #180.
+ */
+export const PROXY_BASE_URL_EMBED: string = import.meta.env?.VITE_PROXY_URL_EMBED || PROXY_BASE_URL;
+
+/**
+ * URL de collecte du **beacon de télémétrie** baké dans le bundle lib
+ * (`packages/core`). Le bundle étant distribué sur npm/CDN et chargé par
+ * des sites tiers, l'URL doit pointer vers le domaine qui héberge la
+ * collecte (typiquement = domaine d'embed).
+ * Surchargeable via `VITE_BEACON_URL` au build, fallback sur
+ * `PROXY_BASE_URL_EMBED` (= cas du déploiement de référence). Cf. #180.
+ */
+export const BEACON_BASE_URL: string = import.meta.env?.VITE_BEACON_URL || PROXY_BASE_URL_EMBED;
 
 /**
  * Base URL for the dsfr-data JS library in generated code.
@@ -58,9 +84,16 @@ function resolveLibUrl(): string {
 }
 export const LIB_URL: string = resolveLibUrl();
 
-/** Default production proxy configuration */
+/**
+ * Default production proxy configuration. Utilise `PROXY_BASE_URL_EMBED`
+ * (= `PROXY_BASE_URL` par défaut) car les adapters de `packages/core`
+ * tournent dans le bundle lib, qui s'exécute aussi bien dans l'app
+ * elle-même (preview) que sur des sites tiers embarquant un widget.
+ * Dans les deux cas, l'URL doit être celle publiquement accessible.
+ * Cf. issue #180.
+ */
 export const DEFAULT_PROXY_CONFIG: ProxyConfig = {
-  baseUrl: PROXY_BASE_URL,
+  baseUrl: PROXY_BASE_URL_EMBED,
   endpoints: {
     grist: '/grist-proxy',
     gristGouv: '/grist-gouv-proxy',
@@ -89,10 +122,18 @@ export function isTauriMode(): boolean {
 }
 
 /**
- * Get the proxy configuration based on the current environment
+ * Get the proxy configuration based on the current environment.
  * - Dev mode: relative URLs (handled by Vite proxy)
- * - Tauri mode: full URLs to the production proxy
- * - Production web: configurable via VITE_PROXY_URL or defaults to production proxy
+ * - Tauri mode: full URLs to the production proxy (PROXY_BASE_URL_EMBED)
+ * - Production web: PROXY_BASE_URL_EMBED
+ *
+ * Note : utilise `PROXY_BASE_URL_EMBED` (et non `PROXY_BASE_URL` runtime) car
+ * cette config est consommée par les adapters de `packages/core` qui tournent
+ * dans le bundle lib — chargé indifféremment dans l'app elle-même (preview)
+ * ou sur un site tiers embarquant un widget. L'URL doit donc être celle
+ * publiquement accessible. Sans `VITE_PROXY_URL_EMBED` défini, la cascade
+ * retombe sur `PROXY_BASE_URL` (= déploiement de référence inchangé).
+ * Cf. issue #180.
  */
 export function getProxyConfig(): ProxyConfig {
   const endpoints = { ...DEFAULT_PROXY_CONFIG.endpoints };
@@ -102,14 +143,14 @@ export function getProxyConfig(): ProxyConfig {
     return { baseUrl: '', endpoints };
   }
 
-  // Tauri: always use the remote proxy
+  // Tauri: always use the remote proxy (embed URL = publicly accessible)
   if (isTauriMode()) {
-    return { baseUrl: DEFAULT_PROXY_CONFIG.baseUrl, endpoints };
+    return { baseUrl: PROXY_BASE_URL_EMBED, endpoints };
   }
 
-  // Production web: uses PROXY_BASE_URL (already respects VITE_PROXY_URL)
+  // Production web
   return {
-    baseUrl: PROXY_BASE_URL,
+    baseUrl: PROXY_BASE_URL_EMBED,
     endpoints,
   };
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -28,6 +28,8 @@ export {
   isTauriMode,
   DEFAULT_PROXY_CONFIG,
   PROXY_BASE_URL,
+  PROXY_BASE_URL_EMBED,
+  BEACON_BASE_URL,
   LIB_URL,
 } from './api/proxy-config.js';
 export type { ProxyConfig } from './api/proxy-config.js';


### PR DESCRIPTION
## Contexte

Clôt l'issue [#180](https://github.com/bmatge/dsfr-data/issues/180), follow-up explicitement déposé par l'épic [#168](https://github.com/bmatge/dsfr-data/issues/168) dans sa section "Non-objectifs" ("Refondre la séparation `PROXY_BASE_URL_RUNTIME` vs `PROXY_BASE_URL_EMBED` … à traiter dans un epic séparé").

## Summary

Sépare trois dimensions auparavant collapsées sur `VITE_PROXY_URL` :

- **`PROXY_BASE_URL`** (runtime) — domaine où l'app tourne (peut être interne / privé)
- **`PROXY_BASE_URL_EMBED`** — domaine inliné dans les widgets générés (doit être public, accessible aux sites tiers qui embarquent)
- **`BEACON_BASE_URL`** — domaine de collecte télémétrie (peut être un endpoint d'analytics distinct)

Cascade de fallback : **aucune régression possible** sans changement explicite côté `.env`.

```
BEACON_BASE_URL = VITE_BEACON_URL || PROXY_BASE_URL_EMBED || PROXY_BASE_URL
PROXY_BASE_URL_EMBED = VITE_PROXY_URL_EMBED || PROXY_BASE_URL
PROXY_BASE_URL = VITE_PROXY_URL || 'https://chartsbuilder.matge.com'
```

## Implémentation

- **`packages/shared/src/api/proxy-config.ts`** : 2 nouvelles exports avec cascade. `getProxyConfig()` et `DEFAULT_PROXY_CONFIG.baseUrl` repositionnés sur `PROXY_BASE_URL_EMBED` (les adapters de `packages/core` tournent dans le bundle lib, chargé indifféremment dans l'app ou sur sites tiers — l'URL doit être publiquement accessible).
- **`packages/core/src/utils/beacon.ts`** : `BEACON_BASE_URL` pour l'URL beacon ET le check skip-host (cohérent).
- **Retarget EMBED** (10 call-sites) : `apps/builder/src/ui/code-generator.ts` (×2), `apps/builder-ia/src/skills.ts` (×8 dont l'import), `apps/builder-carto/src/ui/code-generator.ts` (×1).
- **Restent sur RUNTIME** : `apps/grist-widgets`, `apps/monitoring`, `apps/sources` (code app-domain).
- **Infra Docker** : `Dockerfile` + `Dockerfile.db` + `docker-compose*.yml` propagent les 3 variables au build.

## Documentation

- `.env.example` — 2 nouvelles sections documentant les 3 dimensions et la cascade.
- `docs/DEPLOYMENT.md` §"Configuration self-hosted" — **Scénario D** ajouté : "app interne + widgets publics" avec protocole de validation par grep sur les bundles produits.

## Validation empirique

Build avec 3 URLs distinctes pour vérifier la séparation :

```bash
VITE_PROXY_URL=https://app.test \
  VITE_PROXY_URL_EMBED=https://cdn.test \
  VITE_BEACON_URL=https://analytics.test \
  DSFR_DATA_DEV_BUILD=1 npm run build:all
```

Distribution observée dans les bundles produits :

| Bundle | `app.test` (RUNTIME) | `cdn.test` (EMBED) | `analytics.test` (BEACON) | Statut |
|---|---|---|---|---|
| `apps/builder/dist/*.js` | 0 | 2 | 2 | ✅ Pas de leak runtime |
| `apps/builder-ia/dist/*.js` | 0 | 2 | 2 | ✅ Pas de leak runtime |
| `apps/builder-carto/dist/*.js` | 0 | 2 | 2 | ✅ Pas de leak runtime |
| `apps/grist-widgets/dist/*.js` | 1 | 0 | 0 | ✅ Runtime only (app-domain) |
| `apps/monitoring/dist/*.js` | 1 | 1 | 2 | ✅ Runtime fetch + lib intégrée |
| `packages/core/dist/*.js` | 0 | 1 | 2 | ✅ Lib utilise embed pour les adapters + beacon |

## Test plan

- [x] Tests unitaires : 2946/2946 ✅
- [x] Lint OK
- [x] Build complet avec valeurs distinctes : aucune URL ne fuit dans la mauvaise dimension
- [ ] Validation CI complète (ce PR)
- [ ] Vérification post-merge en prod : `deploy-server.sh` continue de fonctionner avec une seule variable (`VITE_PROXY_URL` générée depuis `APP_DOMAIN`, les autres cascadent)

Closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)