### PR TITLE
epic(ux): wording Sources batch 3 — modales API + jointures (closes #183)

### DIFF
--- a/.changeset/ux-wording-sources-batch-3.md
+++ b/.changeset/ux-wording-sources-batch-3.md
@@ -1,0 +1,38 @@
+---
+'dsfr-data': patch
+---
+
+fix(ux): wording naturel des modales Sources (closes #193 + #194, EPIC #183 complet, audit UX 2026-05-26 §M-S-1 + §M-S-4).
+
+Dernier batch de l'EPIC #183 « wording, jargon & accents ». Couvre les 2 modales de l'app Sources qui restaient les plus chargées en jargon technique.
+
+**#193 — Modale Nouvelle connexion API**
+
+Renommages des 4 labels + hints :
+- `URL de l'API` (hint « endpoint JSON ») → **`URL des données`** (hint « Adresse complète d'une page qui renvoie des données au format JSON »)
+- `Méthode HTTP` + ajout d'un hint pédagogique (« Choisir GET sauf cas spécifique »)
+- `En-têtes (optionnel)` + hint avec JSON brut `Bearer xxx` → **`Authentification (optionnel)`** + hint accessible (« Si l'API demande un jeton ou une clé pour autoriser l'accès, ajoutez-le ici »)
+- `Chemin vers les données (optionnel)` (hint « Chemin JSON ») → **`Emplacement des données (optionnel)`** (hint « Si les données ne sont pas à la racine, indiquer où aller les chercher »)
+
+**Remplacement du textarea JSON brut par un éditeur clé/valeur** pour l'authentification : 2 inputs côte-à-côte (nom + valeur) + bouton « + Ajouter un en-tête » + bouton supprimer par ligne. Le textarea `#api-headers` est conservé en hidden pour rester la source de vérité JSON consommée par `saveApiConnection()` — synchronisé automatiquement à chaque modification de l'éditeur. Édition d'une connexion existante : les en-têtes JSON sont parsés et pré-remplis dans l'éditeur via `populateApiHeadersFromJson()`.
+
+Nouveaux exports dans `connection-manager.ts` : `addApiHeaderRow(name?, value?)`, `populateApiHeadersFromJson(jsonStr)`, `clearApiHeadersEditor()`.
+
+**#194 — Modale Joindre deux sources**
+
+Renommages des 5 labels + descriptions :
+- `Source gauche (principale)` → **`Source A (principale)`** + hint plus naturel
+- `Source droite` → **`Source B (complémentaire)`**
+- `Clé de jointure` (hint cryptique « champ_gauche=champ_droite ») → **`Colonne commune aux deux sources`** + hint accessible (« Le champ qui permet de relier les deux sources. Si les noms diffèrent : champ_A=champ_B »)
+- Les 4 types de jointure (`Left/Inner/Right/Full` avec parenthèses techniques) → descriptions en langage naturel :
+  - Left → « Garder toutes les lignes de A, compléter avec B si possible (recommandé) »
+  - Inner → « Garder uniquement les lignes présentes dans A et dans B »
+  - Right → « Garder toutes les lignes de B, compléter avec A si possible »
+  - Full → « Garder toutes les lignes des deux sources (union) »
+- `Préfixe des champs droite (en cas de collision)` → **`Préfixe pour les champs de B en cas de doublon`** + hint avec exemple concret
+
+Les `value` des options du select restent `left`/`inner`/`right`/`full` (aucun changement de logique côté `performJoin` dans `@dsfr-data/shared`).
+
+L'affichage « Champs gauche » / « Champs droite » dans le bloc d'info devient « Champs source A » / « Champs source B » pour rester cohérent.
+
+**EPIC #183 entièrement livré** après cette PR (6/6 sous-issues : #192 accents, #193 API wording, #194 jointures, #195 DataBox, #196 palettes, #197 axes).

--- a/apps/sources/index.html
+++ b/apps/sources/index.html
@@ -205,8 +205,8 @@
         <div id="api-fields" style="display: none;">
           <div class="fr-input-group fr-mt-2w">
             <label class="fr-label" for="api-url">
-              URL de l'API
-              <span class="fr-hint-text">URL complète de l'endpoint JSON (ex: https://api.example.com/data)</span>
+              URL des données
+              <span class="fr-hint-text">Adresse complète d'une page qui renvoie des données au format JSON (ex : https://api.example.com/data).</span>
             </label>
             <input class="fr-input" type="url" id="api-url" placeholder="https://api.example.com/data.json">
           </div>
@@ -214,6 +214,7 @@
           <div class="fr-input-group fr-mt-2w">
             <label class="fr-label" for="api-method">
               Méthode HTTP
+              <span class="fr-hint-text">Choisir GET sauf cas spécifique (POST quand l'API attend un corps de requête).</span>
             </label>
             <select class="fr-select" id="api-method">
               <option value="GET" selected>GET</option>
@@ -222,17 +223,23 @@
           </div>
 
           <div class="fr-input-group fr-mt-2w">
-            <label class="fr-label" for="api-headers">
-              En-têtes (optionnel)
-              <span class="fr-hint-text">Format JSON. Ex: {"Authorization": "Bearer xxx"}</span>
+            <label class="fr-label">
+              Authentification (optionnel)
+              <span class="fr-hint-text">Si l'API demande un jeton ou une clé pour autoriser l'accès, ajoutez-le ici (ex : nom <code>Authorization</code>, valeur <code>Bearer votre_token</code>).</span>
             </label>
-            <textarea class="fr-input" id="api-headers" rows="2" placeholder='{"Authorization": "Bearer votre_token"}'></textarea>
+            <div id="api-headers-editor" class="api-headers-editor"></div>
+            <button type="button" class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-mt-1w" id="add-api-header-btn">
+              <i class="ri-add-line"></i> Ajouter un en-tête
+            </button>
+            <!-- Hidden textarea: source de vérité JSON consommée par saveApiConnection.
+                 Synchronisée automatiquement depuis l'éditeur clé/valeur. -->
+            <textarea id="api-headers" hidden></textarea>
           </div>
 
           <div class="fr-input-group fr-mt-2w">
             <label class="fr-label" for="api-data-path">
-              Chemin vers les données (optionnel)
-              <span class="fr-hint-text">Chemin JSON vers le tableau de données (ex: data.items, results)</span>
+              Emplacement des données (optionnel)
+              <span class="fr-hint-text">Si les données ne sont pas à la racine de la réponse, indiquer où aller les chercher (ex : <code>data.items</code>, <code>results</code>).</span>
             </label>
             <input class="fr-input" type="text" id="api-data-path" placeholder="data.items">
           </div>
@@ -371,8 +378,8 @@
 
         <div class="fr-input-group fr-mt-2w">
           <label class="fr-label" for="join-left-source">
-            Source gauche (principale)
-            <span class="fr-hint-text">Les lignes de cette source seront conservees selon le type de jointure</span>
+            Source A (principale)
+            <span class="fr-hint-text">Les lignes de cette source servent de base. Les lignes de la source B viennent les compléter.</span>
           </label>
           <select class="fr-select" id="join-left-source">
             <option value="">-- Sélectionner --</option>
@@ -381,7 +388,7 @@
 
         <div class="fr-input-group fr-mt-2w">
           <label class="fr-label" for="join-right-source">
-            Source droite
+            Source B (complémentaire)
           </label>
           <select class="fr-select" id="join-right-source">
             <option value="">-- Sélectionner --</option>
@@ -392,11 +399,11 @@
         <div id="join-fields-info" class="fr-mt-2w" style="display: none;">
           <div style="display: flex; gap: 1rem;">
             <div style="flex: 1;">
-              <p class="fr-text--sm fr-text--bold" style="margin-bottom: 0.25rem;">Champs gauche</p>
+              <p class="fr-text--sm fr-text--bold" style="margin-bottom: 0.25rem;">Champs source A</p>
               <p class="fr-text--sm" id="join-left-fields" style="color: var(--text-mention-grey);"></p>
             </div>
             <div style="flex: 1;">
-              <p class="fr-text--sm fr-text--bold" style="margin-bottom: 0.25rem;">Champs droite</p>
+              <p class="fr-text--sm fr-text--bold" style="margin-bottom: 0.25rem;">Champs source B</p>
               <p class="fr-text--sm" id="join-right-fields" style="color: var(--text-mention-grey);"></p>
             </div>
           </div>
@@ -404,8 +411,8 @@
 
         <div class="fr-input-group fr-mt-2w">
           <label class="fr-label" for="join-on">
-            Clé de jointure
-            <span class="fr-hint-text">Le champ present dans les deux sources (ex : code_dept). Si les noms different : champ_gauche=champ_droite</span>
+            Colonne commune aux deux sources
+            <span class="fr-hint-text">Le champ qui permet de relier les deux sources (ex : code_dept). Si les noms diffèrent entre A et B : champ_A=champ_B.</span>
           </label>
           <input class="fr-input" type="text" id="join-on" placeholder="code_dept">
         </div>
@@ -413,17 +420,17 @@
         <div class="fr-input-group fr-mt-2w">
           <label class="fr-label" for="join-type">Type de jointure</label>
           <select class="fr-select" id="join-type">
-            <option value="left" selected>Left (toutes les lignes gauche)</option>
-            <option value="inner">Inner (seulement les correspondances)</option>
-            <option value="right">Right (toutes les lignes droite)</option>
-            <option value="full">Full (toutes les lignes des deux cotes)</option>
+            <option value="left" selected>Garder toutes les lignes de A, compléter avec B si possible (recommandé)</option>
+            <option value="inner">Garder uniquement les lignes présentes dans A et dans B</option>
+            <option value="right">Garder toutes les lignes de B, compléter avec A si possible</option>
+            <option value="full">Garder toutes les lignes des deux sources (union)</option>
           </select>
         </div>
 
         <div class="fr-input-group fr-mt-2w">
           <label class="fr-label" for="join-prefix-right">
-            Prefixe des champs droite (en cas de collision)
-            <span class="fr-hint-text">Evite les conflits de noms : "budget" → "right_budget"</span>
+            Préfixe pour les champs de B en cas de doublon
+            <span class="fr-hint-text">Évite que deux colonnes du même nom se mélangent (ex : préfixe « right_ » → la colonne « budget » de B devient « right_budget »).</span>
           </label>
           <input class="fr-input" type="text" id="join-prefix-right" placeholder="right_" value="right_">
         </div>

--- a/apps/sources/src/connections/connection-manager.ts
+++ b/apps/sources/src/connections/connection-manager.ts
@@ -349,14 +349,13 @@ export function editConnection(id: string): void {
 
     const apiUrlEl = document.getElementById('api-url') as HTMLInputElement | null;
     const apiMethodEl = document.getElementById('api-method') as HTMLSelectElement | null;
-    const apiHeadersEl = document.getElementById('api-headers') as HTMLTextAreaElement | null;
     const apiDataPathEl = document.getElementById('api-data-path') as HTMLInputElement | null;
 
     if (apiUrlEl) apiUrlEl.value = ((conn as Record<string, unknown>).apiUrl as string) || '';
     if (apiMethodEl)
       apiMethodEl.value = ((conn as Record<string, unknown>).method as string) || 'GET';
-    if (apiHeadersEl)
-      apiHeadersEl.value = ((conn as Record<string, unknown>).headers as string) || '';
+    // Headers: populate the key/value editor (which keeps `#api-headers` in sync).
+    populateApiHeadersFromJson(((conn as Record<string, unknown>).headers as string) || '');
     if (apiDataPathEl)
       apiDataPathEl.value = ((conn as Record<string, unknown>).dataPath as string) || '';
   } else {
@@ -475,8 +474,8 @@ export function resetConnectionForm(): void {
   const methodEl = document.getElementById('api-method') as HTMLSelectElement | null;
   if (methodEl) methodEl.value = 'GET';
 
-  const headersEl = document.getElementById('api-headers') as HTMLTextAreaElement | null;
-  if (headersEl) headersEl.value = '';
+  // Headers: clear the key/value editor (also clears the hidden textarea).
+  clearApiHeadersEditor();
 
   const dataPathEl = document.getElementById('api-data-path') as HTMLInputElement | null;
   if (dataPathEl) dataPathEl.value = '';
@@ -539,6 +538,108 @@ export function refreshCurrentView(): void {
 // ============================================================
 // Source mode switching (manual source modal)
 // ============================================================
+
+// ============================================================
+// API headers — key/value editor
+// ============================================================
+
+/**
+ * Append an empty header row (name + value + remove button) to the editor.
+ * If `name`/`value` are provided, pre-fill them — used by `editConnection()`
+ * to populate the editor with the existing headers of a saved API connection.
+ */
+export function addApiHeaderRow(name = '', value = ''): void {
+  const editor = document.getElementById('api-headers-editor');
+  if (!editor) return;
+
+  const row = document.createElement('div');
+  row.className = 'api-headers-row';
+  row.style.cssText = 'display:flex;gap:0.5rem;align-items:center;margin-bottom:0.5rem;';
+
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'fr-input fr-input--sm api-header-name';
+  nameInput.placeholder = 'Nom (ex : Authorization)';
+  nameInput.value = name;
+  nameInput.style.flex = '1';
+
+  const valueInput = document.createElement('input');
+  valueInput.type = 'text';
+  valueInput.className = 'fr-input fr-input--sm api-header-value';
+  valueInput.placeholder = 'Valeur (ex : Bearer votre_token)';
+  valueInput.value = value;
+  valueInput.style.flex = '2';
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'api-header-remove-btn';
+  removeBtn.title = 'Supprimer cet en-tête';
+  removeBtn.setAttribute('aria-label', 'Supprimer cet en-tête');
+  removeBtn.style.cssText =
+    'background:none;border:none;color:var(--text-mention-grey);cursor:pointer;padding:0.25rem;font-size:1rem;';
+  removeBtn.innerHTML = '<i class="ri-delete-bin-line" aria-hidden="true"></i>';
+  removeBtn.addEventListener('click', () => {
+    row.remove();
+    syncApiHeadersTextarea();
+  });
+
+  nameInput.addEventListener('input', syncApiHeadersTextarea);
+  valueInput.addEventListener('input', syncApiHeadersTextarea);
+
+  row.appendChild(nameInput);
+  row.appendChild(valueInput);
+  row.appendChild(removeBtn);
+  editor.appendChild(row);
+
+  syncApiHeadersTextarea();
+}
+
+/**
+ * Serialize all editor rows into the hidden `#api-headers` textarea
+ * (which `saveApiConnection` already consumes as JSON).
+ */
+function syncApiHeadersTextarea(): void {
+  const editor = document.getElementById('api-headers-editor');
+  const textarea = document.getElementById('api-headers') as HTMLTextAreaElement | null;
+  if (!editor || !textarea) return;
+
+  const headers: Record<string, string> = {};
+  editor.querySelectorAll('.api-headers-row').forEach((row) => {
+    const name = (row.querySelector('.api-header-name') as HTMLInputElement | null)?.value.trim();
+    const value = (row.querySelector('.api-header-value') as HTMLInputElement | null)?.value.trim();
+    if (name) headers[name] = value ?? '';
+  });
+
+  textarea.value = Object.keys(headers).length > 0 ? JSON.stringify(headers) : '';
+}
+
+/** Remove all rows from the API headers editor and clear the hidden textarea. */
+export function clearApiHeadersEditor(): void {
+  const editor = document.getElementById('api-headers-editor');
+  if (editor) editor.innerHTML = '';
+  const textarea = document.getElementById('api-headers') as HTMLTextAreaElement | null;
+  if (textarea) textarea.value = '';
+}
+
+/**
+ * Parse a JSON object of headers into editor rows. Silently ignores invalid
+ * JSON (the legacy textarea allowed any string; we don't want to crash on
+ * malformed saved data).
+ */
+export function populateApiHeadersFromJson(jsonStr: string | null | undefined): void {
+  clearApiHeadersEditor();
+  if (!jsonStr) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch {
+    return;
+  }
+  if (!parsed || typeof parsed !== 'object') return;
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    addApiHeaderRow(String(key), value == null ? '' : String(value));
+  }
+}
 
 export function switchSourceMode(mode: string): void {
   import('../state.js').then(({ setCurrentSourceMode }) => {

--- a/apps/sources/src/main.ts
+++ b/apps/sources/src/main.ts
@@ -49,6 +49,7 @@ import {
   saveJoinSource,
   updateJoinFieldsInfo,
   previewJoinResult,
+  addApiHeaderRow,
 } from './connections/connection-manager.js';
 
 import {
@@ -229,6 +230,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     .getElementById('add-source-btn')
     ?.addEventListener('click', () => openModal('manual-source-modal'));
   document.getElementById('save-connection-btn')?.addEventListener('click', saveConnection);
+  document.getElementById('add-api-header-btn')?.addEventListener('click', () => addApiHeaderRow());
   document.getElementById('save-source-btn')?.addEventListener('click', saveManualSource);
   document
     .getElementById('create-table-btn')


### PR DESCRIPTION
Closes #193. Closes #194. **EPIC #183 entièrement livré** après cette PR (6/6 sous-issues).

Dernier batch wording de l'EPIC #183. Couvre les 2 modales de l'app Sources qui restaient les plus chargées en jargon technique. Audit UX 2026-05-26 §M-S-1 + §M-S-4.

## [#194](https://github.com/bmatge/dsfr-data/issues/194) — Modale Joindre deux sources

Renommages des 5 labels + descriptions :

| Avant | Après |
|---|---|
| `Source gauche (principale)` | **`Source A (principale)`** + hint plus naturel |
| `Source droite` | **`Source B (complémentaire)`** |
| `Clé de jointure` (hint cryptique « champ_gauche=champ_droite ») | **`Colonne commune aux deux sources`** + hint accessible |
| Select Left/Inner/Right/Full avec parenthèses techniques | Descriptions en langage naturel (cf. ci-dessous) |
| `Préfixe des champs droite (en cas de collision)` | **`Préfixe pour les champs de B en cas de doublon`** + exemple |

**Descriptions des types de jointure** :
- Left → « Garder toutes les lignes de A, compléter avec B si possible (recommandé) »
- Inner → « Garder uniquement les lignes présentes dans A et dans B »
- Right → « Garder toutes les lignes de B, compléter avec A si possible »
- Full → « Garder toutes les lignes des deux sources (union) »

Les `value` du select restent `left/inner/right/full` — **zéro changement de logique** côté `performJoin()` dans `@dsfr-data/shared`. Le bloc « Champs gauche/droite » devient « Champs source A/B » pour rester cohérent.

## [#193](https://github.com/bmatge/dsfr-data/issues/193) — Modale Nouvelle connexion API

Renommages des 4 labels + hints :

| Avant | Après |
|---|---|
| `URL de l'API` (hint « endpoint JSON ») | **`URL des données`** (hint « Adresse complète d'une page qui renvoie des données au format JSON ») |
| `Méthode HTTP` (sans hint) | `Méthode HTTP` + hint pédagogique « Choisir GET sauf cas spécifique » |
| `En-têtes (optionnel)` + hint avec JSON brut `Bearer xxx` | **`Authentification (optionnel)`** + hint accessible |
| `Chemin vers les données (optionnel)` (hint « Chemin JSON ») | **`Emplacement des données (optionnel)`** + hint « Si les données ne sont pas à la racine, indiquer où aller les chercher » |

### Remplacement du textarea JSON brut par un éditeur clé/valeur

Avant, l'utilisateur devait taper du JSON valide à la main : `{"Authorization": "Bearer xxx"}`. Marie ne savait pas ce que ça voulait dire. Maintenant : 2 inputs côte-à-côte (nom + valeur, ex. `Authorization` + `Bearer votre_token`) + bouton « + Ajouter un en-tête » + bouton supprimer par ligne.

**Compat préservée à 100%** : le textarea `#api-headers` est conservé en `hidden` pour rester la source de vérité JSON consommée par `saveApiConnection()`. Il est synchronisé automatiquement à chaque modification de l'éditeur via `syncApiHeadersTextarea()`. À l'édition d'une connexion existante (`editConnection()`), les en-têtes JSON sont parsés et pré-remplis dans l'éditeur via `populateApiHeadersFromJson()` (silencieusement ignore le JSON invalide pour ne pas crasher sur des données legacy).

Nouveaux exports dans `connection-manager.ts` : `addApiHeaderRow(name?, value?)`, `populateApiHeadersFromJson(jsonStr)`, `clearApiHeadersEditor()`.

`resetConnectionForm()` adapté pour appeler `clearApiHeadersEditor()` au lieu de vider directement le textarea.

## EPIC #183 — Bilan final

| Sous-issue | Statut | PR |
|---|---|---|
| #192 — Accents UTF-8 transverse (T-1) | ✅ Livré | #214 |
| #193 — Wording API Sources (M-S-1) | ✅ **Cette PR** | #216 |
| #194 — Jointures wording Sources (M-S-4) | ✅ **Cette PR** | #216 |
| #195 — DataBox → Cadre officiel DSFR (M-B-2) | ✅ Livré | #213 |
| #196 — Palettes wording + fix leak (M-B-3) | ✅ Livré | #213 |
| #197 — Axes naturels + validation alignée (M-B-4) | ✅ Livré | #213 |

L'EPIC peut être fermé à l'issue de cette PR.

## Test plan

- [ ] `npm run dev` → Sources : ouvrir « Nouvelle connexion API » → vérifier les nouveaux libellés (URL des données / Authentification / Emplacement des données).
- [ ] Cliquer « Ajouter un en-tête » → vérifier l'apparition d'une ligne avec 2 inputs + bouton supprimer. Saisir Authorization / Bearer xxx → vérifier que `#api-headers` (hidden) contient `{"Authorization":"Bearer xxx"}`.
- [ ] Sauvegarder la connexion → réouvrir avec « Modifier » → vérifier que l'éditeur est pré-rempli.
- [ ] Sources : ouvrir « Joindre deux sources » → vérifier les nouveaux libellés (Source A/B, Colonne commune, descriptions naturelles dans le select Type de jointure).
- [ ] Faire une jointure → vérifier que le résultat est strictement identique à avant (zéro changement de logique).

## CI / tests automatisés

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:run` ✅ (2946/2946)
- `npm run check:accents` ✅
- `npm run build --workspace=@dsfr-data/app-sources` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)