### PR TITLE
docs: refonte README orienté audiences + checklist post-déploiement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,33 +6,51 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Security Policy](https://img.shields.io/badge/security-policy-red.svg)](./docs/SECURITY.md)
 
-dsfr-data est un module complementaire au [Systeme de design de l'Etat](https://www.systeme-de-design.gouv.fr/) (DSFR) pour l'integration de donnees dynamiques. Il s'agit d'une bibliotheque de [Web Components](https://developer.mozilla.org/fr/docs/Web/API/Web_components) (Lit), sous la forme de balises HTML `<dsfr-data-*>`, a destination des developpeurs et integrateurs ayant besoin d'afficher des donnees issues d'APIs ouvertes dans leurs pages web.
+> **Web Components de dataviz** (Lit) pour sites gouvernementaux francais, conformes au [Systeme de design de l'Etat (DSFR)](https://www.systeme-de-design.gouv.fr/). Connectez vos sources (Huwise/ODS, Tabular, Grist, INSEE Melodi…), composez votre pipeline en balises `<dsfr-data-*>`, et exportez du HTML pret a integrer.
 
-dsfr-data s'appuie sur [DSFR Chart](https://github.com/GouvernementFR/dsfr-chart) pour le rendu des graphiques.
+```html
+<dsfr-data-source id="src" api-type="opendatasoft"
+  base-url="https://data.economie.gouv.fr" dataset-id="industrie-du-futur" limit="100">
+</dsfr-data-source>
 
-## Demo
+<dsfr-data-query id="q" source="src"
+  group-by="nom_region" aggregate="nombre_beneficiaires:sum:total" order-by="total:desc">
+</dsfr-data-query>
 
-L'ensemble des composants et leurs options sont documentes sur la page de [specifications](https://bmatge.github.io/dsfr-data/specs/).
+<dsfr-data-chart source="q" type="bar"
+  label-field="nom_region" value-field="total" titre="Beneficiaires par region">
+</dsfr-data-chart>
+```
+
+**Demo interactive et reference complete des composants** : [bmatge.github.io/dsfr-data/specs](https://bmatge.github.io/dsfr-data/specs/)
+
+---
+
+## Selon votre profil
+
+| Vous etes… | Vous voulez… | Allez ici |
+|---|---|---|
+| **Integrateur / developpeur web** | Coller un widget DSFR sur votre page | [Installation](#installation) ci-dessous + [specifications interactives](https://bmatge.github.io/dsfr-data/specs/) |
+| **Utilisateur metier / non-tech** | Generer un graphique sans coder via le Builder | [Guide utilisateur](docs/USER-GUIDE.md) |
+| **Operateur / ops** | Heberger votre instance dsfr-data | [Guide de deploiement](docs/DEPLOYMENT.md) |
+| **Contributeur** | Contribuer au code, comprendre l'architecture | [Guide de contribution](docs/CONTRIBUTING.md) + [Architecture](docs/ARCHITECTURE.md) |
+| **Decideur / acheteur** | Positionnement produit, comparatifs, cibles | [Fiche produit](docs/DATASHEET.md) |
+| **RSSI / equipe securite** | Politique de signalement, baseline SCA/DAST | [Politique de securite](docs/SECURITY.md) |
 
 ## Installation
 
-### Fichiers statiques (CDN)
+### CDN (sans build)
 
 **Prerequis** : le projet doit utiliser le [DSFR](https://www.systeme-de-design.gouv.fr/comment-utiliser-le-dsfr/developpeurs/prise-en-main-du-dsfr/) et [DSFR Chart](https://github.com/GouvernementFR/dsfr-chart).
 
 ```html
-<!-- DSFR -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css">
-
-<!-- DSFR Chart -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css">
 <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js"></script>
-
-<!-- dsfr-data -->
 <script src="https://unpkg.com/dsfr-data/dist/dsfr-data.core.umd.js"></script>
 ```
 
-### NPM
+### npm
 
 ```bash
 npm install dsfr-data
@@ -42,387 +60,49 @@ npm install dsfr-data
 import 'dsfr-data';
 ```
 
-### Structure des bundles
+### Bundles disponibles
 
-Quatre bundles sont disponibles selon les besoins :
-
-| Bundle | Contenu | Taille (gzip) |
-|--------|---------|---------------|
-| `dsfr-data.core.{esm,umd}.js` | Tous les composants sauf carte du monde et carte interactive (inclut `dsfr-data-join`) | ~61 Ko |
-| `dsfr-data.world-map.{esm,umd}.js` | Composant `dsfr-data-world-map` (d3-geo, topojson) | ~31 Ko |
-| `dsfr-data.map.{esm,umd}.js` | `dsfr-data-map` + `dsfr-data-map-layer` (Leaflet charge dynamiquement) | ~33 Ko |
+| Bundle | Contenu | gzip |
+|---|---|---|
+| `dsfr-data.core.{esm,umd}.js` | Tous les composants sauf cartes (inclut `dsfr-data-join`) | ~61 Ko |
+| `dsfr-data.world-map.{esm,umd}.js` | `dsfr-data-world-map` (d3-geo, topojson) | ~31 Ko |
+| `dsfr-data.map.{esm,umd}.js` | `dsfr-data-map` + `dsfr-data-map-layer` (Leaflet lazy) | ~33 Ko |
 | `dsfr-data.{esm,umd}.js` | Tout-en-un | ~97 Ko |
 
-## Deployer la webapp
+La specification exhaustive de chaque composant (attributs, valeurs, exemples interactifs) est sur [bmatge.github.io/dsfr-data/specs](https://bmatge.github.io/dsfr-data/specs/) — c'est la source de verite.
 
-En plus de la bibliotheque, le repo contient une webapp (Builder, Builder IA, Sources, Playground, Favoris, Dashboard, Monitoring, Pipeline Helper, Admin) deployable en self-hosted via Docker. Deux modes :
+## Heberger votre instance
 
-- **Statique** (nginx + localStorage) — usage individuel, aucune persistance serveur.
+Le repo embarque une webapp d'edition (Builder, Builder IA, Sources, Playground, Dashboard, Monitoring…) deployable via Docker en deux modes :
+
+- **Statique** (nginx + localStorage) — usage individuel.
 - **Serveur** (nginx + Express + MariaDB) — multi-utilisateurs, auth JWT, partages, audit.
 
-Voir le **[guide de deploiement](docs/DEPLOYMENT.md)** pour les prerequis (Traefik, DNS, secrets), la configuration `.env`, les migrations de schema, la sauvegarde, le diagnostic et la checklist securite. La section [Configuration self-hosted](docs/DEPLOYMENT.md#configuration-self-hosted) couvre les trois scenarios de deploiement (reference, proxy d'entreprise, reverse externe gerant les routes `/*-proxy/`) avec le contrat exhaustif des chemins de proxying.
+La procedure complete (Traefik, DNS, secrets, migrations, sauvegarde, diagnostic, [validation post-deploiement](docs/DEPLOYMENT.md#validation-post-deploiement), [checklist securite](docs/DEPLOYMENT.md#checklist-securite)) est dans [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md). La section [Configuration self-hosted](docs/DEPLOYMENT.md#configuration-self-hosted) detaille les 4 scenarios supportes (reference, proxy d'entreprise, reverse externe pour les `/*-proxy/`, app interne + widgets publics) avec le contrat exhaustif des chemins de proxying.
 
----
-
-# Composants disponibles
-
-Les composants se chainent de facon declarative pour former un pipeline :
-
-```
-dsfr-data-source → dsfr-data-normalize → dsfr-data-query → dsfr-data-chart / dsfr-data-kpi / dsfr-data-list
-                                                          → dsfr-data-facets / dsfr-data-search
-                                                          → dsfr-data-a11y
-
-Multi-sources :
-dsfr-data-source (A) ──┐
-                       ├──► dsfr-data-join ──► dsfr-data-query ──► dsfr-data-chart
-dsfr-data-source (B) ──┘
-```
-
-## Source de donnees (`dsfr-data-source`)
-
-Composant invisible de connexion aux donnees. Recupere des donnees depuis une API REST ou des donnees inline et les distribue aux autres composants.
-
-### Parametres
-
-#### Obligatoires (mode URL) :
-
-- **url** : _(String)_ URL de l'API a interroger.
-
-#### Obligatoires (mode adapter) :
-
-- **api-type** : _(String)_ Type de provider. Valeurs possibles : `opendatasoft`, `tabular`, `grist`, `generic`.
-- **base-url** : _(String)_ URL de base du portail de donnees.
-- **dataset-id** : _(String)_ Identifiant du jeu de donnees (ODS) ou document (Grist).
-
-#### Optionnels :
-
-- **transform** : _(String)_ Chemin JSON vers les donnees dans la reponse (ex: `results`, `records`).
-- **resource** : _(String)_ Identifiant de la ressource (Tabular) ou table (Grist).
-- **server-side** : _(Boolean)_ Active la pagination server-side.
-- **page-size** : _(Number)_ Nombre d'enregistrements par page (defaut: 100).
-- **where** : _(String)_ Filtre server-side (syntaxe ODSQL ou colon selon le provider).
-- **select** : _(String)_ Colonnes a selectionner.
-- **group-by** : _(String)_ Regroupement server-side.
-- **order-by** : _(String)_ Tri server-side.
-- **limit** : _(Number)_ Nombre maximum d'enregistrements.
-- **refresh** : _(Number)_ Intervalle de rafraichissement en secondes.
-- **data** : _(String)_ Donnees JSON inline (alternative a `url`).
-- **headers** : _(String)_ En-tetes HTTP (JSON).
-- **cache-ttl** : _(Number)_ Duree du cache en secondes.
-
-### Exemple
-
-```html
-<dsfr-data-source id="src" api-type="opendatasoft"
-  base-url="https://data.economie.gouv.fr"
-  dataset-id="industrie-du-futur"
-  limit="100">
-</dsfr-data-source>
-```
-
----
-
-## Requetage (`dsfr-data-query`)
-
-Transformateur client-side : filtre, regroupe, agrege et trie les donnees recues d'une source.
-
-### Parametres
-
-#### Obligatoires :
-
-- **source** : _(String)_ ID du composant source a ecouter.
-
-#### Optionnels :
-
-- **filter** : _(String)_ Expression de filtre (ex: `population > 5000`).
-- **group-by** : _(String)_ Champ(s) de regroupement.
-- **aggregate** : _(String)_ Agregation au format `champ:fonction:alias` (ex: `population:sum:total`). Fonctions : `sum`, `avg`, `count`, `min`, `max`, `first`, `last`, `distinct`.
-- **order-by** : _(String)_ Tri au format `champ:asc|desc`.
-- **limit** : _(Number)_ Nombre maximum de resultats.
-
-### Exemple
-
-```html
-<dsfr-data-query id="q" source="src"
-  group-by="nom_region"
-  aggregate="nombre_beneficiaires:sum:total"
-  order-by="total:desc" limit="10">
-</dsfr-data-query>
-```
-
----
-
-## Jointure multi-sources (`dsfr-data-join`)
-
-Composant invisible qui joint deux sources de donnees sur une ou plusieurs cles pivot. Permet d'enrichir un jeu de donnees avec des informations provenant d'une autre source. Ne fait aucun fetch HTTP.
-
-### Parametres
-
-#### Obligatoires :
-
-- **left** : _(String)_ ID de la source gauche (source principale).
-- **right** : _(String)_ ID de la source droite.
-- **on** : _(String)_ Cle(s) de jointure. Formats : `"code"`, `"dept_code=code"`, `"annee,code_region"`.
-
-#### Optionnels :
-
-- **type** : _(String)_ Type de jointure : `inner`, `left` (defaut), `right`, `full`.
-- **prefix-left** : _(String)_ Prefixe pour les champs gauche en cas de collision (defaut : vide).
-- **prefix-right** : _(String)_ Prefixe pour les champs droite en cas de collision (defaut : `right_`).
-
-### Exemple
-
-```html
-<dsfr-data-source id="pop" data='[{"code":"75","region":"IDF","population":12263},...]'></dsfr-data-source>
-<dsfr-data-source id="budget" data='[{"code":"75","budget":5200},...]'></dsfr-data-source>
-
-<dsfr-data-join id="enriched"
-  left="pop" right="budget"
-  on="code" type="left">
-</dsfr-data-join>
-
-<dsfr-data-chart source="enriched" type="bar"
-  label-field="region" value-field="population" value-fields="budget">
-</dsfr-data-chart>
-```
-
----
-
-## Normalisation (`dsfr-data-normalize`)
-
-Nettoie et transforme les donnees avant traitement.
-
-### Parametres
-
-- **source** : _(String)_ ID du composant source.
-- **to-number** : _(String)_ Champs a convertir en nombre (separes par des virgules).
-- **rename** : _(String)_ Renommage de colonnes au format `ancien:nouveau`.
-- **trim** : _(Boolean)_ Supprime les espaces en debut/fin des valeurs texte.
-- **replace** : _(String)_ Remplacement de valeurs au format `champ:ancien:nouveau`.
-
----
-
-## Graphique DSFR (`dsfr-data-chart`)
-
-Connecte les donnees a un graphique [DSFR Chart](https://github.com/GouvernementFR/dsfr-chart).
-
-### Parametres
-
-#### Obligatoires :
-
-- **source** : _(String)_ ID du composant source.
-- **type** : _(String)_ Type de graphique. Valeurs possibles : `bar`, `line`, `pie`, `radar`, `scatter`, `gauge`, `bar-line`, `map`, `map-reg`.
-- **label-field** : _(String)_ Champ pour les etiquettes.
-- **value-field** : _(String)_ Champ pour les valeurs.
-
-#### Optionnels :
-
-- **value-field-2** : _(String)_ Champ pour une seconde serie (bar-line).
-- **titre** : _(String)_ Titre du graphique.
-- **selected-palette** : _(String)_ Palette de couleurs : `default`, `neutral`, `categorical`, `sequentialAscending`, `sequentialDescending`, `divergentAscending`, `divergentDescending`.
-- **unit-tooltip** : _(String)_ Unite affichee dans l'infobulle (ex: `%`, `EUR`).
-- **horizontal** : _(Boolean)_ Barres horizontales (types bar, bar-line).
-- **stacked** : _(Boolean)_ Barres empilees (types bar, bar-line).
-
-### Exemple
-
-```html
-<dsfr-data-chart source="q" type="bar"
-  label-field="nom_region" value-field="total"
-  titre="Beneficiaires par region"
-  selected-palette="categorical">
-</dsfr-data-chart>
-```
-
----
-
-## Indicateur cle (`dsfr-data-kpi`)
-
-Affiche un indicateur chiffre (KPI) avec formatage, couleur conditionnelle et icone.
-
-### Parametres
-
-- **source** : _(String)_ ID du composant source.
-- **value-field** : _(String)_ Champ de la valeur.
-- **aggregate** : _(String)_ Fonction d'agregation : `sum`, `avg`, `count`, `min`, `max`.
-- **format** : _(String)_ Format d'affichage : `number`, `percent`, `euro`, `decimal`.
-- **label** : _(String)_ Libelle affiche sous la valeur.
-- **icon** : _(String)_ Classe Remix Icon (ex: `ri-line-chart-line`).
-- **color** : _(String)_ Couleur : `blue`, `green`, `orange`, `red`, ou `auto` (seuils automatiques).
-
----
-
-## Tableau (`dsfr-data-list`)
-
-Affiche les donnees sous forme de tableau avec recherche, tri, pagination et export CSV.
-
-### Parametres
-
-- **source** : _(String)_ ID du composant source.
-- **colonnes** : _(String)_ Colonnes a afficher (separes par des virgules, vide = toutes).
-- **pagination** : _(Number)_ Nombre de lignes par page (0 = tout afficher).
-- **search** : _(Boolean)_ Active la barre de recherche.
-- **export-csv** : _(Boolean)_ Active l'export CSV.
-
----
-
-## Filtres a facettes (`dsfr-data-facets`)
-
-Ajoute des filtres interactifs (checkbox, radio, select) sur les donnees.
-
-### Parametres
-
-- **source** : _(String)_ ID du composant source.
-- **fields** : _(String)_ Champs filtrables (separes par des virgules).
-- **type** : _(String)_ Type de rendu : `checkbox`, `radio`, `select`.
-
----
-
-## Recherche (`dsfr-data-search`)
-
-Barre de recherche textuelle avec filtrage client ou server-side.
-
-### Parametres
-
-- **source** : _(String)_ ID du composant source.
-- **fields** : _(String)_ Champs dans lesquels chercher.
-- **placeholder** : _(String)_ Texte d'indication.
-- **server-side** : _(Boolean)_ Delegue la recherche au serveur.
-
----
-
-## Affichage libre (`dsfr-data-display`)
-
-Template HTML libre pour afficher les donnees sous forme de cartes, fiches ou grilles.
-
-### Parametres
-
-- **source** : _(String)_ ID du composant source.
-- **template** : _(String)_ Template HTML avec placeholders `{{champ}}`.
-- **empty-message** : _(String)_ Message quand aucune donnee.
-
----
-
-## Carte du monde (`dsfr-data-world-map`)
-
-Carte choropleth du monde coloree par valeurs.
-
-### Parametres
-
-- **source** : _(String)_ ID du composant source.
-- **code-field** : _(String)_ Champ contenant le code pays ISO.
-- **value-field** : _(String)_ Champ contenant la valeur.
-- **label-field** : _(String)_ Champ contenant le nom du pays.
-
-> Necessite le bundle `dsfr-data.world-map.umd.js` en complement du bundle core.
-
----
-
-## Accessibilite (`dsfr-data-a11y`)
-
-Companion d'accessibilite : tableau de donnees alternatif, export CSV, description textuelle.
-
-### Parametres
-
-- **for** : _(String)_ ID du composant graphique associe.
-- **source** : _(String)_ ID du composant source de donnees.
-- **table** : _(Boolean)_ Affiche un tableau alternatif.
-- **download** : _(Boolean)_ Ajoute un lien d'export CSV.
-- **description** : _(String)_ Description textuelle du graphique.
-
-### Exemple
-
-```html
-<dsfr-data-a11y for="mon-graph" source="q" table download></dsfr-data-a11y>
-```
-
----
-
-# Exemple complet
-
-```html
-<!-- Charger DSFR + DSFR Chart + dsfr-data (voir section Installation) -->
-
-<!-- Source de donnees -->
-<dsfr-data-source id="data"
-  url="https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/industrie-du-futur/records?limit=100"
-  transform="results">
-</dsfr-data-source>
-
-<!-- Agregation par region -->
-<dsfr-data-query id="q" source="data"
-  group-by="nom_region"
-  aggregate="nombre_beneficiaires:sum:beneficiaires"
-  order-by="beneficiaires:desc" limit="10">
-</dsfr-data-query>
-
-<!-- Graphique en barres -->
-<dsfr-data-chart id="mon-graph" source="q" type="bar"
-  label-field="nom_region" value-field="beneficiaires"
-  titre="Beneficiaires par region">
-</dsfr-data-chart>
-
-<!-- Accessibilite -->
-<dsfr-data-a11y for="mon-graph" source="q" table download></dsfr-data-a11y>
-```
-
----
-
-# Applications de creation
-
-Le projet inclut des applications web permettant de generer le code HTML des composants sans ecrire de code :
-
-| Application | Description |
-|-------------|-------------|
-| **Builder** | Generateur visuel de graphiques pas-a-pas |
-| **Builder IA** | Generateur par conversation avec l'IA Albert |
-| **Playground** | Editeur de code interactif avec apercu temps reel |
-| **Dashboard** | Editeur visuel de tableaux de bord multi-widgets |
-| **Sources** | Gestionnaire de connexions aux APIs |
-| **Favoris** | Sauvegarde et reutilisation des creations |
-| **Monitoring** | Suivi des widgets deployes en production |
-
----
-
-# Developpement
-
-## Prerequis
-
-- Node.js >= 24
-- npm >= 9
-
-## Installation
+## Developpement rapide
 
 ```bash
 git clone https://github.com/bmatge/dsfr-data.git
 cd dsfr-data
 npm install
+npm run dev           # Vite dev server (port 5173)
+npm run test:run      # Tests Vitest
+npm run build:all     # Build lib + apps
 ```
 
-## Commandes
-
-| Commande | Description |
-|----------|-------------|
-| `npm run dev` | Serveur de dev Vite (port 5173) |
-| `npm run build` | Build bibliotheque (ESM + UMD) |
-| `npm run build:shared` | Build du package `@dsfr-data/shared` |
-| `npm run build:apps` | Build de toutes les applications |
-| `npm run build:all` | Build complet (shared + lib + apps) |
-| `npm run test` | Tests Vitest en watch mode |
-| `npm run test:run` | Tests une seule fois |
-| `npm run test:e2e` | Tests E2E Playwright |
+Pour le detail du monorepo, des conventions, du workflow de release Changesets et de la baseline securite : voir [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md).
 
 ## Documentation
 
-- [Specifications des composants](https://bmatge.github.io/dsfr-data/specs/) -- Demo interactive et reference des parametres
-- [Guide utilisateur](docs/USER-GUIDE.md) -- Parcours pas-a-pas
-- [Architecture](docs/ARCHITECTURE.md) -- Architecture technique detaillee
-- [Fiche produit](docs/DATASHEET.md) -- Positionnement, comparatif, cibles
-- [Contribuer](docs/CONTRIBUTING.md) -- Guide de contribution
-- [Politique de sécurité](docs/SECURITY.md) -- Signalement, pipeline CI, défenses
-- [Proxy CORS](proxy/README.md) -- Deploiement du proxy
+- [Specifications interactives des composants](https://bmatge.github.io/dsfr-data/specs/)
+- [Guide utilisateur](docs/USER-GUIDE.md) — parcours dans le Builder, exemples concrets
+- [Architecture](docs/ARCHITECTURE.md) — pipeline, adapters, bundles, build
+- [Guide de deploiement](docs/DEPLOYMENT.md) — Docker, 4 scenarios self-hosted, validation
+- [Contribuer](docs/CONTRIBUTING.md) — monorepo, conventions, release Changesets
+- [Fiche produit](docs/DATASHEET.md) — positionnement, comparatif, cibles
+- [Politique de securite](docs/SECURITY.md) + [baseline](docs/security-baseline.md) — signalement, pipeline CI/CD, defenses
 
 ## Licence
 
-MIT
+MIT.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -26,6 +26,7 @@ Ce guide couvre le deploiement de la **webapp dsfr-data** (apps Builder, Builder
 - [Migrations de schema MariaDB](#migrations-de-schema-mariadb)
 - [Sauvegarde et restauration](#sauvegarde-et-restauration)
 - [Diagnostic et logs](#diagnostic-et-logs)
+- [Validation post-deploiement](#validation-post-deploiement)
 - [Migration SQLite -> MariaDB](#migration-sqlite---mariadb)
 - [Checklist securite](#checklist-securite)
 - [Pieges connus](#pieges-connus)
@@ -430,6 +431,117 @@ L'app expose un endpoint sante sur `/api/health` (mode serveur) :
 curl https://${APP_DOMAIN}/api/health
 # {"status":"ok","mode":"database"}
 ```
+
+## Validation post-deploiement
+
+Une fois `./docker/deploy.sh` ou `./docker/deploy-server.sh` termine, executer la checklist ci-dessous pour valider que l'instance est saine. Toutes les commandes utilisent `${APP_DOMAIN}` — exporter la variable avant ou substituer.
+
+```bash
+export APP_DOMAIN=mon-domaine.example.com
+```
+
+### 1. Sante des conteneurs
+
+```bash
+docker compose --env-file .env -f docker/docker-compose.yml -f docker/docker-compose.db.yml ps
+# Attendu : tous les conteneurs en STATUS "Up" / "healthy" (mariadb doit afficher "healthy")
+```
+
+### 2. Healthcheck applicatif
+
+```bash
+# Mode statique
+curl -sf "https://${APP_DOMAIN}/" -o /dev/null && echo OK || echo FAIL
+
+# Mode serveur (en plus du ci-dessus)
+curl -sf "https://${APP_DOMAIN}/api/health" | grep -q '"status":"ok"' && echo OK || echo FAIL
+```
+
+### 3. Aucune URL ne fuit vers le domaine de reference
+
+Verifier qu'aucun bundle servi n'embarque `chartsbuilder.matge.com` en dur (sauf si c'est legitimement votre domaine). Adapter le pattern de match a votre domaine de reference si besoin :
+
+```bash
+# Bundle de la lib (servi sur /dist/)
+curl -sf "https://${APP_DOMAIN}/dist/dsfr-data.core.esm.js" | grep -c "chartsbuilder.matge.com" || echo "(0 fuites)"
+
+# Bundles des apps de creation
+for app in builder builder-ia builder-carto dashboard playground; do
+  echo "=== ${app} ==="
+  curl -sf "https://${APP_DOMAIN}/${app}/" \
+    | grep -oE 'src="/[^"]+\.js"' | head -1 \
+    | sed -E "s@src=\"(/[^\"]+)\"@https://${APP_DOMAIN}\1@" \
+    | xargs curl -sf \
+    | grep -c "chartsbuilder.matge.com" || echo "(0 fuites)"
+done
+```
+
+Resultat attendu : `0` partout (ou `(0 fuites)` si grep ne trouve rien). Si une valeur > 0 apparait, c'est probablement un `VITE_PROXY_URL` non propage au build (cf. issue #168 PR-1).
+
+### 4. Routes de proxying actives
+
+Chaque route doit repondre `204` au preflight OPTIONS (sauf si vous avez desactive le bloc en faveur d'un reverse externe — cf. [Scenario C](#scenario-c--reverse-externe-gerant-les-routes-de-proxying)).
+
+```bash
+for path in /grist-gouv-proxy/ /grist-proxy/ /albert-proxy/ /insee-proxy/ /tabular-proxy/ /cors-proxy /ia-proxy /ia-proxy-default; do
+  code=$(curl -s -o /dev/null -w "%{http_code}" -X OPTIONS "https://${APP_DOMAIN}${path}")
+  printf "%-25s %s\n" "${path}" "${code}"
+done
+# Attendu : 204 partout (ou code de votre reverse externe si scenario C)
+```
+
+### 5. Endpoint IA serveur (si `IA_DEFAULT_TOKEN` configure)
+
+```bash
+curl -sf "https://${APP_DOMAIN}/ia-server-config" | python3 -m json.tool
+# Attendu : { "available": true, "apiUrl": "...", "model": "..." } (sans le token)
+```
+
+### 6. Security headers + CSP
+
+```bash
+curl -sI "https://${APP_DOMAIN}/" | grep -iE "strict-transport|content-security|x-frame|x-content-type|referrer-policy|permissions-policy"
+# Attendu : 6 headers presents
+```
+
+Verifier visuellement la CSP dans la console DevTools du navigateur (`F12` → onglet `Console`) en chargeant une page qui consomme des donnees externes. Aucun message `Refused to ... violates Content Security Policy` ne doit apparaitre.
+
+### 7. Proxy d'entreprise active au runtime (si configure)
+
+Si `HTTP_PROXY` / `HTTPS_PROXY` est defini dans le `.env` (Scenario B), confirmer que le conteneur l'a bien charge :
+
+```bash
+docker compose --env-file .env -f docker/docker-compose.yml ${COMPOSE_DB:+-f docker/docker-compose.db.yml} \
+  logs chartsbuilder | grep -E "Outbound proxy enabled"
+# Attendu : "[ia-default-server] Outbound proxy enabled (HTTPS_PROXY=..., NO_PROXY=...)"
+#          + "[dsfr-data-mcp] Outbound proxy enabled (...)"
+```
+
+### 8. Bundles a jour (cache)
+
+Apres une mise a jour, vider le cache du navigateur (`Ctrl+Shift+R`) et verifier que les bundles sont reservis. Sinon, les bundles `/dist/*.js` (non hashes) doivent passer en revalidation systematique (cf. [ADR-008](https://github.com/bmatge/dsfr-data/blob/main/docs/ADR/ADR-008-politique-de-cache-http-pour-bundles-non-hashes.md)) :
+
+```bash
+curl -sI "https://${APP_DOMAIN}/dist/dsfr-data.core.esm.js" | grep -i "cache-control"
+# Attendu : "Cache-Control: no-cache, must-revalidate"
+```
+
+### 9. Smoke test fonctionnel
+
+Ouvrir `https://${APP_DOMAIN}/playground/` dans un navigateur et charger un exemple embarque. Le rendu doit s'afficher sans erreur dans la console DevTools.
+
+### Si une etape echoue
+
+| Etape | Probleme | Piste |
+|---|---|---|
+| 1-2 | Conteneur ne demarre pas | `docker compose ... logs --tail=200 chartsbuilder` |
+| 3 | URL `chartsbuilder.matge.com` baked dans le bundle | Verifier `VITE_PROXY_URL` dans `.env` ET rebuild avec `--no-cache` |
+| 4 | OPTIONS retourne 404 | Bloc nginx commente sans reverse externe configure (cf. [Scenario C](#scenario-c--reverse-externe-gerant-les-routes-de-proxying)) |
+| 5 | `available: false` | `IA_DEFAULT_TOKEN` non defini ou conteneur non redemarre apres ajout |
+| 6 | Headers manquants | Snippet `security-headers.conf` non charge ou Traefik qui les ecrase |
+| 7 | Pas de log "Outbound proxy enabled" | `HTTP_PROXY` non passe au runtime (`environment:` du docker-compose) |
+| 8 | Bundle servi en cache long | Conf nginx hors-date (cache 1y au lieu de no-cache, must-revalidate sur `/dist/*`) |
+| 9 | Erreur CSP / CORS en DevTools | Cf. CSP point 6 + routes proxy point 4 |
 
 ## Migration SQLite -> MariaDB
 


### PR DESCRIPTION
## Summary

Deux changements de doc qui font suite au retour du partenaire Bercy/Actimage (cas Scénario C de la « Configuration self-hosted ») :

### 1. Refonte du README (428 → 108 lignes, **-75%**)

L'ancien README dupliquait massivement la spec auto-générée disponible sur [bmatge.github.io/dsfr-data/specs](https://bmatge.github.io/dsfr-data/specs/) (200+ lignes de référence par composant). Le nouveau README :

- **Tagline + exemple HTML court** en tête pour montrer l'intention en 10 secondes.
- **Table « Selon votre profil »** qui route vers la bonne doc selon l'audience :
  - Intégrateur / dev web → spec interactive + section Installation
  - Utilisateur métier → [USER-GUIDE.md](docs/USER-GUIDE.md)
  - Opérateur / ops → [DEPLOYMENT.md](docs/DEPLOYMENT.md)
  - Contributeur → [CONTRIBUTING.md](docs/CONTRIBUTING.md) + [ARCHITECTURE.md](docs/ARCHITECTURE.md)
  - Décideur → [DATASHEET.md](docs/DATASHEET.md)
  - RSSI → [SECURITY.md](docs/SECURITY.md)
- **Quick start intégrateur** condensé (CDN + npm + bundles, ~15 lignes).
- **Section « Héberger votre instance »** qui pointe directement vers les 4 scénarios self-hosted + la nouvelle checklist post-déploiement.
- Renvoi vers la spec interactive comme **source de vérité** pour les composants (plus de duplication maintenue à la main).
- Suppression du lien `[LICENSE](LICENSE)` cassé (fichier inexistant — le badge MIT reste).

### 2. Nouvelle section « Validation post-déploiement » dans `docs/DEPLOYMENT.md`

Pour qu'un opérateur (le partenaire Bercy a justement eu ce besoin) puisse valider une instance fraîchement déployée en ~5 minutes :

**9 checks copy-paste** :
1. Santé des conteneurs (`docker compose ps`)
2. Healthcheck applicatif (`curl /api/health`)
3. **Aucune URL ne fuit vers le domaine de référence** (grep sur `/dist/*.js` + bundles d'apps — détecte exactement le bug latent corrigé par #168 PR-1)
4. Routes de proxying répondent en OPTIONS (9 chemins testés)
5. Endpoint IA serveur (si `IA_DEFAULT_TOKEN` configuré)
6. Security headers + CSP
7. Proxy d'entreprise activé au runtime (logs « Outbound proxy enabled »)
8. Politique de cache `/dist/*` (no-cache, must-revalidate — cf. ADR-008)
9. Smoke test fonctionnel (Playground)

**Table de diagnostic « Si une étape échoue »** qui mappe chaque check à une piste de résolution (cause probable + commande à lancer).

## Test plan

- [x] Tous les liens internes du nouveau README pointent vers des fichiers existants (vérifié par script).
- [x] Les 3 ancres `#validation-post-deploiement`, `#checklist-securite`, `#configuration-self-hosted` correspondent à des sections existantes de `DEPLOYMENT.md`.
- [x] Sommaire de `DEPLOYMENT.md` à jour avec la nouvelle section.
- [ ] Validation CI (changesets non requis : changements doc uniquement, pas d'impact sur `packages/core` ni `packages/shared`).

## Motivation produit

Constat de la session précédente : le partenaire Bercy/Actimage a dû reconstruire manuellement la procédure de validation (curl, grep sur les bundles, vérification des routes proxy) pour vérifier que son déploiement fonctionnait. Cette checklist industrialise cette validation, et le README court permet aux nouveaux arrivants de trouver la bonne doc selon leur rôle sans lire 400 lignes de référence composants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)