### PR TITLE
docs(pages): nav Specs↔Guide + redirect /guide/ + README pointe vers Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 | Vous etes… | Vous voulez… | Allez ici |
 |---|---|---|
 | **Integrateur / developpeur web** | Coller un widget DSFR sur votre page | [Installation](#installation) ci-dessous + [specifications interactives](https://bmatge.github.io/dsfr-data/specs/) |
-| **Utilisateur metier / non-tech** | Generer un graphique sans coder via le Builder | [Guide utilisateur](docs/USER-GUIDE.md) |
+| **Utilisateur metier / non-tech** | Generer un graphique sans coder via le Builder | [Guide utilisateur](https://bmatge.github.io/dsfr-data/guide/) (parcours interactifs + exemples live) |
 | **Operateur / ops** | Heberger votre instance dsfr-data | [Guide de deploiement](docs/DEPLOYMENT.md) |
 | **Contributeur** | Contribuer au code, comprendre l'architecture | [Guide de contribution](docs/CONTRIBUTING.md) + [Architecture](docs/ARCHITECTURE.md) |
 | **Decideur / acheteur** | Positionnement produit, comparatifs, cibles | [Fiche produit](docs/DATASHEET.md) |
@@ -96,7 +96,8 @@ Pour le detail du monorepo, des conventions, du workflow de release Changesets e
 ## Documentation
 
 - [Specifications interactives des composants](https://bmatge.github.io/dsfr-data/specs/)
-- [Guide utilisateur](docs/USER-GUIDE.md) — parcours dans le Builder, exemples concrets
+- [Guide utilisateur](https://bmatge.github.io/dsfr-data/guide/) — parcours interactifs + exemples live (HTML)
+- [Guide utilisateur (markdown)](docs/USER-GUIDE.md) — meme contenu en markdown, navigable depuis GitHub
 - [Architecture](docs/ARCHITECTURE.md) — pipeline, adapters, bundles, build
 - [Guide de deploiement](docs/DEPLOYMENT.md) — Docker, 4 scenarios self-hosted, validation
 - [Contribuer](docs/CONTRIBUTING.md) — monorepo, conventions, release Changesets

--- a/guide/index.html
+++ b/guide/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="refresh" content="0;url=guide.html" />
+    <title>Guide utilisateur — dsfr-data</title>
+    <link rel="canonical" href="guide.html" />
+  </head>
+  <body>
+    <p>
+      Redirection vers le <a href="guide.html">guide utilisateur</a>…
+    </p>
+  </body>
+</html>

--- a/scripts/transform-docs-for-pages.ts
+++ b/scripts/transform-docs-for-pages.ts
@@ -2,34 +2,53 @@
 /**
  * Transforme les pages HTML de docs (specs/ et guide/) pour le déploiement
  * GitHub Pages : remplace le Web Component `<app-header>` (menu de navigation
- * vers les apps Builder, Dashboard, etc.) par un header statique minimaliste,
- * et `<app-footer>` par un footer statique.
+ * vers les apps Builder, Dashboard, etc.) par un header statique minimaliste
+ * avec accès rapide Specs ↔ Guide, et `<app-footer>` par un footer statique.
  *
  * Rationale : sur GitHub Pages, seules `specs/` et `guide/` sont déployées
  * — les apps (Builder, Builder IA, Dashboard, etc.) ne le sont pas. Le menu
  * du header pointait donc vers des routes inexistantes (404). Ce script
  * applique la transformation **uniquement** sur les fichiers copiés dans
- * `_site/` par le workflow `deploy-grist-widgets.yml` — les sources dans
- * le repo restent inchangées pour préserver l'expérience dans la webapp
- * déployée (où le header est partagé entre toutes les pages).
+ * `_site/` par le workflow `deploy-pages.yml` — les sources dans le repo
+ * restent inchangées pour préserver l'expérience dans la webapp déployée
+ * (où le header est partagé entre toutes les pages).
+ *
+ * Header statique = logo République française + titre + tagline + nav
+ * minimaliste avec liens Specs / Guide / GitHub. Le `base-path` est
+ * récupéré de l'attribut de `<app-header base-path="...">` original pour
+ * que les liens internes pointent au bon endroit quelle que soit la
+ * profondeur de la page. La section courante reçoit `aria-current="page"`
+ * pour une mise en valeur visuelle (style DSFR natif).
  *
  * Usage :
- *   npx tsx scripts/transform-docs-for-pages.ts <dir>
- *   Ex. : npx tsx scripts/transform-docs-for-pages.ts _site
+ *   npx tsx scripts/transform-docs-for-pages.ts <dir> [--section=specs|guide]
+ *   Ex. : npx tsx scripts/transform-docs-for-pages.ts _site/specs
+ *
+ * Si --section est omis, la section est auto-détectée depuis le nom du
+ * dossier cible (`_site/specs` → specs ; `_site/guide` → guide).
  *
  * Le script :
  *   - Parcourt récursivement `<dir>` à la recherche de fichiers .html
- *   - Remplace `<app-header ...></app-header>` → bloc statique
+ *   - Remplace `<app-header base-path="..."></app-header>` → bloc statique
+ *     paramétré par le base-path et la section courante
  *   - Remplace `<app-footer ...></app-footer>` → bloc statique
  *   - Conserve `<app-sidemenu>` (navigation intra-doc, utile sur Pages)
  *
- * Cf. discussion #207 + retour partenaire Bercy (épic #168).
+ * Cf. issues #168, #210.
  */
 
 import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
-import { join, extname } from 'node:path';
+import { join, extname, basename } from 'node:path';
 
-const STATIC_HEADER = `<!-- Header statique (docs GitHub Pages : pas d'auth, pas de menu app-only) -->
+type Section = 'specs' | 'guide' | 'other';
+
+/** Construit le header statique en injectant le base-path et la section active. */
+function buildStaticHeader(basePath: string, section: Section): string {
+  const specsCurrent = section === 'specs' ? ' aria-current="page"' : '';
+  const guideCurrent = section === 'guide' ? ' aria-current="page"' : '';
+  // base-path peut être "../" ou "../../" — on l'utilise tel quel pour
+  // construire les liens vers les autres sections.
+  return `<!-- Header statique (docs GitHub Pages : pas d'auth, pas de menu app-only) -->
 <header role="banner" class="fr-header">
   <div class="fr-header__body">
     <div class="fr-container">
@@ -41,7 +60,7 @@ const STATIC_HEADER = `<!-- Header statique (docs GitHub Pages : pas d'auth, pas
             </div>
           </div>
           <div class="fr-header__service">
-            <a href="https://github.com/bmatge/dsfr-data" title="dsfr-data sur GitHub">
+            <a href="${basePath}" title="Documentation dsfr-data">
               <p class="fr-header__service-title">dsfr-data</p>
             </a>
             <p class="fr-header__service-tagline">Documentation — Web Components DSFR pour la dataviz</p>
@@ -50,7 +69,25 @@ const STATIC_HEADER = `<!-- Header statique (docs GitHub Pages : pas d'auth, pas
       </div>
     </div>
   </div>
+  <div class="fr-header__menu">
+    <div class="fr-container">
+      <nav class="fr-nav" role="navigation" aria-label="Navigation documentation">
+        <ul class="fr-nav__list">
+          <li class="fr-nav__item">
+            <a class="fr-nav__link"${specsCurrent} href="${basePath}specs/">Spécifications</a>
+          </li>
+          <li class="fr-nav__item">
+            <a class="fr-nav__link"${guideCurrent} href="${basePath}guide/">Guide utilisateur</a>
+          </li>
+          <li class="fr-nav__item">
+            <a class="fr-nav__link" href="https://github.com/bmatge/dsfr-data" target="_blank" rel="noopener">GitHub</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
 </header>`;
+}
 
 const STATIC_FOOTER = `<!-- Footer statique (docs GitHub Pages) -->
 <footer role="contentinfo" class="fr-footer">
@@ -76,8 +113,10 @@ const STATIC_FOOTER = `<!-- Footer statique (docs GitHub Pages) -->
   </div>
 </footer>`;
 
-const HEADER_REGEX = /<app-header [^>]*><\/app-header>/g;
-const FOOTER_REGEX = /<app-footer [^>]*><\/app-footer>/g;
+// Capture base-path dans l'attribut. Tolère l'ordre des attributs.
+const HEADER_REGEX =
+  /<app-header\b[^>]*\bbase-path="([^"]*)"[^>]*><\/app-header>|<app-header\b[^>]*><\/app-header>/g;
+const FOOTER_REGEX = /<app-footer\b[^>]*><\/app-footer>/g;
 
 function walk(dir: string): string[] {
   const out: string[] = [];
@@ -92,12 +131,26 @@ function walk(dir: string): string[] {
   return out;
 }
 
-const target = process.argv[2];
-if (!target) {
-  console.error('Usage : tsx scripts/transform-docs-for-pages.ts <dir>');
-  process.exit(1);
+function parseArgs(argv: string[]): { target: string; section: Section } {
+  const args = argv.slice(2);
+  const target = args.find((a) => !a.startsWith('--'));
+  if (!target) {
+    console.error('Usage : tsx scripts/transform-docs-for-pages.ts <dir> [--section=specs|guide]');
+    process.exit(1);
+  }
+  const sectionArg = args.find((a) => a.startsWith('--section='))?.split('=')[1];
+  let section: Section;
+  if (sectionArg === 'specs' || sectionArg === 'guide') {
+    section = sectionArg;
+  } else {
+    // Auto-détection depuis le nom du dossier cible
+    const name = basename(target.replace(/\/$/, ''));
+    section = name === 'specs' || name === 'guide' ? (name as Section) : 'other';
+  }
+  return { target, section };
 }
 
+const { target, section } = parseArgs(process.argv);
 const files = walk(target);
 let touchedFiles = 0;
 let headers = 0;
@@ -108,7 +161,9 @@ for (const file of files) {
   const h = content.match(HEADER_REGEX)?.length ?? 0;
   const f = content.match(FOOTER_REGEX)?.length ?? 0;
   if (h === 0 && f === 0) continue;
-  content = content.replace(HEADER_REGEX, STATIC_HEADER);
+  content = content.replace(HEADER_REGEX, (_match, capturedBasePath?: string) => {
+    return buildStaticHeader(capturedBasePath ?? '../', section);
+  });
   content = content.replace(FOOTER_REGEX, STATIC_FOOTER);
   writeFileSync(file, content);
   touchedFiles += 1;
@@ -117,6 +172,6 @@ for (const file of files) {
 }
 
 console.log(
-  `[transform-docs-for-pages] ${touchedFiles}/${files.length} fichiers HTML modifiés ` +
+  `[transform-docs-for-pages] section=${section} · ${touchedFiles}/${files.length} fichiers HTML modifiés ` +
     `· ${headers} <app-header> → statique · ${footers} <app-footer> → statique`
 );


### PR DESCRIPTION
## Summary

Suite de la PR #210 (header statique pour GitHub Pages). Le partenaire a aussi remonté que sur Pages on veut **uniquement les sections `/specs` et `/guide`**, avec un header minimaliste qui **permet de naviguer entre Specs et Guide**.

3 changements liés :

### 1. `guide/index.html` (nouveau) — `/guide/` cesse de 404

Avant cette PR, `https://bmatge.github.io/dsfr-data/guide/` retournait 404 sur Pages (le dossier `guide/` n'avait pas d'`index.html`). Maintenant : redirection meta-refresh vers `guide.html` (même pattern que le `_site/index.html` généré par le workflow Pages). Marche aussi dans la webapp.

### 2. `scripts/transform-docs-for-pages.ts` — header statique enrichi

Le header statique sur Pages ne permettait pas de naviguer entre Specs et Guide. Ajout :

- **Récupération du `base-path`** depuis l'attribut `<app-header base-path="...">` original (`../` ou `../../`) pour que les liens internes pointent au bon endroit quelle que soit la profondeur de la page.
- **Auto-détection de la section** (specs vs guide) depuis le dossier cible (`_site/specs` → specs). Surchargeable via `--section=specs|guide`.
- **Nav `fr-nav`** avec 3 liens d'accès rapide : **Spécifications**, **Guide utilisateur**, **GitHub**. La section courante reçoit `aria-current="page"` (mise en valeur DSFR native).
- Le titre dsfr-data du header pointe maintenant vers la racine Pages (`${basePath}`) plutôt que vers GitHub repo — plus pertinent comme "retour à l'accueil docs".

### 3. `README.md` — liens guide pointent vers Pages

Le lien "Guide utilisateur" de la table "Selon votre profil" et de la section Documentation pointe maintenant vers `https://bmatge.github.io/dsfr-data/guide/` (HTML interactif avec exemples live) au lieu du markdown statique. Le markdown reste accessible en lien secondaire dans la section Documentation pour ceux qui préfèrent lire depuis GitHub.

## Smoke test local

```bash
$ cp -r specs/ /tmp/pages-smoke/specs/ && cp -r guide/ /tmp/pages-smoke/guide/
$ npx tsx scripts/transform-docs-for-pages.ts /tmp/pages-smoke/specs
[transform-docs-for-pages] section=specs · 28/28 fichiers HTML modifiés ...

$ npx tsx scripts/transform-docs-for-pages.ts /tmp/pages-smoke/guide
[transform-docs-for-pages] section=guide · 19/25 fichiers HTML modifiés ...
```

Trois profondeurs validées :

| Fichier source | base-path injecté | aria-current sur |
|---|---|---|
| `specs/index.html` (depth 1) | `../` → liens `../specs/` `../guide/` | Spécifications ✓ |
| `specs/components/dsfr-data-source.html` (depth 2) | `../../` → liens `../../specs/` `../../guide/` | Spécifications ✓ |
| `guide/guide.html` (depth 1) | `../` → liens `../specs/` `../guide/` | Guide utilisateur ✓ |

## Test plan

- [x] Smoke test local : 47 fichiers transformés (28 specs + 19 guide), base-path et aria-current OK aux 3 profondeurs.
- [x] Les sources `specs/*.html` et `guide/*.html` restent **inchangées** (vérifié `git diff`).
- [x] `guide/index.html` créé (redirect meta-refresh, ~12 lignes).
- [x] README.md : 2 liens vers le guide HTML, 1 lien secondaire vers le markdown.
- [ ] Validation CI.
- [ ] Vérification post-merge sur https://bmatge.github.io/dsfr-data/specs/ et /guide/ : nav fonctionnelle, current bien mis en valeur, liens entre sections OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)