### PR TITLE
fix(ux): polish batch 3 — map warning + palette swatches + smart defaults

### DIFF
--- a/.changeset/ux-polish-batch-3.md
+++ b/.changeset/ux-polish-batch-3.md
@@ -1,0 +1,21 @@
+---
+'dsfr-data': patch
+---
+
+fix(ux): polish batch 3 — m-B-6 + T-5 + T-6 (salve 2 de l'audit UX 2026-05-26).
+
+3 quick wins indépendants centrés sur le Builder, prolongeant les patches polish déjà livrés (#217 batch 2). Pas d'issues GitHub dédiées (salve 2 reportée sans décomposition dans le plan `~/.claude/plans/je-veux-que-tu-vectorized-raven.md`).
+
+**§m-B-6 — Warning carte départementale quand la source ne contient pas de codes INSEE**
+
+Quand l'utilisateur choisit le type « Carte départementale » sur une source qui contient des noms (« Île-de-France »…) mais pas de codes département, le select Code département reste vide silencieusement et la carte ne s'affiche pas. Nouvelle détection : `findDeptCodeField()` parcourt les 50 premières lignes des champs string/number et valide via `isValidDeptCode()` (existant dans `@dsfr-data/shared`) ; si au moins 80% des valeurs non-vides d'une colonne sont des codes valides, on la considère candidate. Sinon, affichage d'un encadré jaune « Aucun code département détecté — Convertissez vos noms en codes ou choisissez un autre type de graphique ». Re-évalué quand : (1) le type de graphique change vers/depuis « map », (2) une source est chargée et `populateFieldSelects()` est appelée.
+
+**§T-5 — Aperçus visuels des palettes de couleurs**
+
+Sous le select `#chart-palette`, nouveau strip de swatches qui affiche les 5 couleurs de la palette sélectionnée. Mis à jour à l'ouverture du Builder + à chaque changement de palette + à l'auto-swap vers `sequentialAscending` quand le type passe en `map`. Utilise `PALETTE_COLORS` déjà exporté depuis `@dsfr-data/shared`. CSS minimal (~10 lignes : flex row de spans avec background-color).
+
+**§T-6 — Valeurs par défaut intelligentes : pré-sélection auto du seul candidat**
+
+`populateFieldSelects()` faisait déjà la pré-sélection par mot-clé (« nom » / « region » / « departement » / « label » pour les étiquettes ; « prix » / « score » / « valeur » / « value » pour les valeurs numériques). Nouveau fallback : si aucun mot-clé ne matche, mais qu'il n'y a **qu'un seul candidat** du bon type (string pour étiquettes, number pour valeurs), on le pré-sélectionne quand même. Économise un clic sur les datasets simples sans ambiguïté (ex : `{region, population}` → les 2 champs auto-remplis même si « population » ne contient pas de mot-clé). Test ajouté : `tests/apps/builder/sources-fields.test.ts:auto-selection T-6`. Test existant adapté pour refléter le nouveau contrat (« no auto-select » nécessite désormais 2+ candidats non-matchants).
+
+**Nouveaux exports dans `apps/builder/src/ui/ui-helpers.ts`** : `renderPaletteSwatches(paletteKey?)`, `findDeptCodeField()`, `updateMapCodeFieldWarning()`.

--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -235,6 +235,14 @@
           <select class="fr-select" id="code-field">
             <option value="">— Charger les champs —</option>
           </select>
+          <!-- Avertissement affiché par updateMapCodeFieldWarning() quand aucun champ
+               de la source ne ressemble à un code INSEE valide (audit UX §m-B-6). -->
+          <div id="code-field-warning" class="field-warning" hidden>
+            <strong>Aucun code département détecté.</strong>
+            La source ne semble pas contenir de champ avec des codes INSEE
+            (01-95, 2A, 2B, 971-976). Convertissez vos noms de départements en
+            codes ou choisissez un autre type de graphique.
+          </div>
         </div>
 
         <!-- Tri -->
@@ -411,6 +419,8 @@
             <option value="divergentDescending">Bicolore (centre foncé)</option>
             <option value="neutral">Tons neutres (gris)</option>
           </select>
+          <!-- Aperçu visuel des couleurs de la palette sélectionnée. Rendu par renderPaletteSwatches(). -->
+          <div id="palette-swatches" class="palette-swatches" role="img" aria-label="Aperçu des couleurs de la palette"></div>
         </div>
 
         <!-- Options spécifiques KPI -->

--- a/apps/builder/src/main.ts
+++ b/apps/builder/src/main.ts
@@ -22,6 +22,7 @@ import {
   copyCode,
   toggleSection,
   syncFavoriteIcon,
+  renderPaletteSwatches,
 } from './ui/ui-helpers.js';
 import type { ChartType } from './state.js';
 import { setupDatalistListeners } from './ui/datalist-config.js';
@@ -75,8 +76,11 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (paletteSelect) {
     paletteSelect.addEventListener('change', (e) => {
       state.palette = (e.target as HTMLSelectElement).value;
+      renderPaletteSwatches(state.palette);
     });
   }
+  // Render initial swatches for the default palette on page load.
+  renderPaletteSwatches();
 
   // Field selects — track changes for preview steps
   const labelFieldSelect = document.getElementById('label-field') as HTMLSelectElement | null;

--- a/apps/builder/src/sources-fields.ts
+++ b/apps/builder/src/sources-fields.ts
@@ -4,6 +4,7 @@
  */
 
 import { state } from './state.js';
+import { updateMapCodeFieldWarning } from './ui/ui-helpers.js';
 
 /**
  * Populate label/value/code field dropdowns from state.fields.
@@ -57,22 +58,30 @@ export function populateFieldSelects(): void {
   const fieldNameLower = (f: { displayName?: string; name: string }): string =>
     (f.displayName || f.name).toLowerCase();
 
-  const stringField = state.fields.find(
-    (f) =>
-      f.type === 'string' &&
-      (fieldNameLower(f).includes('nom') ||
+  // Smart defaults (T-6 from audit UX 2026-05-26) : 1) prioritise field names
+  // matching domain keywords, 2) fall back to "the only candidate" when there
+  // is no ambiguity. Saves Marie one click on simple datasets.
+  const stringCandidates = state.fields.filter((f) => f.type === 'string');
+  const numberCandidates = state.fields.filter((f) => f.type === 'number');
+
+  const stringField =
+    stringCandidates.find(
+      (f) =>
+        fieldNameLower(f).includes('nom') ||
         fieldNameLower(f).includes('region') ||
         fieldNameLower(f).includes('departement') ||
-        fieldNameLower(f).includes('label'))
-  );
-  const numberField = state.fields.find(
-    (f) =>
-      f.type === 'number' &&
-      (fieldNameLower(f).includes('prix') ||
+        fieldNameLower(f).includes('label')
+    ) ?? (stringCandidates.length === 1 ? stringCandidates[0] : undefined);
+
+  const numberField =
+    numberCandidates.find(
+      (f) =>
+        fieldNameLower(f).includes('prix') ||
         fieldNameLower(f).includes('score') ||
         fieldNameLower(f).includes('valeur') ||
-        fieldNameLower(f).includes('value'))
-  );
+        fieldNameLower(f).includes('value')
+    ) ?? (numberCandidates.length === 1 ? numberCandidates[0] : undefined);
+
   // Auto-select code field for maps (look for code_dept, departement, code_insee, etc.)
   const codeField = state.fields.find(
     (f) =>
@@ -98,6 +107,9 @@ export function populateFieldSelects(): void {
 
   // Re-populate existing extra séries selects
   refreshExtraSeriesSelects();
+
+  // Re-evaluate the "no INSEE codes" warning now that the field list changed.
+  updateMapCodeFieldWarning();
 }
 
 /**

--- a/apps/builder/src/styles/builder.css
+++ b/apps/builder/src/styles/builder.css
@@ -809,3 +809,35 @@ h3 .help-btn i {
   text-decoration: line-through;
   text-decoration-color: rgba(0, 0, 0, 0.15);
 }
+
+/* Palette swatches — aperçu visuel des couleurs de la palette sélectionnée.
+   Affichés juste sous le select #chart-palette pour donner un feedback
+   visuel immédiat sur le rendu (audit UX 2026-05-26 §T-5). */
+.palette-swatches {
+  display: flex;
+  gap: 2px;
+  margin-top: 0.5rem;
+  height: 18px;
+  border-radius: 3px;
+  overflow: hidden;
+}
+.palette-swatches .palette-swatch {
+  flex: 1;
+  min-width: 12px;
+}
+
+/* Warning sous le select Code département quand la source ne contient
+   manifestement pas de codes INSEE (audit UX 2026-05-26 §m-B-6). */
+.field-warning {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-left: 3px solid var(--background-action-high-warning, #d97706);
+  background: var(--background-contrast-warning, #fef3c7);
+  border-radius: 0 3px 3px 0;
+  font-size: 0.8125rem;
+  color: var(--text-default-grey, #3a3a3a);
+  line-height: 1.4;
+}
+.field-warning[hidden] {
+  display: none;
+}

--- a/apps/builder/src/ui/chart-type-selector.ts
+++ b/apps/builder/src/ui/chart-type-selector.ts
@@ -5,6 +5,7 @@
 
 import { state, type ChartType } from '../state.js';
 import { initDatalistColumns } from './datalist-config.js';
+import { renderPaletteSwatches, updateMapCodeFieldWarning } from './ui-helpers.js';
 
 /**
  * Select a chart type and update the UI accordingly.
@@ -45,7 +46,13 @@ export function selectChartType(type: ChartType): void {
     state.palette = 'sequentialAscending';
     const paletteSelect = document.getElementById('chart-palette') as HTMLSelectElement | null;
     if (paletteSelect) paletteSelect.value = 'sequentialAscending';
+    renderPaletteSwatches(state.palette);
   }
+
+  // Warn the user if they pick "Carte départementale" on a source that doesn't
+  // actually contain INSEE codes (audit UX §m-B-6). Re-evaluated on every
+  // chart-type change since the warning only shows when chartType === 'map'.
+  updateMapCodeFieldWarning();
 
   // Label field: hide for single value types (KPI, gauge)
   const labelField = document.getElementById('label-field');

--- a/apps/builder/src/ui/ui-helpers.ts
+++ b/apps/builder/src/ui/ui-helpers.ts
@@ -12,6 +12,8 @@ import {
   toastInfo,
   navigateTo,
   promptDialog,
+  PALETTE_COLORS,
+  isValidDeptCode,
 } from '@dsfr-data/shared';
 import type { Favorite } from '../state.js';
 
@@ -80,6 +82,70 @@ export function openInPlayground(): void {
   sessionStorage.setItem('playground-code', code);
   // Redirect to the playground
   navigateTo('playground', { from: 'builder' });
+}
+
+/**
+ * Render the colour swatches preview right below the palette `<select>`,
+ * giving an immediate visual feedback on the selected palette without
+ * having to generate the chart (audit UX 2026-05-26 §T-5).
+ *
+ * Safe to call when the container is not mounted (no-op).
+ */
+export function renderPaletteSwatches(paletteKey: string = state.palette): void {
+  const container = document.getElementById('palette-swatches');
+  if (!container) return;
+  const colors = PALETTE_COLORS[paletteKey] ?? PALETTE_COLORS.default ?? [];
+  container.innerHTML = colors
+    .map((c) => `<span class="palette-swatch" style="background:${c}"></span>`)
+    .join('');
+}
+
+/**
+ * Detect whether the loaded source has a column that *looks like* it contains
+ * French INSEE department codes (sample-based validation via `isValidDeptCode`,
+ * not just name-matching). Used to warn the user when they pick "Carte
+ * départementale" on an incompatible source (audit UX §m-B-6).
+ *
+ * Returns the name of the best candidate column, or `null` if none qualifies.
+ */
+export function findDeptCodeField(): string | null {
+  const data = (state.data ?? state.localData ?? []) as Record<string, unknown>[];
+  if (!Array.isArray(data) || data.length === 0) return null;
+
+  // Only consider string/number fields (codes can be "2A" or numeric)
+  const candidates = state.fields.filter((f) => f.type === 'string' || f.type === 'number');
+  if (candidates.length === 0) return null;
+
+  const sample = data.slice(0, 50);
+  for (const field of candidates) {
+    let valid = 0;
+    let nonEmpty = 0;
+    for (const row of sample) {
+      const raw = row[field.name];
+      if (raw == null || raw === '') continue;
+      nonEmpty++;
+      if (isValidDeptCode(String(raw))) valid++;
+    }
+    // Accept the field if at least 80% of its non-empty sample values are valid codes
+    if (nonEmpty > 0 && valid / nonEmpty >= 0.8) return field.name;
+  }
+  return null;
+}
+
+/**
+ * Show or hide the warning below the `#code-field` select based on whether
+ * the loaded source actually contains valid INSEE department codes.
+ * Only relevant when the chart type is "map" (the warning element is hidden
+ * by the section toggle when not on map).
+ */
+export function updateMapCodeFieldWarning(): void {
+  const warning = document.getElementById('code-field-warning');
+  if (!warning) return;
+  if (state.chartType !== 'map' || state.fields.length === 0) {
+    warning.hidden = true;
+    return;
+  }
+  warning.hidden = findDeptCodeField() !== null;
 }
 
 /**

--- a/tests/apps/builder/sources-fields.test.ts
+++ b/tests/apps/builder/sources-fields.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { populateFieldSelects } from '../../../apps/builder/src/sources-fields';
 import { state } from '../../../apps/builder/src/state';
-import type { Field } from '../../../apps/builder/src/state';
 
 describe('builder sources-fields', () => {
   beforeEach(() => {
@@ -71,9 +70,7 @@ describe('builder sources-fields', () => {
   });
 
   it('should display field type in option text', () => {
-    state.fields = [
-      { name: 'score', type: 'number', sample: 42 },
-    ];
+    state.fields = [{ name: 'score', type: 'number', sample: 42 }];
     populateFieldSelects();
 
     const labelSelect = document.getElementById('label-field') as HTMLSelectElement;
@@ -83,7 +80,13 @@ describe('builder sources-fields', () => {
 
   it('should use displayName when available', () => {
     state.fields = [
-      { name: 'pop', displayName: 'Population', type: 'number', sample: 1000, fullPath: 'fields.pop' },
+      {
+        name: 'pop',
+        displayName: 'Population',
+        type: 'number',
+        sample: 1000,
+        fullPath: 'fields.pop',
+      },
     ];
     populateFieldSelects();
 
@@ -126,10 +129,14 @@ describe('builder sources-fields', () => {
       expect(codeSelect.value).toBe('code_dept');
     });
 
-    it('should not auto-select when no matching candidates', () => {
+    it('should not auto-select when several non-matching candidates exist', () => {
+      // 2+ string and 2+ number candidates, none matching domain keywords →
+      // ambiguous, leave the user choose.
       state.fields = [
         { name: 'x', type: 'string', sample: 'a' },
-        { name: 'y', type: 'number', sample: 1 },
+        { name: 'y', type: 'string', sample: 'b' },
+        { name: 'a', type: 'number', sample: 1 },
+        { name: 'b', type: 'number', sample: 2 },
       ];
       populateFieldSelects();
 
@@ -138,6 +145,22 @@ describe('builder sources-fields', () => {
       // No auto-selection: default option stays selected
       expect(labelSelect.value).toBe('');
       expect(valueSelect.value).toBe('');
+    });
+
+    it('should auto-select the only string/number field even without a keyword match (T-6)', () => {
+      // Smart-default fallback : if there is exactly one candidate of a given
+      // type, pre-select it (audit UX 2026-05-26 §T-6). Saves the user a click
+      // on simple datasets where there is no ambiguity.
+      state.fields = [
+        { name: 'x', type: 'string', sample: 'a' },
+        { name: 'y', type: 'number', sample: 1 },
+      ];
+      populateFieldSelects();
+
+      const labelSelect = document.getElementById('label-field') as HTMLSelectElement;
+      const valueSelect = document.getElementById('value-field') as HTMLSelectElement;
+      expect(labelSelect.value).toBe('x');
+      expect(valueSelect.value).toBe('y');
     });
   });
 });


### PR DESCRIPTION
3 quick wins indépendants de la **salve 2** du rapport d'audit UX 2026-05-26, prolongeant les patches polish déjà livrés (#217 batch 2). Pas d'issues GitHub dédiées (salve 2 reportée sans décomposition dans le plan `~/.claude/plans/je-veux-que-tu-vectorized-raven.md`).

## §m-B-6 — Warning carte départementale sans codes INSEE

**Avant** : sélection « Carte départementale » sur une source qui contient des noms (« Île-de-France »…) mais pas de codes département → select Code département reste vide silencieusement, carte ne s'affiche pas.

**Après** : détection automatique via la nouvelle fonction `findDeptCodeField()` qui parcourt les 50 premières lignes des champs string/number et valide via `isValidDeptCode()` (existant dans `@dsfr-data/shared`). Si au moins 80% des valeurs non-vides d'une colonne sont des codes valides, la colonne est considérée comme candidate. Sinon, encadré jaune actionnable :

> **Aucun code département détecté.** La source ne semble pas contenir de champ avec des codes INSEE (01-95, 2A, 2B, 971-976). Convertissez vos noms de départements en codes ou choisissez un autre type de graphique.

Re-évalué automatiquement quand : (1) le type de graphique change vers/depuis `map`, (2) une source est chargée et `populateFieldSelects()` est appelée.

## §T-5 — Aperçus visuels des palettes

Nouveau strip de swatches sous le select `#chart-palette` qui affiche les 5 couleurs de la palette sélectionnée. Pour Marie (P1), un libellé comme « Dégradé clair → foncé » est plus parlant qu'un nom technique, mais voir effectivement les couleurs vaut mille mots.

Mis à jour : (1) au chargement de la page, (2) à chaque changement manuel de palette, (3) à l'auto-swap vers `sequentialAscending` quand le type passe en `map`.

Utilise `PALETTE_COLORS` déjà exporté depuis `@dsfr-data/shared`. CSS minimal (~10 lignes : flex row de spans avec background-color).

## §T-6 — Pré-sélection automatique du seul candidat

`populateFieldSelects()` faisait déjà la pré-sélection par mot-clé (« nom » / « region » / « departement » / « label » pour étiquettes ; « prix » / « score » / « valeur » / « value » pour valeurs numériques).

**Nouveau fallback** : si aucun mot-clé ne matche mais qu'il n'y a **qu'un seul candidat** du bon type (string pour étiquettes, number pour valeurs), on le pré-sélectionne quand même. Économise un clic sur les datasets simples sans ambiguïté.

Exemple concret : source `{region, population}` → les 2 champs auto-remplis dès le chargement (avant la PR, « population » n'était pas pré-sélectionné car le mot ne contient pas « valeur »/« value »).

Test ajouté : `tests/apps/builder/sources-fields.test.ts:'should auto-select the only string/number field even without a keyword match (T-6)'`. Test existant adapté (« no auto-select » nécessite désormais 2+ candidats non-matchants pour caractériser l'ambiguïté).

## Nouveaux exports

Dans `apps/builder/src/ui/ui-helpers.ts` :
- `renderPaletteSwatches(paletteKey?)` — peuple `#palette-swatches` avec les couleurs de la palette
- `findDeptCodeField()` — retourne le nom du champ qui contient des codes INSEE valides, ou `null`
- `updateMapCodeFieldWarning()` — affiche/masque `#code-field-warning` selon le chartType et la détection

**Bonus hygiène** : `Field` import inutilisé retiré du test `sources-fields.test.ts` (pré-existant, surfacé par lint-staged sur cette PR).

## Test plan

- [ ] `npm run dev` → Builder : observer le strip de couleurs sous le select Palette de couleurs. Changer la palette → swatches mis à jour. Passer le type en « Carte départementale » → palette auto-swap vers « Dégradé clair → foncé » + swatches mis à jour.
- [ ] Builder : créer une source manuelle `{region: 'Bretagne', population: 3000000}` (sans champ `code_dept`) → sélectionner type « Carte départementale » → vérifier l'encadré jaune « Aucun code département détecté ». Ajouter un champ `code: '35'` → encadré disparaît.
- [ ] Builder : créer une source `{x: 'a', y: 1}` (noms qui ne matchent aucun mot-clé) → vérifier que `x` est auto-sélectionné comme Étiquettes et `y` comme Valeur (sans avoir besoin de cliquer).
- [ ] Builder : créer une source `{a: 1, b: 2, c: 3}` (3 numbers, 0 string) → vérifier qu'aucun champ n'est pré-sélectionné en Étiquettes (pas de string) ET qu'aucun champ n'est pré-sélectionné en Valeur (ambiguïté entre 3 numerics).

## CI / tests automatisés

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test:run` ✅ (**2947/2947** — +1 test pour T-6)
- `npm run check:accents` ✅
- `npm run build --workspace=@dsfr-data/app-builder` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)