### PR TITLE
epic(ux): wording naturel du Builder (batch 1 de #183)

### DIFF
--- a/.changeset/ux-wording-builder-batch-1.md
+++ b/.changeset/ux-wording-builder-batch-1.md
@@ -1,0 +1,11 @@
+---
+'dsfr-data': patch
+---
+
+fix(ux): wording naturel du Builder (EPIC #183, batch 1) — couvre les 3 issues Majeur ciblant les libellés du panneau de configuration.
+
+- **#195** — Section « Habillage DataBox » → **« Cadre officiel DSFR »** (et toggle « Activer la DataBox DSFR » → **« Encadrer le graphique (titre, source, téléchargement) »**). Le nom interne `DataBox` ne fuite plus dans le label. L'aide tooltip explique déjà la chose, label maintenant cohérent.
+- **#196** — Libellés de palettes plus parlants pour P1 : `Categorielle` → **« Couleurs distinctes par catégorie »**, `Sequentielle ↑` → **« Dégradé clair → foncé »**, `Divergente ↑` → **« Bicolore (centre clair) »**, etc. **Fix d'un leak** : le résumé de la section Apparence (visible quand collapsée) affichait la clé interne brute (`sequentialAscending`) — désormais passé par le nouveau `PALETTE_DISPLAY_NAMES[key]`. Tooltip d'aide `chart-palette` réécrit pour expliquer chaque famille de palettes en termes d'usage (« comparer des catégories indépendantes », « valeurs ordonnées », « écarts par rapport à une référence »).
+- **#197** — Labels d'axes harmonisés sur le ton naturel déjà utilisé ailleurs dans la même section (« Si plusieurs lignes par catégorie, agréger par » est exemplaire) : `Axe X / Categories` → **« Étiquettes (axe horizontal) »**, `Axe Y / Valeurs (Serie 1)` → **« Valeur à mesurer (Série 1) »**. Messages de validation `getCompleteness()` alignés (« le champ Étiquettes », « le champ Valeur à mesurer ») pour qu'un user qui voit « Il manque : le champ X » retrouve le même libellé à l'écran.
+
+**Nouveau export public dans `@dsfr-data/shared`** : `PALETTE_DISPLAY_NAMES: Record<string, string>` — mapping clé interne → libellé utilisateur (cf. `packages/shared/src/constants/dsfr-palettes.ts`). À utiliser partout où le nom de palette apparaît dans l'UI rendue.

--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -177,11 +177,11 @@
         </div>
         <div class="config-section-content">
 
-        <!-- Axe X -->
+        <!-- Étiquettes (anciennement « Axe X ») -->
         <div style="display: flex; gap: 0.5rem; align-items: flex-end;" class="fr-mb-1w">
           <div class="fr-select-group fr-select-group--sm" style="flex: 1; margin-bottom: 0;">
             <label class="fr-label" for="label-field">
-              Axe X / Categories
+              Étiquettes (axe horizontal)
               <button type="button" class="help-btn" aria-label="Aide" aria-describedby="help-label-field" data-help="label-field"><i class="ri-question-line" aria-hidden="true"></i></button>
               <span class="fr-hint-text">Le champ pour les etiquettes (ex&nbsp;: region, annee)</span>
             </label>
@@ -194,15 +194,15 @@
               Libelle
               <span class="fr-hint-text">Nom affiche (vide = nom du champ)</span>
             </label>
-            <input type="text" class="fr-input fr-input--sm" id="label-field-label" placeholder="Nom de l'axe X">
+            <input type="text" class="fr-input fr-input--sm" id="label-field-label" placeholder="Nom des étiquettes">
           </div>
         </div>
 
-        <!-- Axe Y / Serie 1 -->
+        <!-- Valeur à mesurer (anciennement « Axe Y / Serie 1 ») -->
         <div style="display: flex; gap: 0.5rem; align-items: flex-end;">
           <div class="fr-select-group fr-select-group--sm" style="flex: 1; margin-bottom: 0;">
             <label class="fr-label" for="value-field">
-              Axe Y / Valeurs (Serie 1)
+              Valeur à mesurer (Série 1)
               <button type="button" class="help-btn" aria-label="Aide" aria-describedby="help-value-field" data-help="value-field"><i class="ri-question-line" aria-hidden="true"></i></button>
               <span class="fr-hint-text">Le champ numerique a mesurer (ex&nbsp;: population, budget)</span>
             </label>
@@ -404,12 +404,12 @@
           </label>
           <select class="fr-select" id="chart-palette">
             <option value="default">Bleu France</option>
-            <option value="categorical">Categorielle</option>
-            <option value="sequentialAscending">Sequentielle &#8593;</option>
-            <option value="sequentialDescending">Sequentielle &#8595;</option>
-            <option value="divergentAscending">Divergente &#8593;</option>
-            <option value="divergentDescending">Divergente &#8595;</option>
-            <option value="neutral">Neutre</option>
+            <option value="categorical">Couleurs distinctes par catégorie</option>
+            <option value="sequentialAscending">Dégradé clair → foncé</option>
+            <option value="sequentialDescending">Dégradé foncé → clair</option>
+            <option value="divergentAscending">Bicolore (centre clair)</option>
+            <option value="divergentDescending">Bicolore (centre foncé)</option>
+            <option value="neutral">Tons neutres (gris)</option>
           </select>
         </div>
 
@@ -562,17 +562,17 @@
         </div>
       </div>
 
-      <!-- Habillage DataBox -->
+      <!-- Cadre officiel DSFR (anciennement « Habillage DataBox ») -->
       <div class="config-section collapsed" id="section-databox">
         <div class="config-section-header" onclick="toggleSection('section-databox')">
-          <h3><i class="ri-layout-4-line"></i> Habillage DataBox <button type="button" class="help-btn" aria-label="Aide" aria-describedby="help-databox" data-help="databox"><i class="ri-question-line" aria-hidden="true"></i></button></h3>
+          <h3><i class="ri-layout-4-line"></i> Cadre officiel DSFR <button type="button" class="help-btn" aria-label="Aide" aria-describedby="help-databox" data-help="databox"><i class="ri-question-line" aria-hidden="true"></i></button></h3>
           <i class="ri-arrow-down-s-line collapse-icon"></i>
         </div>
         <div class="config-section-content">
           <div class="fr-checkbox-group fr-checkbox-group--sm">
             <input type="checkbox" id="databox-toggle">
             <label class="fr-label" for="databox-toggle">
-              Activer la DataBox DSFR
+              Encadrer le graphique (titre, source, téléchargement)
             </label>
           </div>
           <div id="databox-options" style="display: none; margin-left: 1.5rem; margin-top: 0.5rem;">

--- a/apps/builder/src/state.ts
+++ b/apps/builder/src/state.ts
@@ -244,8 +244,8 @@ export function getCompleteness(s: BuilderState, generated: boolean = false): Co
         break;
       default:
         config = !!s.labelField && !!s.valueField;
-        if (!s.labelField) missing.push('le champ catégorie (axe X)');
-        if (!s.valueField) missing.push('le champ numérique (axe Y)');
+        if (!s.labelField) missing.push('le champ Étiquettes');
+        if (!s.valueField) missing.push('le champ Valeur à mesurer');
         break;
     }
   }

