### PR TITLE
feat(mcp): generate_widget_code connaît la prep de données (normalize + unpivot)

### DIFF
--- a/mcp-server/src/skills.ts
+++ b/mcp-server/src/skills.ts
@@ -25,6 +25,12 @@ export function getWidgetSkillIds(chartType?: string): string[] {
   const ids = [
     'compositionPatterns',
     'dsfrDataSource',
+    // Préparation des données : nettoyage/typage (compute, decimales FR) et bascule
+    // des tableurs "wide" (temps dans les noms de colonnes) via dsfr-data-unpivot.
+    // Pertinent quelle que soit la visualisation → toujours injecté pour que la
+    // génération connaisse le pipeline complet (source → unpivot → normalize → query → chart).
+    'dsfrDataNormalize',
+    'dsfrDataUnpivot',
     'dsfrDataChart',
     'apiProviders',
     'troubleshooting',

--- a/tests/mcp/skills.test.ts
+++ b/tests/mcp/skills.test.ts
@@ -24,6 +24,9 @@ function getWidgetSkillIds(chartType?: string): string[] {
   const ids = [
     'compositionPatterns',
     'dsfrDataSource',
+    // Préparation des données : nettoyage/typage et bascule des tableurs "wide".
+    'dsfrDataNormalize',
+    'dsfrDataUnpivot',
     'dsfrDataChart',
     'apiProviders',
     'troubleshooting',
@@ -214,6 +217,16 @@ describe('getWidgetSkillIds', () => {
   it('has no duplicates', () => {
     const ids = getWidgetSkillIds();
     expect(ids.length).toBe(new Set(ids).size);
+  });
+
+  it('inclut toujours les skills de preparation des donnees (normalize + unpivot)', () => {
+    // Pipeline complet : la generation doit connaitre le nettoyage et la bascule
+    // des tableurs "wide", quel que soit le type de graphique.
+    for (const type of [undefined, 'bar', 'kpi', 'map', 'datalist']) {
+      const ids = getWidgetSkillIds(type);
+      expect(ids, `type=${type}`).toContain('dsfrDataNormalize');
+      expect(ids, `type=${type}`).toContain('dsfrDataUnpivot');
+    }
   });
 });
 


### PR DESCRIPTION
## But

Aligner l'outil MCP **`generate_widget_code`** sur l'epic A : il n'injectait que des skills *orientés graphique*, et ignorait la **préparation de données**. Désormais `getWidgetSkillIds()` ajoute **`dsfrDataNormalize`** et **`dsfrDataUnpivot`** au set de base — quel que soit le type de graphique.

## Pourquoi

Après l'epic A (#223), la lib sait consommer un tableur **« wide »** sans JS (`unpivot → compute → series-field`). Mais la génération de code via MCP ne proposait jamais ce pipeline : un agent générant un widget ne « voyait » ni le nettoyage/typage, ni la bascule des colonnes-temps. C'était le seul maillon MCP non aligné (le contenu des skills, lui, se propage déjà via `skills.json`).

## Détail

- `mcp-server/src/skills.ts` : `dsfrDataNormalize` + `dsfrDataUnpivot` ajoutés au tableau `ids` de base.
- Robustesse : les ids absents d'un `skills.json` plus ancien restent filtrés (`.filter(Boolean)`) côté serveur → aucune régression.
- `tests/mcp/skills.test.ts` (qui ré-implémente les fonctions pures) mis à jour + assertion couvrant tous les types.

## Validation

- `tests/mcp/skills.test.ts` : **26 verts**.
- `mcp-server` build (`tsc`) OK.
- Pas de changeset (hors `packages/core`/`packages/shared`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)