### PR TITLE
fix(ux): polish batch — 6 quick wins de la salve 2 de l'audit UX

### DIFF
--- a/.changeset/ux-polish-batch-2.md
+++ b/.changeset/ux-polish-batch-2.md
@@ -1,0 +1,16 @@
+---
+'dsfr-data': patch
+---
+
+fix(ux): polish batch — 6 quick wins de la salve 2 du rapport d'audit UX 2026-05-26.
+
+Petits ajustements indépendants extraits de la salve 2 du plan (mineurs + suggestions reportés après les 3 EPIC structurants déjà livrés). Pas d'issues GitHub dédiées — cf. plan `~/.claude/plans/je-veux-que-tu-vectorized-raven.md`.
+
+- **S-H-3** : badge header `Beta 0.7.0` (orange `fr-badge--warning`, anxiogène) → **`Aperçu 0.7.0`** (bleu `fr-badge--info`) avec tooltip explicatif « Outil en évolution, vos exports restent stables ». Pour Marie (P1), le label « BETA » sur un site officiel suggère « instable / pas pour la prod ». « Aperçu » est neutre.
+- **m-S-1** : tour Sources step 3 — « Sélectionnez une connexion pour parcourir ses tables… » (théorique au 1er accès) → **« Une fois une connexion ajoutée, vous pourrez parcourir ses tables… »** (cohérent quand zéro connexion).
+- **m-S-2** : bouton « Rafraîchir » désormais masqué quand la source courante est de type `manual` ou `join` (pas de données distantes à rafraîchir). Réaffiché automatiquement quand l'utilisateur sélectionne une connexion API/Grist.
+- **m-S-3** : couleurs des badges « API / Grist / Manuel / Jointure » alignées sur la palette DSFR officielle (`#000091` Bleu France / `#18753C` Vert émeraude / `#A558A0` Violet macaron / `#B34000` Orange terre-battue, toutes définies dans `packages/shared/src/constants/dsfr-palettes.ts`). Le violet custom `#9333ea` qui faisait l'objet du finding est remplacé ; les 3 autres sont aussi alignés pour la cohérence.
+- **m-B-1** : tour Builder step 1 — retire la mention « cliquez sur une des cartes d'exemple » qui n'existent pas dans l'UI. Nouveau wording : « Commencez ici : choisissez une source de données existante dans la liste déroulante. Pas encore de source ? Créez-en une depuis l'app Sources. »
+- **m-B-5** : `CHART_TYPE_LABELS.bar = 'Barres verticales'` → **`'Barres'`** pour aligner avec le libellé du bouton de la grille (« Barres »). Plus de divergence entre le bouton sélectionné et le résumé de la section quand collapsée.
+
+**m-B-4 vérifié sans changement** : le feedback « Copié ! » sur le bouton « Copier le code » existe déjà (`apps/builder/src/ui/ui-helpers.ts:174-180`, swap d'innerHTML 2 secondes). L'audit suspectait son absence — c'était en fait déjà implémenté.

--- a/.changeset/ux-wording-sources-batch-3.md
+++ b/.changeset/ux-wording-sources-batch-3.md
@@ -1,0 +1,38 @@
+---
+'dsfr-data': patch
+---
+
+fix(ux): wording naturel des modales Sources (closes #193 + #194, EPIC #183 complet, audit UX 2026-05-26 §M-S-1 + §M-S-4).
+
+Dernier batch de l'EPIC #183 « wording, jargon & accents ». Couvre les 2 modales de l'app Sources qui restaient les plus chargées en jargon technique.
+
+**#193 — Modale Nouvelle connexion API**
+
+Renommages des 4 labels + hints :
+- `URL de l'API` (hint « endpoint JSON ») → **`URL des données`** (hint « Adresse complète d'une page qui renvoie des données au format JSON »)
+- `Méthode HTTP` + ajout d'un hint pédagogique (« Choisir GET sauf cas spécifique »)
+- `En-têtes (optionnel)` + hint avec JSON brut `Bearer xxx` → **`Authentification (optionnel)`** + hint accessible (« Si l'API demande un jeton ou une clé pour autoriser l'accès, ajoutez-le ici »)
+- `Chemin vers les données (optionnel)` (hint « Chemin JSON ») → **`Emplacement des données (optionnel)`** (hint « Si les données ne sont pas à la racine, indiquer où aller les chercher »)
+
+**Remplacement du textarea JSON brut par un éditeur clé/valeur** pour l'authentification : 2 inputs côte-à-côte (nom + valeur) + bouton « + Ajouter un en-tête » + bouton supprimer par ligne. Le textarea `#api-headers` est conservé en hidden pour rester la source de vérité JSON consommée par `saveApiConnection()` — synchronisé automatiquement à chaque modification de l'éditeur. Édition d'une connexion existante : les en-têtes JSON sont parsés et pré-remplis dans l'éditeur via `populateApiHeadersFromJson()`.
+
+Nouveaux exports dans `connection-manager.ts` : `addApiHeaderRow(name?, value?)`, `populateApiHeadersFromJson(jsonStr)`, `clearApiHeadersEditor()`.
+
+**#194 — Modale Joindre deux sources**
+
+Renommages des 5 labels + descriptions :
+- `Source gauche (principale)` → **`Source A (principale)`** + hint plus naturel
+- `Source droite` → **`Source B (complémentaire)`**
+- `Clé de jointure` (hint cryptique « champ_gauche=champ_droite ») → **`Colonne commune aux deux sources`** + hint accessible (« Le champ qui permet de relier les deux sources. Si les noms diffèrent : champ_A=champ_B »)
+- Les 4 types de jointure (`Left/Inner/Right/Full` avec parenthèses techniques) → descriptions en langage naturel :
+  - Left → « Garder toutes les lignes de A, compléter avec B si possible (recommandé) »
+  - Inner → « Garder uniquement les lignes présentes dans A et dans B »
+  - Right → « Garder toutes les lignes de B, compléter avec A si possible »
+  - Full → « Garder toutes les lignes des deux sources (union) »
+- `Préfixe des champs droite (en cas de collision)` → **`Préfixe pour les champs de B en cas de doublon`** + hint avec exemple concret
+
+Les `value` des options du select restent `left`/`inner`/`right`/`full` (aucun changement de logique côté `performJoin` dans `@dsfr-data/shared`).
+
+L'affichage « Champs gauche » / « Champs droite » dans le bloc d'info devient « Champs source A » / « Champs source B » pour rester cohérent.
+
+**EPIC #183 entièrement livré** après cette PR (6/6 sous-issues : #192 accents, #193 API wording, #194 jointures, #195 DataBox, #196 palettes, #197 axes).

--- a/apps/builder/src/ui/progress-indicator.ts
+++ b/apps/builder/src/ui/progress-indicator.ts
@@ -20,7 +20,7 @@ const GENERATE_MISSING_ID = 'generate-missing';
 const GENERATE_BTN_ID = 'generate-btn';
 
 const CHART_TYPE_LABELS: Record<string, string> = {
-  bar: 'Barres verticales',
+  bar: 'Barres',
   horizontalBar: 'Barres horizontales',
   line: 'Courbe',
   pie: 'Camembert',

--- a/apps/builder/src/ui/tour.ts
+++ b/apps/builder/src/ui/tour.ts
@@ -21,7 +21,7 @@ export const BUILDER_TOUR: TourConfig = {
       selector: '#section-source',
       title: 'Vos données',
       description:
-        "Commencez ici : choisissez une source de données existante, ou cliquez sur une des cartes d'exemple pour essayer tout de suite.",
+        "Commencez ici : choisissez une source de données existante dans la liste déroulante. Pas encore de source ? Créez-en une depuis l'app Sources.",
       position: 'right',
       onBeforeShow: () => openSection('section-source'),
     },

--- a/apps/sources/index.html
+++ b/apps/sources/index.html
@@ -205,8 +205,8 @@
         <div id="api-fields" style="display: none;">
           <div class="fr-input-group fr-mt-2w">
             <label class="fr-label" for="api-url">
-              URL de l'API
-              <span class="fr-hint-text">URL complète de l'endpoint JSON (ex: https://api.example.com/data)</span>
+              URL des données
+              <span class="fr-hint-text">Adresse complète d'une page qui renvoie des données au format JSON (ex : https://api.example.com/data).</span>
             </label>
             <input class="fr-input" type="url" id="api-url" placeholder="https://api.example.com/data.json">
           </div>
@@ -214,6 +214,7 @@
           <div class="fr-input-group fr-mt-2w">
             <label class="fr-label" for="api-method">
               Méthode HTTP
+              <span class="fr-hint-text">Choisir GET sauf cas spécifique (POST quand l'API attend un corps de requête).</span>
             </label>
             <select class="fr-select" id="api-method">
               <option value="GET" selected>GET</option>
@@ -222,17 +223,23 @@
           </div>
 
           <div class="fr-input-group fr-mt-2w">
-            <label class="fr-label" for="api-headers">
-              En-têtes (optionnel)
-              <span class="fr-hint-text">Format JSON. Ex: {"Authorization": "Bearer xxx"}</span>
+            <label class="fr-label">
+              Authentification (optionnel)
+              <span class="fr-hint-text">Si l'API demande un jeton ou une clé pour autoriser l'accès, ajoutez-le ici (ex : nom <code>Authorization</code>, valeur <code>Bearer votre_token</code>).</span>
             </label>
-            <textarea class="fr-input" id="api-headers" rows="2" placeholder='{"Authorization": "Bearer votre_token"}'></textarea>
+            <div id="api-headers-editor" class="api-headers-editor"></div>
+            <button type="button" class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-mt-1w" id="add-api-header-btn">
+              <i class="ri-add-line"></i> Ajouter un en-tête
+            </button>
+            <!-- Hidden textarea: source de vérité JSON consommée par saveApiConnection.
+                 Synchronisée automatiquement depuis l'éditeur clé/valeur. -->
+            <textarea id="api-headers" hidden></textarea>
           </div>
 
           <div class="fr-input-group fr-mt-2w">
             <label class="fr-label" for="api-data-path">
-              Chemin vers les données (optionnel)
-              <span class="fr-hint-text">Chemin JSON vers le tableau de données (ex: data.items, results)</span>
+              Emplacement des données (optionnel)
+              <span class="fr-hint-text">Si les données ne sont pas à la racine de la réponse, indiquer où aller les chercher (ex : <code>data.items</code>, <code>results</code>).</span>
             </label>
             <input class="fr-input" type="text" id="api-data-path" placeholder="data.items">
           </div>
@@ -371,8 +378,8 @@
 
         <div class="fr-input-group fr-mt-2w">
           <label class="fr-label" for="join-left-source">
-            Source gauche (principale)
-            <span class="fr-hint-text">Les lignes de cette source seront conservees selon le type de jointure</span>
+            Source A (principale)
+            <span class="fr-hint-text">Les lignes de cette source servent de base. Les lignes de la source B viennent les compléter.</span>
           </label>
           <select class="fr-select" id="join-left-source">
             <option value="">-- Sélectionner --</option>
@@ -381,7 +388,7 @@
 
         <div class="fr-input-group fr-mt-2w">
           <label class="fr-label" for="join-right-source">
-            Source droite
+            Source B (complémentaire)
           </label>
           <select class="fr-select" id="join-right-source">
             <option value="">-- Sélectionner --</option>
@@ -392,11 +399,11 @@
         <div id="join-fields-info" class="fr-mt-2w" style="display: none;">
           <div style="display: flex; gap: 1rem;">
             <div style="flex: 1;">
-              <p class="fr-text--sm fr-text--bold" style="margin-bottom: 0.25rem;">Champs gauche</p>
+              <p class="fr-text--sm fr-text--bold" style="margin-bottom: 0.25rem;">Champs source A</p>
               <p class="fr-text--sm" id="join-left-fields" style="color: var(--text-mention-grey);"></p>
             </div>
             <div style="flex: 1;">
-              <p class="fr-text--sm fr-text--bold" style="margin-bottom: 0.25rem;">Champs droite</p>
+              <p class="fr-text--sm fr-text--bold" style="margin-bottom: 0.25rem;">Champs source B</p>
               <p class="fr-text--sm" id="join-right-fields" style="color: var(--text-mention-grey);"></p>
             </div>
           </div>
@@ -404,8 +411,8 @@
 
         <div class="fr-input-group fr-mt-2w">
           <label class="fr-label" for="join-on">
-            Clé de jointure
-            <span class="fr-hint-text">Le champ present dans les deux sources (ex : code_dept). Si les noms different : champ_gauche=champ_droite</span>
+            Colonne commune aux deux sources
+            <span class="fr-hint-text">Le champ qui permet de relier les deux sources (ex : code_dept). Si les noms diffèrent entre A et B : champ_A=champ_B.</span>
           </label>
           <input class="fr-input" type="text" id="join-on" placeholder="code_dept">
         </div>
@@ -413,17 +420,17 @@
         <div class="fr-input-group fr-mt-2w">
           <label class="fr-label" for="join-type">Type de jointure</label>
           <select class="fr-select" id="join-type">
-            <option value="left" selected>Left (toutes les lignes gauche)</option>
-            <option value="inner">Inner (seulement les correspondances)</option>
-            <option value="right">Right (toutes les lignes droite)</option>
-            <option value="full">Full (toutes les lignes des deux cotes)</option>
+            <option value="left" selected>Garder toutes les lignes de A, compléter avec B si possible (recommandé)</option>
+            <option value="inner">Garder uniquement les lignes présentes dans A et dans B</option>
+            <option value="right">Garder toutes les lignes de B, compléter avec A si possible</option>
+            <option value="full">Garder toutes les lignes des deux sources (union)</option>
           </select>
         </div>
 
         <div class="fr-input-group fr-mt-2w">
           <label class="fr-label" for="join-prefix-right">
-            Prefixe des champs droite (en cas de collision)
-            <span class="fr-hint-text">Evite les conflits de noms : "budget" → "right_budget"</span>
+            Préfixe pour les champs de B en cas de doublon
+            <span class="fr-hint-text">Évite que deux colonnes du même nom se mélangent (ex : préfixe « right_ » → la colonne « budget » de B devient « right_budget »).</span>
           </label>
           <input class="fr-input" type="text" id="join-prefix-right" placeholder="right_" value="right_">
         </div>

--- a/apps/sources/src/connections/connection-manager.ts
+++ b/apps/sources/src/connections/connection-manager.ts
@@ -424,6 +424,10 @@ export async function selectConnection(id: string): Promise<void> {
   const exportBtn = document.getElementById('export-grist-btn');
   if (exportBtn) exportBtn.style.display = 'none';
 
+  // Show "Rafraîchir" — connections always have remote data.
+  const refreshBtn = document.getElementById('refresh-btn');
+  if (refreshBtn) refreshBtn.style.display = '';
+
   // Show explorer tabs
   const tabsEl = document.getElementById('explorer-tabs');
   if (tabsEl) tabsEl.style.display = '';
@@ -808,6 +812,11 @@ export function previewSource(id: string): void {
   const exportBtn = document.getElementById('export-grist-btn');
   if (exportBtn)
     exportBtn.style.display = source.type === 'manual' || source.type === 'join' ? '' : 'none';
+
+  // Hide "Rafraîchir" for manual/join sources — they have no remote data to refresh.
+  const refreshBtn = document.getElementById('refresh-btn');
+  if (refreshBtn)
+    refreshBtn.style.display = source.type === 'manual' || source.type === 'join' ? 'none' : '';
 
   // Render preview table
   const info = document.getElementById('preview-info');

--- a/apps/sources/src/connections/connection-manager.ts
+++ b/apps/sources/src/connections/connection-manager.ts
@@ -349,14 +349,13 @@ export function editConnection(id: string): void {
 
     const apiUrlEl = document.getElementById('api-url') as HTMLInputElement | null;
     const apiMethodEl = document.getElementById('api-method') as HTMLSelectElement | null;
-    const apiHeadersEl = document.getElementById('api-headers') as HTMLTextAreaElement | null;
     const apiDataPathEl = document.getElementById('api-data-path') as HTMLInputElement | null;
 
     if (apiUrlEl) apiUrlEl.value = ((conn as Record<string, unknown>).apiUrl as string) || '';
     if (apiMethodEl)
       apiMethodEl.value = ((conn as Record<string, unknown>).method as string) || 'GET';
-    if (apiHeadersEl)
-      apiHeadersEl.value = ((conn as Record<string, unknown>).headers as string) || '';
+    // Headers: populate the key/value editor (which keeps `#api-headers` in sync).
+    populateApiHeadersFromJson(((conn as Record<string, unknown>).headers as string) || '');
     if (apiDataPathEl)
       apiDataPathEl.value = ((conn as Record<string, unknown>).dataPath as string) || '';
   } else {
@@ -475,8 +474,8 @@ export function resetConnectionForm(): void {
   const methodEl = document.getElementById('api-method') as HTMLSelectElement | null;
   if (methodEl) methodEl.value = 'GET';
 
-  const headersEl = document.getElementById('api-headers') as HTMLTextAreaElement | null;
-  if (headersEl) headersEl.value = '';
+  // Headers: clear the key/value editor (also clears the hidden textarea).
+  clearApiHeadersEditor();
 
   const dataPathEl = document.getElementById('api-data-path') as HTMLInputElement | null;
   if (dataPathEl) dataPathEl.value = '';
@@ -539,6 +538,108 @@ export function refreshCurrentView(): void {
 // ============================================================
 // Source mode switching (manual source modal)
 // ============================================================
+
+// ============================================================
+// API headers — key/value editor
+// ============================================================
+
+/**
+ * Append an empty header row (name + value + remove button) to the editor.
+ * If `name`/`value` are provided, pre-fill them — used by `editConnection()`
+ * to populate the editor with the existing headers of a saved API connection.
+ */
+export function addApiHeaderRow(name = '', value = ''): void {
+  const editor = document.getElementById('api-headers-editor');
+  if (!editor) return;
+
+  const row = document.createElement('div');
+  row.className = 'api-headers-row';
+  row.style.cssText = 'display:flex;gap:0.5rem;align-items:center;margin-bottom:0.5rem;';
+
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.className = 'fr-input fr-input--sm api-header-name';
+  nameInput.placeholder = 'Nom (ex : Authorization)';
+  nameInput.value = name;
+  nameInput.style.flex = '1';
+
+  const valueInput = document.createElement('input');
+  valueInput.type = 'text';
+  valueInput.className = 'fr-input fr-input--sm api-header-value';
+  valueInput.placeholder = 'Valeur (ex : Bearer votre_token)';
+  valueInput.value = value;
+  valueInput.style.flex = '2';
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'api-header-remove-btn';
+  removeBtn.title = 'Supprimer cet en-tête';
+  removeBtn.setAttribute('aria-label', 'Supprimer cet en-tête');
+  removeBtn.style.cssText =
+    'background:none;border:none;color:var(--text-mention-grey);cursor:pointer;padding:0.25rem;font-size:1rem;';
+  removeBtn.innerHTML = '<i class="ri-delete-bin-line" aria-hidden="true"></i>';
+  removeBtn.addEventListener('click', () => {
+    row.remove();
+    syncApiHeadersTextarea();
+  });
+
+  nameInput.addEventListener('input', syncApiHeadersTextarea);
+  valueInput.addEventListener('input', syncApiHeadersTextarea);
+
+  row.appendChild(nameInput);
+  row.appendChild(valueInput);
+  row.appendChild(removeBtn);
+  editor.appendChild(row);
+
+  syncApiHeadersTextarea();
+}
+
+/**
+ * Serialize all editor rows into the hidden `#api-headers` textarea
+ * (which `saveApiConnection` already consumes as JSON).
+ */
+function syncApiHeadersTextarea(): void {
+  const editor = document.getElementById('api-headers-editor');
+  const textarea = document.getElementById('api-headers') as HTMLTextAreaElement | null;
+  if (!editor || !textarea) return;
+
+  const headers: Record<string, string> = {};
+  editor.querySelectorAll('.api-headers-row').forEach((row) => {
+    const name = (row.querySelector('.api-header-name') as HTMLInputElement | null)?.value.trim();
+    const value = (row.querySelector('.api-header-value') as HTMLInputElement | null)?.value.trim();
+    if (name) headers[name] = value ?? '';
+  });
+
+  textarea.value = Object.keys(headers).length > 0 ? JSON.stringify(headers) : '';
+}
+
+/** Remove all rows from the API headers editor and clear the hidden textarea. */
+export function clearApiHeadersEditor(): void {
+  const editor = document.getElementById('api-headers-editor');
+  if (editor) editor.innerHTML = '';
+  const textarea = document.getElementById('api-headers') as HTMLTextAreaElement | null;
+  if (textarea) textarea.value = '';
+}
+
+/**
+ * Parse a JSON object of headers into editor rows. Silently ignores invalid
+ * JSON (the legacy textarea allowed any string; we don't want to crash on
+ * malformed saved data).
+ */
+export function populateApiHeadersFromJson(jsonStr: string | null | undefined): void {
+  clearApiHeadersEditor();
+  if (!jsonStr) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch {
+    return;
+  }
+  if (!parsed || typeof parsed !== 'object') return;
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    addApiHeaderRow(String(key), value == null ? '' : String(value));
+  }
+}
 
 export function switchSourceMode(mode: string): void {
   import('../state.js').then(({ setCurrentSourceMode }) => {

--- a/apps/sources/src/main.ts
+++ b/apps/sources/src/main.ts
@@ -49,6 +49,7 @@ import {
   saveJoinSource,
   updateJoinFieldsInfo,
   previewJoinResult,
+  addApiHeaderRow,
 } from './connections/connection-manager.js';
 
 import {
@@ -229,6 +230,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     .getElementById('add-source-btn')
     ?.addEventListener('click', () => openModal('manual-source-modal'));
   document.getElementById('save-connection-btn')?.addEventListener('click', saveConnection);
+  document.getElementById('add-api-header-btn')?.addEventListener('click', () => addApiHeaderRow());
   document.getElementById('save-source-btn')?.addEventListener('click', saveManualSource);
   document
     .getElementById('create-table-btn')

--- a/apps/sources/src/styles/sources.css
+++ b/apps/sources/src/styles/sources.css
@@ -1,4 +1,7 @@
-body { min-height: 100vh; background: var(--background-alt-grey); }
+body {
+  min-height: 100vh;
+  background: var(--background-alt-grey);
+}
 
 .page-header {
   background: var(--background-default-grey);
@@ -13,7 +16,10 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
   gap: 0.5rem;
 }
 
-.page-header p { margin: 0.5rem 0 0; color: var(--text-mention-grey); }
+.page-header p {
+  margin: 0.5rem 0 0;
+  color: var(--text-mention-grey);
+}
 
 .sidebar {
   background: var(--background-default-grey);
@@ -42,14 +48,35 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
   transition: all 0.15s;
 }
 
-.connection-card:hover { border-color: var(--border-default-grey); }
-.connection-card.selected { border-color: var(--border-action-high-blue-france); background: var(--background-contrast-info); }
+.connection-card:hover {
+  border-color: var(--border-default-grey);
+}
+.connection-card.selected {
+  border-color: var(--border-action-high-blue-france);
+  background: var(--background-contrast-info);
+}
 
-.connection-card .name { font-weight: 600; display: flex; align-items: center; gap: 0.5rem; }
-.connection-card .url { font-size: 0.75rem; color: var(--text-mention-grey); word-break: break-all; }
-.connection-card .status { font-size: 0.7rem; margin-top: 0.25rem; }
-.connection-card .status.connected { color: var(--text-default-success); }
-.connection-card .status.error { color: var(--text-default-error); }
+.connection-card .name {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.connection-card .url {
+  font-size: 0.75rem;
+  color: var(--text-mention-grey);
+  word-break: break-all;
+}
+.connection-card .status {
+  font-size: 0.7rem;
+  margin-top: 0.25rem;
+}
+.connection-card .status.connected {
+  color: var(--text-default-success);
+}
+.connection-card .status.error {
+  color: var(--text-default-error);
+}
 
 .add-btn {
   width: 100%;
@@ -79,7 +106,9 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
   color: var(--text-action-high-blue-france);
 }
 
-.tree-view { font-size: 0.875rem; }
+.tree-view {
+  font-size: 0.875rem;
+}
 
 .tree-item {
   padding: 0.5rem;
@@ -92,11 +121,21 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
   gap: 0.5rem;
 }
 
-.tree-item:hover { background: var(--background-contrast-grey); }
-.tree-item i { color: var(--text-mention-grey); }
-.tree-item .count { margin-left: auto; font-size: 0.75rem; color: var(--text-mention-grey); }
+.tree-item:hover {
+  background: var(--background-contrast-grey);
+}
+.tree-item i {
+  color: var(--text-mention-grey);
+}
+.tree-item .count {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--text-mention-grey);
+}
 
-.tree-children { margin-left: 1.5rem; }
+.tree-children {
+  margin-left: 1.5rem;
+}
 
 .table-preview {
   margin-top: 1rem;
@@ -110,7 +149,11 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
   color: var(--text-mention-grey);
 }
 
-.empty-state i { font-size: 3rem; margin-bottom: 1rem; display: block; }
+.empty-state i {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+  display: block;
+}
 
 /* Modal */
 .modal-overlay {
@@ -123,7 +166,9 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
   z-index: 1000;
 }
 
-.modal-overlay.active { display: flex; }
+.modal-overlay.active {
+  display: flex;
+}
 
 .modal {
   background: var(--background-default-grey);
@@ -142,7 +187,9 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
   justify-content: space-between;
 }
 
-.modal-header h3 { margin: 0; }
+.modal-header h3 {
+  margin: 0;
+}
 
 .modal-close {
   background: none;
@@ -152,7 +199,9 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
   color: var(--text-mention-grey);
 }
 
-.modal-body { padding: 1.5rem; }
+.modal-body {
+  padding: 1.5rem;
+}
 .modal-footer {
   padding: 1rem 1.5rem;
   border-top: 1px solid var(--border-default-grey);
@@ -178,10 +227,26 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
   font-weight: 600;
 }
 
-.badge-grist { background: #16a34a; color: white; }
-.badge-api { background: #2563eb; color: white; }
-.badge-manual { background: #9333ea; color: white; }
-.badge-join { background: #d97706; color: white; }
+/* Couleurs alignées sur la palette DSFR (cf. packages/shared/src/constants/dsfr-palettes.ts
+   DSFR_COLORS) pour une cohérence institutionnelle — anciennes valeurs custom
+   #16a34a/#2563eb/#9333ea/#d97706 remplacées par les équivalents DSFR
+   « Vert émeraude / Bleu France / Violet macaron / Orange terre-battue ». */
+.badge-grist {
+  background: #18753c;
+  color: white;
+}
+.badge-api {
+  background: #000091;
+  color: white;
+}
+.badge-manual {
+  background: #a558a0;
+  color: white;
+}
+.badge-join {
+  background: #b34000;
+  color: white;
+}
 
 .field-row {
   display: flex;
@@ -190,9 +255,14 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
   margin-bottom: 0.5rem;
 }
 
-.field-row .fr-input-group { flex: 1; margin: 0; }
+.field-row .fr-input-group {
+  flex: 1;
+  margin: 0;
+}
 
-.columns-editor { margin-top: 1rem; }
+.columns-editor {
+  margin-top: 1rem;
+}
 .column-item {
   display: flex;
   gap: 0.5rem;
@@ -203,7 +273,9 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
   margin-bottom: 0.5rem;
 }
 
-.column-item input { flex: 1; }
+.column-item input {
+  flex: 1;
+}
 
 /* Table editor for manual source */
 .table-editor-wrapper {
@@ -331,7 +403,6 @@ body { min-height: 100vh; background: var(--background-alt-grey); }
 .modal.modal--wide {
   max-width: 800px;
 }
-
 
 /* Edit/Delete button hover */
 .edit-conn-btn:hover,

--- a/packages/core/src/components/layout/app-header.ts
+++ b/packages/core/src/components/layout/app-header.ts
@@ -351,8 +351,10 @@ export class AppHeader extends LitElement {
                     class="fr-header__service-tagline"
                     style="display:flex;align-items:center;gap:0.5rem;"
                   >
-                    <span class="fr-badge fr-badge--sm fr-badge--warning fr-badge--no-icon"
-                      >Beta ${PACKAGE_VERSION}</span
+                    <span
+                      class="fr-badge fr-badge--sm fr-badge--info fr-badge--no-icon"
+                      title="Outil en évolution, vos exports restent stables"
+                      >Aperçu ${PACKAGE_VERSION}</span
                     >
                     Création de visualisations dynamiques conformes DSFR
                   </p>

--- a/packages/shared/src/tour/tour-configs.ts
+++ b/packages/shared/src/tour/tour-configs.ts
@@ -34,7 +34,7 @@ export const SOURCES_TOUR: TourConfig = {
       selector: '#main-content',
       title: 'Explorer et prévisualiser',
       description:
-        'Sélectionnez une connexion pour parcourir ses tables et prévisualiser les données avant de les utiliser dans le Builder.',
+        'Une fois une connexion ajoutée, vous pourrez parcourir ses tables et prévisualiser les données avant de les utiliser dans le Builder.',
       position: 'left',
     },
   ],


### PR DESCRIPTION
Petits ajustements de la **salve 2** du rapport d'audit UX 2026-05-26 (mineurs + suggestions reportés après les 3 EPIC structurants déjà livrés : #182 feedback, #183 wording, #186 édition source). Pas d'issues GitHub dédiées — ces findings étaient explicitement reportés sans décomposition dans le plan initial (`~/.claude/plans/je-veux-que-tu-vectorized-raven.md`).

## Quoi

### S-H-3 — Badge BETA → Aperçu

`Beta 0.7.0` orange (`fr-badge--warning`) → **`Aperçu 0.7.0`** bleu (`fr-badge--info`) + tooltip explicatif « Outil en évolution, vos exports restent stables ». Pour Marie (P1, contributrice non-tech), « BETA » sur un site officiel suggère « instable / pas pour la prod ». « Aperçu » est neutre. Sami (P2) garde la perception « produit qui évolue ».

### m-S-1 — Tour Sources step 3

« Sélectionnez une connexion pour parcourir ses tables… » devenait théorique au tout premier accès (zéro connexion). Reword en **« Une fois une connexion ajoutée, vous pourrez parcourir ses tables… »** — cohérent quel que soit l'état.

### m-S-2 — Bouton « Rafraîchir » masqué sur sources manual/join

Aucun sens d'afficher « Rafraîchir » sur une source qui n'a pas de données distantes. `previewSource()` masque maintenant `#refresh-btn` pour `type === 'manual'` ou `type === 'join'`. `selectConnection()` (toujours sur API/Grist) le réaffiche pour gérer le toggle lors d'un switch.

### m-S-3 — Badges alignés sur la palette DSFR

L'audit flaggait spécifiquement le violet `#9333ea` du badge « Manuel » comme non-DSFR. Les 4 badges sont alignés sur `DSFR_COLORS` (`packages/shared/src/constants/dsfr-palettes.ts`) pour la cohérence institutionnelle :

| Badge | Avant | Après | Nom DSFR |
|---|---|---|---|
| API | `#2563eb` | `#000091` | Bleu France |
| Grist | `#16a34a` | `#18753C` | Vert émeraude |
| Manuel | `#9333ea` ⚠️ | `#A558A0` | Violet macaron |
| Jointure | `#d97706` | `#B34000` | Orange terre-battue |

### m-B-1 — Tour Builder step 1, retirer la mention « cartes d'exemple »

Le tooltip 1/5 disait « cliquez sur une des cartes d'exemple pour essayer tout de suite » — mais aucune carte d'exemple n'existe dans la sidebar (juste un select). Nouveau wording : **« Commencez ici : choisissez une source de données existante dans la liste déroulante. Pas encore de source ? Créez-en une depuis l'app Sources. »**

### m-B-5 — Cohérence libellé Barres

`CHART_TYPE_LABELS.bar = 'Barres verticales'` (résumé section collapsée) vs `<span>Barres</span>` (bouton dans la grille). Aligné sur **« Barres »** côté résumé. `horizontalBar` reste « Barres horizontales » côté résumé (le bouton « Barres H » est une abréviation acceptable).

## m-B-4 vérifié sans changement

Le feedback « Copié ! » sur le bouton « Copier le code » existe déjà (`apps/builder/src/ui/ui-helpers.ts:174-180`, swap innerHTML 2s). L'audit suspectait son absence — c'était en fait déjà implémenté.

## Test plan

- [ ] `npm run dev` → vérifier le badge header : « Aperçu 0.7.0 » bleu (au lieu de « Beta » orange), avec tooltip au survol.
- [ ] Sources, navigation privée (1er accès) : déclencher le tour → step 3 doit dire « Une fois une connexion ajoutée, vous pourrez… » au lieu de « Sélectionnez… ».
- [ ] Sources : créer une source manuelle, sélectionner → bouton « Rafraîchir » MASQUÉ. Sélectionner ensuite une connexion API/Grist → bouton « Rafraîchir » VISIBLE.
- [ ] Sources : créer des sources API/Grist/Manuel/Jointure → vérifier les couleurs des badges (4 couleurs DSFR officielles).
- [ ] Builder, navigation privée : déclencher le tour → step 1 doit dire « Pas encore de source ? Créez-en une depuis l'app Sources. » au lieu de « cartes d'exemple ».
- [ ] Builder : sélectionner type « Barres » → collapser la section Type → résumé affiche « Barres » (au lieu de « Barres verticales »).

## CI / tests automatisés

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:run` ✅ (2946/2946)
- `npm run check:accents` ✅
- `npm run build:shared` + builds builder + sources ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)