--- a/apps/builder/src/ui/help-texts.ts
+++ b/apps/builder/src/ui/help-texts.ts
@@ -23,7 +23,7 @@ export const TOOLTIPS = {
   'generation-mode':
     "Embarque\u00a0: les donnees sont copiees dans le code HTML. Simple, mais les donnees ne se mettent pas a jour.\n\nDynamique\u00a0: les donnees sont chargees depuis l'API a chaque affichage. Le graphique est toujours a jour.",
   'chart-palette':
-    'Jeu de couleurs pour le graphique.\n\u2022 Categoriel\u00a0: couleurs distinctes (ideal pour comparer des categories)\n\u2022 Sequentiel\u00a0: degrade du clair au fonce (ideal pour des valeurs ordonnees)\n\u2022 Divergent\u00a0: deux couleurs qui divergent depuis le centre',
+    'Jeu de couleurs pour le graphique.\n\u2022 Couleurs distinctes par cat\u00e9gorie\u00a0: id\u00e9al pour comparer des cat\u00e9gories ind\u00e9pendantes (r\u00e9gions, secteurs)\n\u2022 D\u00e9grad\u00e9 clair\u2009\u2192\u2009fonc\u00e9 (ou inverse)\u00a0: id\u00e9al pour des valeurs ordonn\u00e9es (population, intensit\u00e9)\n\u2022 Bicolore depuis le centre\u00a0: id\u00e9al pour repr\u00e9senter des \u00e9carts par rapport \u00e0 une r\u00e9f\u00e9rence (positif vs n\u00e9gatif)',
   normalize:
     'Prepare les donnees brutes avant traitement\u00a0: supprime les espaces, convertit les textes "123" en nombres, renomme les colonnes... Utile quand les donnees de l\'API ne sont pas propres.',
   facets:

--- a/apps/builder/src/ui/progress-indicator.ts
+++ b/apps/builder/src/ui/progress-indicator.ts
@@ -10,6 +10,8 @@
  * Pure DOM update functions — the skeleton lives in apps/builder/index.html.
  */
 
+import { PALETTE_DISPLAY_NAMES } from '@dsfr-data/shared';
+
 import { state, getCompleteness, type BuilderState, type Completeness } from '../state.js';
 
 type StepKey = 'source' | 'type' | 'config' | 'generate';
@@ -92,8 +94,10 @@ function buildSummaries(s: BuilderState, c: Completeness): Record<string, Sectio
     }
   }
 
