### PR TITLE
fix(mcp): 404 (au lieu de 400) sur session inconnue → recovery auto après redémarrage

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -26,7 +26,7 @@ import { createServer } from 'node:http';
 import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
 import { z } from 'zod';
 import { getArg, hasFlag } from './cli.js';
-import { matchSkills, getWidgetSkillIds } from './skills.js';
+import { matchSkills, getWidgetSkillIds, routeMcpRequest } from './skills.js';
 import type { Skill } from './skills.js';
 
 // ---------------------------------------------------------------------------
@@ -271,12 +271,17 @@ async function startHttp() {
 
     // Get or create session
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    const route = routeMcpRequest({
+      sessionId,
+      hasSession: !!(sessionId && sessions.has(sessionId)),
+      method: req.method,
+    });
 
-    if (sessionId && sessions.has(sessionId)) {
+    if (route === 'existing') {
       // Existing session
-      const session = sessions.get(sessionId)!;
+      const session = sessions.get(sessionId!)!;
       await session.transport.handleRequest(req, res);
-    } else if (!sessionId && req.method === 'POST') {
+    } else if (route === 'init') {
       // New session (initialization)
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => crypto.randomUUID(),
@@ -300,6 +305,20 @@ async function startHttp() {
         sessions.set(transport.sessionId, { server, transport });
         console.error(`[dsfr-data-mcp] New session ${transport.sessionId} (${sessions.size} active)`);
       }
+    } else if (route === 'not-found') {
+      // Session id présent mais inconnu (souvent : le serveur a redémarré et a
+      // perdu ses sessions en mémoire). 404 — et non 400 — pour que le client MCP
+      // ré-initialise automatiquement une session fraîche (spec StreamableHTTP).
+      // Sinon le connecteur reste bloqué et tous les appels d'outils échouent.
+      console.error(`[dsfr-data-mcp] Unknown session ${sessionId} → 404 (client should re-initialize)`);
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32001, message: 'Session not found' },
+          id: null,
+        }),
+      );
     } else {
       res.writeHead(400, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: 'Invalid request. Missing or unknown session ID.' }));

