### PR TITLE
ci(pages): header/footer statiques sur GitHub Pages uniquement (post-build)

### DIFF
--- a/.github/workflows/deploy-grist-widgets.yml
+++ b/.github/workflows/deploy-grist-widgets.yml
@@ -80,6 +80,16 @@ jobs:
           </html>
           HEREDOC
 
+      - name: Replace app-header / app-footer with static blocks (Pages only)
+        run: |
+          # Les sources gardent <app-header>/<app-footer> pour la webapp
+          # déployée où le header est partagé entre toutes les pages
+          # (Builder, Dashboard, etc.). Sur GitHub Pages, seules specs/ et
+          # guide/ sont publiées — le menu pointerait vers des routes 404.
+          # On substitue donc en post-traitement, uniquement dans _site/.
+          npx tsx scripts/transform-docs-for-pages.ts _site/specs
+          npx tsx scripts/transform-docs-for-pages.ts _site/guide
+
       - name: Fix absolute paths for GitHub Pages
         run: |
           # Get the repository name for the base path

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -9,7 +9,8 @@ on:
       - 'packages/shared/**'
       - 'specs/**'
       - 'guide/**'
-      - '.github/workflows/deploy-grist-widgets.yml'
+      - 'scripts/transform-docs-for-pages.ts'
+      - '.github/workflows/deploy-pages.yml'
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/scripts/transform-docs-for-pages.ts
+++ b/scripts/transform-docs-for-pages.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env tsx
+/**
+ * Transforme les pages HTML de docs (specs/ et guide/) pour le déploiement
+ * GitHub Pages : remplace le Web Component `<app-header>` (menu de navigation
+ * vers les apps Builder, Dashboard, etc.) par un header statique minimaliste,
+ * et `<app-footer>` par un footer statique.
+ *
+ * Rationale : sur GitHub Pages, seules `specs/` et `guide/` sont déployées
+ * — les apps (Builder, Builder IA, Dashboard, etc.) ne le sont pas. Le menu
+ * du header pointait donc vers des routes inexistantes (404). Ce script
+ * applique la transformation **uniquement** sur les fichiers copiés dans
+ * `_site/` par le workflow `deploy-grist-widgets.yml` — les sources dans
+ * le repo restent inchangées pour préserver l'expérience dans la webapp
+ * déployée (où le header est partagé entre toutes les pages).
+ *
+ * Usage :
+ *   npx tsx scripts/transform-docs-for-pages.ts <dir>
+ *   Ex. : npx tsx scripts/transform-docs-for-pages.ts _site
+ *
+ * Le script :
+ *   - Parcourt récursivement `<dir>` à la recherche de fichiers .html
+ *   - Remplace `<app-header ...></app-header>` → bloc statique
+ *   - Remplace `<app-footer ...></app-footer>` → bloc statique
+ *   - Conserve `<app-sidemenu>` (navigation intra-doc, utile sur Pages)
+ *
+ * Cf. discussion #207 + retour partenaire Bercy (épic #168).
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join, extname } from 'node:path';
+
+const STATIC_HEADER = `<!-- Header statique (docs GitHub Pages : pas d'auth, pas de menu app-only) -->
+<header role="banner" class="fr-header">
+  <div class="fr-header__body">
+    <div class="fr-container">
+      <div class="fr-header__body-row">
+        <div class="fr-header__brand fr-enlarge-link">
+          <div class="fr-header__brand-top">
+            <div class="fr-header__logo">
+              <p class="fr-logo">République<br>française</p>
+            </div>
+          </div>
+          <div class="fr-header__service">
+            <a href="https://github.com/bmatge/dsfr-data" title="dsfr-data sur GitHub">
+              <p class="fr-header__service-title">dsfr-data</p>
+            </a>
+            <p class="fr-header__service-tagline">Documentation — Web Components DSFR pour la dataviz</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>`;
+
+const STATIC_FOOTER = `<!-- Footer statique (docs GitHub Pages) -->
+<footer role="contentinfo" class="fr-footer">
+  <div class="fr-container">
+    <div class="fr-footer__body">
+      <div class="fr-footer__brand fr-enlarge-link">
+        <p class="fr-logo">République<br>française</p>
+      </div>
+      <div class="fr-footer__content">
+        <p class="fr-footer__content-desc">Bibliothèque de Web Components DSFR pour intégrer des données dynamiques.</p>
+        <ul class="fr-footer__content-list">
+          <li class="fr-footer__content-item"><a class="fr-footer__content-link" href="https://github.com/bmatge/dsfr-data" target="_blank" rel="noopener">github.com/bmatge/dsfr-data</a></li>
+          <li class="fr-footer__content-item"><a class="fr-footer__content-link" href="https://www.npmjs.com/package/dsfr-data" target="_blank" rel="noopener">npm</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="fr-footer__bottom">
+      <ul class="fr-footer__bottom-list">
+        <li class="fr-footer__bottom-item"><a class="fr-footer__bottom-link" href="https://github.com/bmatge/dsfr-data/blob/main/docs/SECURITY.md">Sécurité</a></li>
+        <li class="fr-footer__bottom-item">MIT License</li>
+      </ul>
+    </div>
+  </div>
+</footer>`;
+
+const HEADER_REGEX = /<app-header [^>]*><\/app-header>/g;
+const FOOTER_REGEX = /<app-footer [^>]*><\/app-footer>/g;
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) {
+      out.push(...walk(p));
+    } else if (extname(p) === '.html') {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+const target = process.argv[2];
+if (!target) {
+  console.error('Usage : tsx scripts/transform-docs-for-pages.ts <dir>');
+  process.exit(1);
+}
+
+const files = walk(target);
+let touchedFiles = 0;
+let headers = 0;
+let footers = 0;
+
+for (const file of files) {
+  let content = readFileSync(file, 'utf8');
+  const h = content.match(HEADER_REGEX)?.length ?? 0;
+  const f = content.match(FOOTER_REGEX)?.length ?? 0;
+  if (h === 0 && f === 0) continue;
+  content = content.replace(HEADER_REGEX, STATIC_HEADER);
+  content = content.replace(FOOTER_REGEX, STATIC_FOOTER);
+  writeFileSync(file, content);
+  touchedFiles += 1;
+  headers += h;
+  footers += f;
+}
+
+console.log(
+  `[transform-docs-for-pages] ${touchedFiles}/${files.length} fichiers HTML modifiés ` +
+    `· ${headers} <app-header> → statique · ${footers} <app-footer> → statique`
+);


### PR DESCRIPTION
## Problème

Sur https://bmatge.github.io/dsfr-data/, seules les pages `specs/` et `guide/` sont déployées — **pas les apps** (Builder, Builder IA, Dashboard, Playground, Sources, etc.). Or le composant `<app-header>` rend un menu de navigation qui pointe vers `apps/builder/index.html`, `apps/dashboard/index.html`, etc. → tous ces liens retournent **404 sur Pages**.

## Contrainte

Le header doit rester **inchangé dans les sources** car il est partagé entre toutes les pages dans la **webapp déployée** (où les apps existent et où la navigation cross-app a tout son sens). Donc transformation en post-traitement **uniquement** dans le pipeline de déploiement Pages.

## Solution

1. **`scripts/transform-docs-for-pages.ts`** (nouveau, ~120 lignes, idempotent) :
   - Walke récursivement un dossier cible, repère les `.html`
   - Remplace `<app-header ...></app-header>` par un bloc statique DSFR-compliant : logo "République française", titre "dsfr-data", tagline "Documentation — Web Components DSFR pour la dataviz", lien vers le repo GitHub. Pas de JS, pas d'auth, pas de menu app.
   - Remplace `<app-footer ...></app-footer>` par un footer statique : logo + 4 liens (repo, npm, Sécurité, MIT).
   - **Conserve `<app-sidemenu>`** (navigation intra-doc utile sur Pages).
   - Log de bilan : `X/Y fichiers HTML modifiés · N headers → statique · M footers → statique`.

2. **`.github/workflows/deploy-grist-widgets.yml`** :
   - Nouvelle étape « Replace app-header / app-footer with static blocks (Pages only) »
   - Insérée juste après le `cp -r specs/ _site/specs/ && cp -r guide/ _site/guide/`
   - Et juste avant l'étape existante « Fix absolute paths for GitHub Pages »
   - Appelle `npx tsx scripts/transform-docs-for-pages.ts _site/specs` puis `_site/guide`

## Smoke test local

```bash
$ cp -r specs/ /tmp/pages-smoke/specs/ && cp -r guide/ /tmp/pages-smoke/guide/
$ grep -c "<app-header\|<app-footer" /tmp/pages-smoke/specs/index.html /tmp/pages-smoke/guide/guide.html
2  # avant : 1 header + 1 footer par fichier
2

$ npx tsx scripts/transform-docs-for-pages.ts /tmp/pages-smoke/specs
[transform-docs-for-pages] 28/28 fichiers HTML modifiés · 28 <app-header> → statique · 28 <app-footer> → statique

$ npx tsx scripts/transform-docs-for-pages.ts /tmp/pages-smoke/guide
[transform-docs-for-pages] 19/24 fichiers HTML modifiés · 19 <app-header> → statique · 19 <app-footer> → statique

$ grep -c "<app-header\|<app-footer" /tmp/pages-smoke/specs/index.html /tmp/pages-smoke/guide/guide.html
0  # après : aucune occurrence restante
0
```

Total : **47 fichiers** transformés (28 specs + 19 guide), 47 `<app-header>` et 47 `<app-footer>` substitués. 5 fichiers de guide/ sans header/footer (assets, partials JS) sont sautés correctement.

## Test plan

- [x] Smoke test local : 47 fichiers transformés, 0 occurrence résiduelle.
- [x] Vérification visuelle d'un fichier transformé : DSFR-compliant, pas de menu app, pas de JS.
- [x] Les sources `specs/*.html` et `guide/*.html` sont **inchangées** (vérifié `git diff` vide sur ces dossiers).
- [ ] Validation CI (déclenchera le workflow Pages → le déploiement effectif validera le rendu).
- [ ] Au prochain déploiement Pages, vérifier visuellement sur https://bmatge.github.io/dsfr-data/specs/ que le header est minimaliste et les liens fonctionnels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)