-  // Appearance — palette (hide when still on DSFR default).
-  const paletteText = s.palette && s.palette !== 'default' ? s.palette : '';
+  // Appearance — palette (hide when still on DSFR default). Use the
+  // human-friendly name; never leak the internal key like `sequentialAscending`.
+  const paletteText =
+    s.palette && s.palette !== 'default' ? PALETTE_DISPLAY_NAMES[s.palette] || s.palette : '';
 
   // Generation mode — mention only when dynamic (non-default).
   const genModeText = s.generationMode === 'dynamic' ? 'dynamique' : '';

--- a/packages/shared/src/constants/dsfr-palettes.ts
+++ b/packages/shared/src/constants/dsfr-palettes.ts
@@ -49,4 +49,20 @@ export const PALETTE_COLORS: Record<string, readonly string[]> = {
   neutral: ['#161616', '#3A3A3A', '#666666', '#929292', '#CECECE'],
 };
 
+/**
+ * Human-friendly display names per palette key.
+ * Used wherever the palette appears in user-visible UI (section summaries, badges, etc.)
+ * so the raw internal key (e.g. `sequentialAscending`) never leaks.
+ * Stay in sync with the `<option>` labels in `apps/builder/index.html` palette select.
+ */
+export const PALETTE_DISPLAY_NAMES: Record<string, string> = {
+  default: 'Bleu France',
+  categorical: 'Couleurs distinctes par catégorie',
+  sequentialAscending: 'Dégradé clair → foncé',
+  sequentialDescending: 'Dégradé foncé → clair',
+  divergentAscending: 'Bicolore (centre clair)',
+  divergentDescending: 'Bicolore (centre foncé)',
+  neutral: 'Tons neutres (gris)',
+};
+
 export type PaletteType = keyof typeof PALETTE_COLORS;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,7 +8,12 @@ export { parseJoinKeys, performJoin } from './utils/join.js';
 export { isUnsafeKey } from './utils/security.js';
 
 // Constants
-export { DSFR_COLORS, PALETTE_PRIMARY_COLOR, PALETTE_COLORS } from './constants/dsfr-palettes.js';
+export {
+  DSFR_COLORS,
+  PALETTE_PRIMARY_COLOR,
+  PALETTE_COLORS,
+  PALETTE_DISPLAY_NAMES,
+} from './constants/dsfr-palettes.js';
 export type { PaletteType } from './constants/dsfr-palettes.js';
 
 // Templates / CDN

--- a/tests/apps/builder/completeness.test.ts
+++ b/tests/apps/builder/completeness.test.ts
@@ -43,7 +43,7 @@ describe('getCompleteness', () => {
       expect(c.source).toBe(true);
       expect(c.type).toBe(true);
       expect(c.config).toBe(false);
-      expect(c.missing).toEqual(['le champ catégorie (axe X)', 'le champ numérique (axe Y)']);
+      expect(c.missing).toEqual(['le champ Étiquettes', 'le champ Valeur à mesurer']);
     });
   });
 


### PR DESCRIPTION
Closes #195, #196, #197. Part of #183 (Audit UX 2026-05-26, EPIC wording/jargon/accents).

## Résumé

Première salve de l'EPIC [#183](https://github.com/bmatge/dsfr-data/issues/183) — partie « renommages des libellés du Builder », indépendante du mode débutant/expert (EPIC 6 / [[ADR-027]]). Couvre 3 issues Majeur qui pointent toutes vers du jargon technique exposé tel quel à l'écran : nom interne de composant (DataBox), clé interne de palette (`sequentialAscending`), et termes math/dataviz (Axe X / Axe Y).

