### PR TITLE
feat(sources): edit existing manual sources (closes #186)

### DIFF
--- a/.changeset/edit-source-manual.md
+++ b/.changeset/edit-source-manual.md
@@ -1,0 +1,23 @@
+---
+'dsfr-data': patch
+---
+
+feat(sources): édition des sources manuelles (closes #186, EPIC #186 complet, audit UX 2026-05-26 §M-S-3).
+
+Avant : une fois une source manuelle créée (via Tableau / Coller JSON / Importer CSV), impossible de l'éditer. Une typo dans une cellule obligeait à supprimer la source et tout recommencer. Le CSS `.edit-source-btn` existait déjà dans `apps/sources/src/styles/sources.css` mais aucun code TypeScript ne le créait.
+
+Après : bouton crayon à gauche du bouton poubelle sur chaque source manuelle (sources API/Grist/jointures ne sont pas éditables ici car dérivées d'un état externe). Au clic, la modale « Nouvelle source manuelle » s'ouvre en mode édition :
+- Titre : « Modifier la source » (au lieu de « Nouvelle source manuelle »)
+- Bouton : « Enregistrer les modifications » (au lieu de « Sauvegarder »)
+- Champ Nom pré-rempli
+- Mode Tableau forcé + grille pré-remplie avec les données existantes (la vue tableau est la plus générale, l'utilisateur peut switch vers JSON/CSV s'il veut tout remplacer en collant un nouveau payload)
+- À la validation : **mise à jour en place** (même `id`), ce qui préserve les références existantes depuis les favoris, dashboards et l'état builder
+- À l'annulation : aucune modification
+
+Nouveaux exports :
+- `loadTableData(data)` dans `apps/sources/src/editors/table-editor.ts` — pré-remplit le table editor avec un tableau de records (union des clés pour les colonnes, lignes ordonnées comme à la sauvegarde). Réutilisable pour de futurs flows d'édition.
+- `editSource(id)` dans `apps/sources/src/connections/connection-manager.ts` — ouvre la modale en mode édition (no-op si la source n'est pas de type `manual`).
+
+`state.editingSourceId: string | null` ajouté au state pour le suivi du mode édition (pattern identique à `editingConnectionId` déjà en place).
+
+Toasts : `« Source X mise à jour. »` après update, `« Source X ajoutée. »` après création (avant, aucun feedback explicite, cf. T-3 audit UX).

--- a/apps/sources/src/connections/connection-manager.ts
+++ b/apps/sources/src/connections/connection-manager.ts
@@ -27,6 +27,7 @@ import { state, EXTERNAL_PROXY } from '../state.js';
 import type { StoredConnection } from '../state.js';
 import { loadDocuments } from './grist-explorer.js';
 import { loadApiData } from './api-explorer.js';
+import { loadTableData } from '../editors/table-editor.js';
 
 // ============================================================
 // Render
@@ -582,11 +583,22 @@ export function renderSources(): void {
             ? '<span class="badge-source-type badge-join">Jointure</span>'
             : '<span class="badge-source-type badge-manual">Manuel</span>';
 
+    // Edit button: only available on manual sources (API/Grist/join sources
+    // are derived from external state, not editable here).
+    const editBtn =
+      source.type === 'manual'
+        ? `<button class="edit-source-btn" title="Modifier"
+            style="background: none; border: none; cursor: pointer; color: var(--text-mention-grey); padding: 0.25rem; font-size: 0.875rem; border-radius: 3px;">
+            <i class="ri-pencil-line"></i>
+          </button>`
+        : '';
+
     card.innerHTML = `
       <div style="display: flex; align-items: center; gap: 0.5rem;">
         ${typeBadge}
         <span style="flex: 1; font-weight: 500;">${escapeHtml(source.name)}</span>
         <span class="count">${source.recordCount || 0} lignes</span>
+        ${editBtn}
         <button class="delete-source-btn" title="Supprimer"
           style="background: none; border: none; cursor: pointer; color: var(--text-mention-grey); padding: 0.25rem; font-size: 0.875rem; border-radius: 3px;">
           <i class="ri-delete-bin-line"></i>
@@ -595,9 +607,14 @@ export function renderSources(): void {
 
     card.addEventListener('click', (e: Event) => {
       const target = e.target as HTMLElement;
-      if (!target.closest('.delete-source-btn')) {
+      if (!target.closest('.delete-source-btn') && !target.closest('.edit-source-btn')) {
         previewSource(source.id);
       }
+    });
+
+    card.querySelector('.edit-source-btn')?.addEventListener('click', (e: Event) => {
+      e.stopPropagation();
+      editSource(source.id);
     });
 
     card.querySelector('.delete-source-btn')?.addEventListener('click', async (e: Event) => {
@@ -627,6 +644,37 @@ export function deleteSource(id: string): void {
   saveToStorage(STORAGE_KEYS.SOURCES, state.sources);
   getApiAdapter()?.deleteItemFromServer(STORAGE_KEYS.SOURCES, id);
   renderSources();
+}
+
+/**
+ * Open the "Nouvelle source manuelle" modal in edit mode, pre-filled with the
+ * existing source. Only valid for sources of type `manual`. The table editor
+ * is used for editing regardless of how the source was originally created
+ * (JSON, CSV, or table) — it's the most general view, and the user can still
+ * switch modes if they want to paste new JSON or import a new CSV.
+ */
+export function editSource(id: string): void {
+  const source = state.sources.find((s) => s.id === id);
+  if (!source || source.type !== 'manual') return;
+
+  state.editingSourceId = id;
+
+  const titleEl = document.querySelector('#manual-source-modal .modal-header h3');
+  if (titleEl) {
+    titleEl.innerHTML = '<i class="ri-pencil-line"></i> Modifier la source';
+  }
+  const saveBtnEl = document.getElementById('save-source-btn');
+  if (saveBtnEl) {
+    saveBtnEl.textContent = 'Enregistrer les modifications';
+  }
+
+  const nameEl = document.getElementById('source-name') as HTMLInputElement | null;
+  if (nameEl) nameEl.value = source.name || '';
+
+  switchSourceMode('table');
+  loadTableData(source.data as Record<string, unknown>[]);
+
+  openModal('manual-source-modal');
 }
 
 export function previewSource(id: string): void {

--- a/apps/sources/src/editors/table-editor.ts
+++ b/apps/sources/src/editors/table-editor.ts
@@ -206,6 +206,71 @@ export function collectTableData(): Record<string, unknown>[] {
 // Reset table editor
 // ============================================================
 
+/**
+ * Pre-fill the table editor with records from an existing source.
+ * Columns are derived from the keys of the first record. Rows after the
+ * first determine extra columns if their key set differs (sparse unions
+ * handled by the union of all keys).
+ */
+export function loadTableData(data: Record<string, unknown>[]): void {
+  const table = getTableEditor();
+  if (!table || data.length === 0) {
+    resetTableEditor();
+    return;
+  }
+
+  // Column union across all rows (preserves first-record order, then adds extras)
+  const seen = new Set<string>();
+  const columns: string[] = [];
+  for (const row of data) {
+    for (const key of Object.keys(row)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        columns.push(key);
+      }
+    }
+  }
+
+  const headerRow = table.querySelector('thead tr');
+  if (headerRow) {
+    let html = '<th style="width: 30px;">#</th>';
+    for (const col of columns) {
+      const escaped = col.replace(/"/g, '&quot;');
+      html += `<th style="position: relative;">
+        <input type="text" value="${escaped}" class="fr-input fr-input--sm" style="min-width: 80px;">
+        <button class="remove-col-btn" onclick="(window as any).removeTableColumn(this)" title="Supprimer la colonne"
+          style="position: absolute; top: -2px; right: -2px; background: var(--background-action-high-error); color: white; border: none; border-radius: 50%; width: 16px; height: 16px; font-size: 10px; cursor: pointer; display: flex; align-items: center; justify-content: center;">
+          x
+        </button>
+      </th>`;
+    }
+    html += '<th style="width: 30px;"></th>';
+    headerRow.innerHTML = html;
+  }
+
+  const tbody = table.querySelector('tbody');
+  if (tbody) {
+    tbody.innerHTML = '';
+    data.forEach((row, idx) => {
+      const tr = document.createElement('tr');
+      let html = `<td class="row-number" style="text-align: center; color: var(--text-mention-grey); font-size: 0.75rem;">${idx + 1}</td>`;
+      for (const col of columns) {
+        const val = row[col];
+        const escaped = String(val ?? '').replace(/"/g, '&quot;');
+        html += `<td><input type="text" class="fr-input fr-input--sm" value="${escaped}"></td>`;
+      }
+      html += `<td>
+        <button onclick="(window as any).removeTableRow(this)" class="remove-row-btn" title="Supprimer"
+          style="background: none; border: none; color: var(--text-mention-grey); cursor: pointer; font-size: 0.875rem;">
+          <i class="ri-delete-bin-line"></i>
+        </button>
+      </td>`;
+      tr.innerHTML = html;
+      tbody.appendChild(tr);
+    });
+  }
+}
+
 export function resetTableEditor(): void {
   const table = getTableEditor();
   if (!table) return;

--- a/apps/sources/src/main.ts
+++ b/apps/sources/src/main.ts
@@ -105,6 +105,28 @@ function saveManualSource(): void {
 
   if (!data) return;
 
+  const editingId = state.editingSourceId;
+  if (editingId) {
+    // Update in place — keep the same id so existing references (favorites,
+    // dashboards, builder state) still resolve.
+    const idx = state.sources.findIndex((s) => s.id === editingId);
+    if (idx >= 0) {
+      state.sources[idx] = {
+        ...state.sources[idx],
+        name,
+        data,
+        recordCount: data.length,
+      };
+      saveToStorage(STORAGE_KEYS.SOURCES, state.sources);
+      renderSources();
+      closeModal('manual-source-modal');
+      resetManualSourceModal();
+      toastSuccess(`Source « ${name} » mise à jour.`);
+      return;
+    }
+    // Edited source was deleted in another tab — fall through to create new.
+  }
+
   const source = {
     id: crypto.randomUUID(),
     name,
@@ -118,9 +140,23 @@ function saveManualSource(): void {
   renderSources();
   closeModal('manual-source-modal');
   resetManualSourceModal();
+  toastSuccess(`Source « ${name} » ajoutée.`);
 }
 
 function resetManualSourceModal(): void {
+  state.editingSourceId = null;
+
+  // Reset modal title and submit button back to the "create new" defaults
+  // (editSource() flips them to "Modifier" / "Enregistrer les modifications").
+  const titleEl = document.querySelector('#manual-source-modal .modal-header h3');
+  if (titleEl) {
+    titleEl.innerHTML = '<i class="ri-edit-line"></i> Nouvelle source manuelle';
+  }
+  const saveBtnEl = document.getElementById('save-source-btn');
+  if (saveBtnEl) {
+    saveBtnEl.textContent = 'Sauvegarder';
+  }
+
   const nameEl = document.getElementById('source-name') as HTMLInputElement | null;
   if (nameEl) nameEl.value = '';
 

--- a/apps/sources/src/state.ts
+++ b/apps/sources/src/state.ts
@@ -71,6 +71,8 @@ export interface SourcesState {
   tableData: GristRecord[] | Record<string, unknown>[];
   /** ID of the connection being edited in the modal (null = creating new) */
   editingConnectionId: string | null;
+  /** ID of the manual source being edited in the modal (null = creating new) */
+  editingSourceId: string | null;
   previewedSource: Source | null;
   /** Total record count reported by API (e.g. ODS total_count), -1 if unknown */
   apiTotalCount: number;
@@ -161,6 +163,7 @@ export function createInitialState(): SourcesState {
     tables: [],
     tableData: [],
     editingConnectionId: null,
+    editingSourceId: null,
     previewedSource: null,
     apiTotalCount: -1,
   };


### PR DESCRIPTION
Closes #186 — EPIC #186 entier livré (1 sous-issue).

Audit UX 2026-05-26 §M-S-3 : une fois une source manuelle créée, impossible de l'éditer. Une typo obligeait à refaire toute la source. Le CSS `.edit-source-btn` existait déjà mais aucun JS ne le créait.

## Détail

### UI

- Nouveau **bouton crayon** à gauche du bouton poubelle sur chaque source manuelle dans la sidebar.
- Visible uniquement pour `source.type === 'manual'` (API/Grist/jointures sont dérivées d'un état externe et non éditables ici).
- Hover state piloté par le CSS `.edit-source-btn:hover` qui existait déjà dans `sources.css` (couleur bleu DSFR, fond gris alt).

### Comportement

Au clic, la modale « Nouvelle source manuelle » s'ouvre en **mode édition** :

| Élément | Mode création | Mode édition |
|---|---|---|
| Titre modale | `Nouvelle source manuelle` | `Modifier la source` |
| Bouton submit | `Sauvegarder` | `Enregistrer les modifications` |
| Champ Nom | vide | pré-rempli |
| Mode actif | dernier utilisé | forcé sur `Tableau` |
| Grille | 3 lignes vides | pré-remplie avec les données existantes |

À la validation : **mise à jour en place** (même `id`) → les références depuis favoris / dashboards / état builder restent valides.

À l'annulation (Esc / × / click outside) : pas de modification.

### Implémentation

- `state.editingSourceId: string | null` ajouté au state (pattern miroir de `editingConnectionId`).
- `editSource(id)` exporté depuis `connection-manager.ts` — no-op si la source n'est pas `manual`.
- `loadTableData(data)` exporté depuis `editors/table-editor.ts` — pré-remplit la grille (union des clés pour les colonnes, lignes ordonnées comme à la sauvegarde, valeurs échappées HTML).
- `saveManualSource()` dans `main.ts` adapté : si `editingSourceId` set → update in-place + `toastSuccess` ; sinon → push nouveau + `toastSuccess` (toast nouveau aussi pour la création, ce qui était silencieux avant — couvre T-3 de l'audit).
- `resetManualSourceModal()` remet le titre, le bouton et `editingSourceId` aux valeurs « mode création ».

### Choix de design

**Pourquoi forcer le mode Tableau à l'édition** : une source manuelle ne stocke que son tableau de records (`source.data: Record<string, unknown>[]`), pas la modalité de saisie originale (Tableau / JSON / CSV). Le Tableau est la vue la plus générale → l'utilisateur peut éditer n'importe quelle cellule. Il peut aussi switcher vers JSON/CSV s'il veut tout remplacer en collant un nouveau payload (le formulaire est réinitialisé à chaque switch dans cette modale).

**Pourquoi pas de `confirmDialog` à l'annulation** : la modale a un bouton × explicite + Esc. Ajouter une confirmation rendrait l'expérience lourde pour 99% des cas où l'utilisateur ferme sans avoir modifié.

## Test plan

- [x] `npm run dev` → Sources : créer une source manuelle (Tableau, 2 lignes 3 colonnes), cliquer crayon → vérifier modale ouverte avec titre/bouton ajustés + nom + grille pré-remplis.
- [x] Modifier une cellule → cliquer « Enregistrer les modifications » → vérifier toast vert « Source X mise à jour. » + aperçu côté droit mis à jour (même `id`, pas de doublon dans la sidebar).
- [x] Annuler (× ou Esc) → vérifier aucune modification persistée.
- [x] Source de type API/Grist/jointure → vérifier que le crayon n'apparaît PAS.

## CI / tests automatisés

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:run` ✅ (2946/2946)
- `npm run check:accents` ✅
- `npm run build --workspace=@dsfr-data/app-sources` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)