### PR TITLE
fix(ci): exclude CHANGELOG.md from check:accents

### DIFF
--- a/scripts/check-french-accents.sh
+++ b/scripts/check-french-accents.sh
@@ -71,10 +71,13 @@ joined=$(IFS='|'; echo "${PATTERNS[*]}")
 
 # Use git grep so .gitignore is honoured automatically.
 # -E: ERE alternation, -w: word boundaries, -n: line numbers, --: end of options.
+# CHANGELOG.md is excluded by design: it documents past mistakes ("avant : donnees,
+# après : données") and contains the unaccented forms as quoted examples.
 if matches=$(git grep -nwE "(${joined})" -- \
       "apps/**/*.ts" "apps/**/*.html" "apps/**/*.css" "apps/**/*.md" \
       "packages/**/*.ts" "packages/**/*.html" "packages/**/*.css" "packages/**/*.md" \
-      ':!**/dist/**' ':!**/node_modules/**' ':!**/*.min.*' 2>/dev/null); then
+      ':!**/dist/**' ':!**/node_modules/**' ':!**/*.min.*' \
+      ':!**/CHANGELOG.md' ':!**/CHANGELOG*' 2>/dev/null); then
   count=$(printf '%s\n' "$matches" | wc -l | tr -d ' ')
   printf '\n\033[31m✗ %d unaccented French word(s) found in UI source files:\033[0m\n\n' "$count"
   printf '%s\n' "$matches"


### PR DESCRIPTION
Hotfix : le job CI \`quality\` a fail sur le merge du release commit \`9758350\` (release \`dsfr-data@0.7.2\`) parce que \`packages/core/CHANGELOG.md\` (généré par Changesets) contient les mots non-accentués \`donnees\`, \`categorie\`, \`Apercu\`, \`Genere\`, etc.

**Pas comme libellés UI**, mais comme **exemples cités** de ce qui a été corrigé (« Avant : labels … écrits sans accents partout (« donnees », « categorie », … )»).

## Cause

Le pattern d'exclusion \`CHANGELOG\` existait déjà dans le script Python local \`restore_french_accents.py\` (utilisé pour les remplacements en batch 2 #214) mais avait été oublié dans le script bash CI \`scripts/check-french-accents.sh\` créé dans la même PR. Bug latent qui s'est manifesté à la **première release** consumant les changesets référençant ces mots dans leurs bodies.

## Fix

Ajout de \`':!**/CHANGELOG.md' ':!**/CHANGELOG*'\` aux exclusions de \`git grep\` dans le script.

Sans ce fix, **chaque future release régénérant un CHANGELOG.md** mentionnant les anciens libellés non-accentués déclencherait un fail CI.

## Vérification locale

\`\`\`bash
$ npm run check:accents
✓ No unaccented French words found in UI source files.
\`\`\`

## Conséquence pour la release 0.7.2

Le release commit \`9758350\` est déjà sur main, le job \`Release\` a aussi fail mais pour une **raison différente** (NPM 404 — token expiré ou perm perdue sur le package, voir log : \`E404 Not Found - PUT https://registry.npmjs.org/dsfr-data\`).

Marche à suivre pour shipper effectivement \`0.7.2\` :
1. Merger cette PR (corrige le \`check:accents\` qui bloquera toute future release)
2. Régénérer le \`NPM_TOKEN\` côté npmjs.com (Automation token avec scope publish), mettre à jour le secret GitHub \`NPM_TOKEN\` du repo
3. Relancer le workflow \`Release\` (\`gh run rerun 26516733820\` ou re-trigger via UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)