Le batch « accents UTF-8 transverses » (#192 T-1) suivra dans une PR séparée — c'est un refactor textuel à plus large surface (~50-100 fichiers).

## Détail

### [#195](https://github.com/bmatge/dsfr-data/issues/195) — DataBox → Cadre officiel DSFR

- Label de section : `Habillage DataBox` → **`Cadre officiel DSFR`**
- Toggle : `Activer la DataBox DSFR` → **`Encadrer le graphique (titre, source, téléchargement)`** — résume directement ce que l'option fait
- Icône et tooltip d'aide inchangés (déjà bons)

### [#196](https://github.com/bmatge/dsfr-data/issues/196) — Palettes : libellés naturels + fix leak

- 6 des 7 options du select passent du jargon dataviz à des descriptions concrètes :

| Avant | Après |
|---|---|
| `Categorielle` | `Couleurs distinctes par catégorie` |
| `Sequentielle ↑` | `Dégradé clair → foncé` |
| `Sequentielle ↓` | `Dégradé foncé → clair` |
| `Divergente ↑` | `Bicolore (centre clair)` |
| `Divergente ↓` | `Bicolore (centre foncé)` |
| `Neutre` | `Tons neutres (gris)` |

- **Fix d'un leak** : `progress-indicator.ts:96` affichait `s.palette` brut (= clé interne) dans le résumé visible quand la section Apparence est collapsée → on voyait littéralement `sequentialAscending`. Désormais passe par le nouveau `PALETTE_DISPLAY_NAMES[key]` du package `@dsfr-data/shared`.
- Tooltip `chart-palette` (help-texts.ts) réécrit en termes d'usage : « comparer des catégories indépendantes », « valeurs ordonnées », « écarts par rapport à une référence ».

### [#197](https://github.com/bmatge/dsfr-data/issues/197) — Axes : libellés naturels + harmonisation validation

| Avant | Après |
|---|---|
| `Axe X / Categories` | `Étiquettes (axe horizontal)` |
| `Axe Y / Valeurs (Serie 1)` | `Valeur à mesurer (Série 1)` |
| Placeholder « Nom de l'axe X » | « Nom des étiquettes » |
| Validation : « le champ catégorie (axe X) » | « le champ Étiquettes » |
| Validation : « le champ numérique (axe Y) » | « le champ Valeur à mesurer » |

Le messages de validation `getCompleteness()` sont alignés sur les nouveaux labels pour qu'un user qui voit « Il manque : le champ X » retrouve le même libellé à l'écran sans avoir à traduire « axe X » → l'étiquette qu'il a effectivement vue.

## Bonus

**Nouveau export `PALETTE_DISPLAY_NAMES`** dans `@dsfr-data/shared/constants/dsfr-palettes` : `Record<string, string>` mappant chaque clé interne → libellé utilisateur. À utiliser partout où une palette apparaît dans l'UI rendue.

## Hors scope

- Les hints `<span class="fr-hint-text">` (lignes 186, 207 de `index.html`) restent inchangés — wording déjà friendly, juste accents manquants → traité dans #192 (T-1 accents UTF-8) qui couvrira tous les apps.
- M-S-1 (jargon API Sources), M-S-4 (jointures SQL) → batch suivant focalisé sur Sources.

## Test plan

- [ ] `npm run dev` → Builder : ouvrir la section « Cadre officiel DSFR » (anciennement « Habillage DataBox »), vérifier que le toggle dit « Encadrer le graphique (titre, source, téléchargement) ».
- [ ] Builder → section Apparence : ouvrir le select de palette, vérifier les 7 nouveaux libellés. Changer pour « Dégradé clair → foncé » → collapser la section → vérifier que le résumé affiche bien `Dégradé clair → foncé` et **pas** `sequentialAscending`.
- [ ] Builder → section Configuration des données : vérifier les labels « Étiquettes (axe horizontal) » et « Valeur à mesurer (Série 1) ». Vider les selects → vérifier message au bas du panneau : « Il manque : le champ Étiquettes, le champ Valeur à mesurer ».
- [ ] Survoler les boutons ? de palette et de DataBox → vérifier les tooltips updated.

## CI / tests automatisés

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:run` ✅ (2946/2946, après update du test `completeness.test.ts:46` pour les nouveaux libellés de validation)
- `npm run build:shared` + `npm run build --workspace=@dsfr-data/app-builder` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)