--- a/mcp-server/src/skills.ts
+++ b/mcp-server/src/skills.ts
@@ -11,6 +11,30 @@ export interface Skill {
 }
 
 /**
+ * Routing decision for an incoming HTTP MCP request, based on its session id.
+ *
+ * Extracted (pure) for testability. Key point: a request carrying a session id
+ * the server doesn't know — typically because the server restarted and lost its
+ * in-memory sessions — must be answered with 404 (`not-found`), NOT 400. The
+ * StreamableHTTP spec lets the client re-initialize a fresh session on 404;
+ * a 400 leaves the client stuck (every tool call keeps failing) until it is
+ * manually reconnected.
+ */
+export type McpRequestRoute = 'existing' | 'init' | 'not-found' | 'bad-request';
+
+export function routeMcpRequest(opts: {
+  sessionId?: string;
+  hasSession: boolean;
+  method?: string;
+}): McpRequestRoute {
+  const { sessionId, hasSession, method } = opts;
+  if (sessionId && hasSession) return 'existing';
+  if (!sessionId && method === 'POST') return 'init';
+  if (sessionId && !hasSession) return 'not-found'; // stale session → 404 → client re-inits
+  return 'bad-request';
+}
+
+/**
  * Match skills whose triggers appear in the given message (case-insensitive).
  */
 export function matchSkills(skills: Skill[], message: string): Skill[] {

--- a/tests/mcp/skills.test.ts
+++ b/tests/mcp/skills.test.ts
@@ -57,6 +57,20 @@ function getWidgetSkillIds(chartType?: string): string[] {
   return [...new Set(ids)];
 }
 
+type McpRequestRoute = 'existing' | 'init' | 'not-found' | 'bad-request';
+
+function routeMcpRequest(opts: {
+  sessionId?: string;
+  hasSession: boolean;
+  method?: string;
+}): McpRequestRoute {
+  const { sessionId, hasSession, method } = opts;
+  if (sessionId && hasSession) return 'existing';
+  if (!sessionId && method === 'POST') return 'init';
+  if (sessionId && !hasSession) return 'not-found';
+  return 'bad-request';
+}
+
 function getArg(argv: string[], flag: string): string | undefined {
   const idx = argv.indexOf(flag);
   if (idx !== -1 && argv[idx + 1] && !argv[idx + 1].startsWith('--')) {
@@ -233,6 +247,40 @@ describe('getWidgetSkillIds', () => {
 // ---------------------------------------------------------------------------
 // Tests: CLI argument parsing
 // ---------------------------------------------------------------------------
+
+describe('routeMcpRequest', () => {
+  it('route une session connue vers le transport existant', () => {
+    expect(routeMcpRequest({ sessionId: 'abc', hasSession: true, method: 'POST' })).toBe(
+      'existing'
+    );
+  });
+
+  it('initialise une nouvelle session sur POST sans session id', () => {
+    expect(routeMcpRequest({ sessionId: undefined, hasSession: false, method: 'POST' })).toBe(
+      'init'
+    );
+  });
+
+  it('renvoie not-found (→ 404) pour une session id inconnue/perimee', () => {
+    // Cas du serveur redemarre : la session en memoire a disparu. Doit aboutir
+    // a un 404 pour que le client MCP re-initialise au lieu de rester bloque.
+    expect(routeMcpRequest({ sessionId: 'stale', hasSession: false, method: 'POST' })).toBe(
+      'not-found'
+    );
+    expect(routeMcpRequest({ sessionId: 'stale', hasSession: false, method: 'GET' })).toBe(
+      'not-found'
+    );
+  });
+
+  it('renvoie bad-request quand ni session ni POST d-initialisation', () => {
+    expect(routeMcpRequest({ sessionId: undefined, hasSession: false, method: 'GET' })).toBe(
+      'bad-request'
+    );
+    expect(routeMcpRequest({ sessionId: undefined, hasSession: false, method: 'DELETE' })).toBe(
+      'bad-request'
+    );
+  });
+});
 
 describe('getArg', () => {
   it('returns value after flag', () => {


### PR DESCRIPTION
## Symptôme

Après le merge/redéploiement précédent, le connecteur **ChartsBuilder** (claude.ai) échouait sur **chaque outil** : `Error occurred during tool execution` + un `request_id`, sans détail. Les logs serveur ne montraient aucune exception.

## Diagnostic

Le serveur MCP est **sain** — vérifié de bout en bout : stdio local ✓, et **HTTP live** (`https://chartsbuilder.matge.com/mcp`) ✓ pour `list_skills` et `generate_widget_code`, sous protocole `2024-11-05` **et** `2025-06-18`.

La cause est un **cycle de session cassé** :
1. Les sessions HTTP sont stockées **en mémoire** (`Map`, `index.ts`).
2. Le redéploiement **redémarre le conteneur** → sessions perdues.
3. Le connecteur claude.ai garde sa `mcp-session-id` d'avant → chaque appel arrive avec une session inconnue.
4. **Le serveur répondait `400`** à ces sessions périmées. Or la spec StreamableHTTP attend un **`404`** pour signaler au client qu'il doit ré-initialiser. Avec un `400`, le connecteur restait **bloqué** (tous les outils KO) jusqu'à reconnexion manuelle.

Reproduit : `POST /mcp` avec une `mcp-session-id` inconnue → `400 {"error":"Invalid request. Missing or unknown session ID."}`.

## Fix

`routeMcpRequest()` (helper pur, testable) distingue le cas **session fournie mais inconnue** → réponse **`404`** + erreur JSON-RPC `-32001 Session not found`, au lieu du `400` générique. Le client MCP ré-initialise alors une session fraîche **automatiquement** → le serveur devient **résilient à chaque redéploiement**.

## Validation

- Serveur HTTP buildé en local : session inconnue → **404** (`Session not found`), `initialize` → **200**.
- Tests unitaires `routeMcpRequest` (existing / init / not-found / bad-request) → **30 verts**.
- `mcp-server` build (`tsc`) OK. Pas de changeset (hors `packages/core`/`shared`).

## Débloquage immédiat (en attendant le déploiement)

Reconnecter le connecteur ChartsBuilder dans claude.ai force un `initialize` → session fraîche → ça remarche tout de suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)