### PR TITLE
feat(builder-ia): assistant Albert agentique (structured outputs + tools) + refonte UX du chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -210,5 +210,14 @@ APP_DOMAIN=chartsbuilder.matge.com
 # Obtenir un token Albert : https://albert.api.etalab.gouv.fr
 #
 # IA_DEFAULT_API_URL=https://albert.api.etalab.gouv.fr/v1/chat/completions
-# IA_DEFAULT_MODEL=albert-large
+# IA_DEFAULT_MODEL=openweight-large
 # IA_DEFAULT_TOKEN=
+#
+# Modeles Albert (depuis la modernisation 2025) :
+#   openweight-large  = openai/gpt-oss-120b (recommande, supporte tools + structured outputs)
+#   openweight-medium = mistralai/Mistral-Small-24B   (ex-"albert-large")
+#   openweight-small  = mistralai/Ministral-3-8B
+# NOTE : le tool-calling (boucle agentique) exige cote gateway vLLM les flags
+#   --tool-call-parser openai --enable-auto-tool-choice. A defaut, builder-ia
+#   retombe sur les structured outputs (response_format json_schema) puis, en
+#   dernier recours, sur le parsing legacy. Verifier avec : npx tsx scripts/probe-albert.ts

--- a/apps/builder-ia/index.html
+++ b/apps/builder-ia/index.html
@@ -34,7 +34,7 @@
       <!-- Source de données + Config IA -->
       <div class="config-section" id="section-source">
         <div class="config-section-header" onclick="toggleSection('section-source')">
-          <h3><i class="ri-database-2-line"></i> Source de données</h3>
+          <h3><i class="ri-database-2-line"></i> Source de données <span id="source-summary" class="config-section-summary"></span></h3>
           <i class="ri-arrow-down-s-line collapse-icon"></i>
         </div>
         <div class="config-section-content">

--- a/apps/builder-ia/index.html
+++ b/apps/builder-ia/index.html
@@ -85,11 +85,18 @@
           </div>
           <div class="fr-input-group">
             <label class="fr-label" for="ia-model">Modele
-              <span class="fr-hint-text">Identifiant du modele (ex: albert-large, gpt-4o, claude-sonnet-4-5-20250929...)</span>
+              <span class="fr-hint-text">Albert : openweight-large = gpt-oss-120b (recommande). Tool-calling/structured outputs supportes par le gateway.</span>
             </label>
-            <input class="fr-input" type="text" id="ia-model"
-                   value="albert-large"
-                   placeholder="albert-large">
+            <select class="fr-select" id="ia-model" onchange="onModelSelectChange()">
+              <option value="openweight-large">openweight-large (gpt-oss-120b) — recommande</option>
+              <option value="openweight-medium">openweight-medium (Mistral-Small-24B)</option>
+              <option value="openweight-small">openweight-small</option>
+              <option value="albert-large">albert-large (alias historique)</option>
+              <option value="__custom__">Personnalise…</option>
+            </select>
+            <input class="fr-input" type="text" id="ia-model-custom"
+                   placeholder="ex: gpt-4o, claude-sonnet-4-5-20250929, mistral-large-latest"
+                   style="display:none;margin-top:0.5rem;">
           </div>
           <div class="fr-input-group">
             <label class="fr-label" for="ia-token">Token API
@@ -104,7 +111,7 @@
             <div id="ia-extra-params">
               <div class="ia-extra-param-row" style="display:flex;gap:0.5rem;margin-bottom:0.5rem;align-items:center;">
                 <input class="fr-input" type="text" placeholder="clé" value="temperature" style="flex:1;">
-                <input class="fr-input" type="text" placeholder="valeur" value="0.7" style="flex:1;">
+                <input class="fr-input" type="text" placeholder="valeur" value="0.2" style="flex:1;">
                 <button class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline" type="button" onclick="this.parentElement.remove()" title="Supprimer"><i class="ri-delete-bin-line"></i></button>
               </div>
               <div class="ia-extra-param-row" style="display:flex;gap:0.5rem;margin-bottom:0.5rem;align-items:center;">

--- a/apps/builder-ia/src/chat/chat.ts
+++ b/apps/builder-ia/src/chat/chat.ts
@@ -25,7 +25,7 @@ import type { ActionResult } from '../ia/action-schema.js';
  */
 type AICallResult =
   | { kind: 'raw'; raw: string }
-  | { kind: 'action'; action: ActionResult | null; text: string };
+  | { kind: 'action'; action: ActionResult | null; text: string; steps?: string[] };
 
 /**
  * Add a message to the chat UI and state
@@ -33,7 +33,8 @@ type AICallResult =
 export function addMessage(
   role: 'user' | 'assistant',
   content: string,
-  suggestions: string[] = []
+  suggestions: string[] = [],
+  reasoningSteps: string[] = []
 ): HTMLElement {
   const container = document.getElementById('chat-messages') as HTMLElement;
 
@@ -68,7 +69,28 @@ export function addMessage(
     messageEl.appendChild(suggestionsEl);
   }
 
+  // Raisonnement agentique persistant : bloc repliable (ferme par defaut) accole
+  // a la reponse. P1 ne le deplie jamais ; P2 l'ouvre pour auditer les etapes.
+  if (reasoningSteps.length > 0 && role === 'assistant') {
+    const details = document.createElement('details');
+    details.className = 'chat-reasoning';
+    const summary = document.createElement('summary');
+    const n = reasoningSteps.length;
+    summary.textContent = `Raisonnement de l'assistant (${n} etape${n > 1 ? 's' : ''})`;
+    details.appendChild(summary);
+    const ul = document.createElement('ul');
+    reasoningSteps.forEach((s) => {
+      const li = document.createElement('li');
+      li.textContent = s; // textContent : pas d'injection HTML
+      ul.appendChild(li);
+    });
+    details.appendChild(ul);
+    messageEl.appendChild(details);
+  }
+
   container.appendChild(messageEl);
+  // Autoscroll vers le dernier message (pattern chat IA moderne) : les anciens
+  // messages defilent par le haut, le plus recent reste visible pres de l'input.
   container.scrollTop = container.scrollHeight;
 
   state.messages.push({ role, content } as Message);
@@ -98,12 +120,25 @@ export function addThinkingMessage(): HTMLElement {
 }
 
 /**
- * Update the thinking indicator label (used by the agentic loop to surface
- * intermediate steps like "Consultation : get_relevant_skills").
+ * Render the cumulative agentic steps live in the thinking indicator: completed
+ * steps with a check, the latest one with the spinner.
  */
-export function updateThinkingMessage(label: string): void {
+export function renderThinkingSteps(steps: string[]): void {
   const el = document.getElementById('thinking-message');
-  if (el) el.innerHTML = `<i class="ri-loader-4-line"></i> ${escapeHtml(label)}`;
+  if (!el) return;
+  if (steps.length === 0) {
+    el.innerHTML = '<i class="ri-loader-4-line"></i> Reflexion en cours...';
+    return;
+  }
+  el.innerHTML = steps
+    .map((s, i) => {
+      const last = i === steps.length - 1;
+      const icon = last ? 'ri-loader-4-line' : 'ri-check-line';
+      return `<div class="chat-step"><i class="${icon}"></i> ${escapeHtml(s)}</div>`;
+    })
+    .join('');
+  const container = document.getElementById('chat-messages');
+  if (container) container.scrollTop = container.scrollHeight;
 }
 
 /**
@@ -178,6 +213,8 @@ En attendant, je peux vous aider avec des commandes simples. Essayez :
       action = result.action as Record<string, unknown> | null;
       textWithoutJson = result.text;
     }
+    // Etapes de raisonnement agentique a accoler a la reponse finale (mode tools).
+    const reasoning = result.kind === 'action' ? (result.steps ?? []) : [];
 
     if (action?.action === 'createChart' && action.config) {
       applyChartConfig(action.config as ChartConfig);
@@ -204,14 +241,16 @@ En attendant, je peux vous aider avec des commandes simples. Essayez :
         'assistant',
         textWithoutJson ||
           (chartConfig.type === 'datalist' ? 'Voici votre tableau !' : 'Voici votre graphique !'),
-        suggestions
+        suggestions,
+        reasoning
       );
     } else if (action?.action === 'resetChart') {
       resetChartPreview();
       addMessage(
         'assistant',
         textWithoutJson || 'Aperçu reinitialise ! Decrivez le graphique que vous souhaitez créer.',
-        ['Barres', 'Camembert', 'Courbe', 'Tableau', 'KPI']
+        ['Barres', 'Camembert', 'Courbe', 'Tableau', 'KPI'],
+        reasoning
       );
     } else if (action?.action === 'reloadData') {
       const success = await handleReloadData(action);
@@ -219,16 +258,19 @@ En attendant, je peux vous aider avec des commandes simples. Essayez :
         addMessage(
           'assistant',
           textWithoutJson || (action.reason as string) || 'Données rechargees avec les filtres.',
-          ['Barres', 'Camembert', 'Courbe']
+          ['Barres', 'Camembert', 'Courbe'],
+          reasoning
         );
       } else {
         addMessage(
           'assistant',
-          textWithoutJson || 'Impossible de recharger les données avec ces filtres.'
+          textWithoutJson || 'Impossible de recharger les données avec ces filtres.',
+          [],
+          reasoning
         );
       }
     } else {
-      addMessage('assistant', result.kind === 'raw' ? result.raw : textWithoutJson);
+      addMessage('assistant', result.kind === 'raw' ? result.raw : textWithoutJson, [], reasoning);
     }
   } catch (error: unknown) {
     removeThinkingMessage();
@@ -277,7 +319,11 @@ Exemple d'enregistrement : ${JSON.stringify(state.localData[0])}${paginationNote
  * Build the legacy full system prompt (everything stuffed in) — used by the
  * legacy OpenAI path and by the Gemini / Anthropic branches (unchanged behavior).
  */
-function buildLegacySystemPrompt(userMessage: string, config: IAConfig, dataContext: string): string {
+function buildLegacySystemPrompt(
+  userMessage: string,
+  config: IAConfig,
+  dataContext: string
+): string {
   const relevantSkills = getRelevantSkills(userMessage, state.source);
   const skillsContext = buildSkillsContext(relevantSkills);
   const skillsList = Object.values(SKILLS)
@@ -371,7 +417,11 @@ async function callAlbertAPI(userMessage: string, config: IAConfig): Promise<AIC
   ): Promise<Record<string, unknown>> {
     const response = await fetchWithTimeout(
       endpoint,
-      { method: 'POST', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify(body) },
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: JSON.stringify(body),
+      },
       timeout
     );
     if (!response.ok) {
@@ -384,7 +434,9 @@ async function callAlbertAPI(userMessage: string, config: IAConfig): Promise<AIC
         /* ignore parse errors */
       }
       throw new Error(
-        detail ? `${httpErrorMessage(response.status)} (${detail})` : httpErrorMessage(response.status)
+        detail
+          ? `${httpErrorMessage(response.status)} (${detail})`
+          : httpErrorMessage(response.status)
       );
     }
     return response.json();
@@ -448,7 +500,8 @@ async function callAlbertAPI(userMessage: string, config: IAConfig): Promise<AIC
     for (const [key, val] of Object.entries(config.extraParams || {})) {
       const num = Number(val);
       const parsed = !isNaN(num) && val !== '' ? num : val;
-      if (key === 'max_tokens' || key === 'maxOutputTokens') generationConfig.maxOutputTokens = parsed;
+      if (key === 'max_tokens' || key === 'maxOutputTokens')
+        generationConfig.maxOutputTokens = parsed;
       else if (key === 'top_p') generationConfig.topP = parsed;
       else if (key === 'top_k') generationConfig.topK = parsed;
       else generationConfig[key] = parsed;
@@ -456,9 +509,13 @@ async function callAlbertAPI(userMessage: string, config: IAConfig): Promise<AIC
     if (Object.keys(generationConfig).length > 0) requestBody.generationConfig = generationConfig;
 
     const separator = config.apiUrl.includes('?') ? '&' : '?';
-    const data = await postProxy('/ia-proxy', {
-      'X-Target-URL': `${config.apiUrl}${separator}key=${config.token}`,
-    }, requestBody);
+    const data = await postProxy(
+      '/ia-proxy',
+      {
+        'X-Target-URL': `${config.apiUrl}${separator}key=${config.token}`,
+      },
+      requestBody
+    );
     const candidates = data.candidates as { content: { parts: { text: string }[] } }[];
     return { kind: 'raw', raw: candidates[0].content.parts[0].text };
   }
@@ -475,11 +532,15 @@ async function callAlbertAPI(userMessage: string, config: IAConfig): Promise<AIC
       const num = Number(val);
       requestBody[key] = !isNaN(num) && val !== '' ? num : val;
     }
-    const data = await postProxy('/ia-proxy', {
-      'X-Target-URL': config.apiUrl,
-      'x-api-key': config.token,
-      'anthropic-version': '2023-06-01',
-    }, requestBody);
+    const data = await postProxy(
+      '/ia-proxy',
+      {
+        'X-Target-URL': config.apiUrl,
+        'x-api-key': config.token,
+        'anthropic-version': '2023-06-01',
+      },
+      requestBody
+    );
     const content = data.content as { text: string }[];
     return { kind: 'raw', raw: content[0].text };
   }
@@ -490,19 +551,23 @@ async function callAlbertAPI(userMessage: string, config: IAConfig): Promise<AIC
 
   // --- Tools / agentic loop -------------------------------------------------
   if (caps.toolCalling) {
-    const systemPrompt = buildSystemPrompt({ mode: 'tools', basePrompt: config.systemPrompt, dataContext });
+    const systemPrompt = buildSystemPrompt({
+      mode: 'tools',
+      basePrompt: config.systemPrompt,
+      dataContext,
+    });
     const result = await runAgentLoop({
       conversation: conversationMessages,
       systemPrompt,
       source: state.source,
       post: postOpenAI(45000),
-      onProgress: (label) => updateThinkingMessage(label),
+      onProgress: (steps) => renderThinkingSteps(steps),
       model: config.model,
       temperature: temperature ?? STRUCTURED_DEFAULT_TEMPERATURE,
       seed,
       extra,
     });
-    return { kind: 'action', action: result.action, text: result.text };
+    return { kind: 'action', action: result.action, text: result.text, steps: result.steps };
   }
 
   // --- Structured outputs (json_schema) -------------------------------------

--- a/apps/builder-ia/src/chat/chat.ts
+++ b/apps/builder-ia/src/chat/chat.ts
@@ -21,7 +21,7 @@ import type { ActionResult } from '../ia/action-schema.js';
  * Resultat d'un appel IA.
  * - `raw`    : reponse texte brute (chemins legacy / Gemini / Anthropic) — parsee
  *              en aval par extractAction/repairAction.
- * - `action` : action deja validee (chemins structured / tools) + texte a afficher.
+ * - `action` : action déjà validée (chemins structured / tools) + texte à afficher.
  */
 type AICallResult =
   | { kind: 'raw'; raw: string }
@@ -69,7 +69,7 @@ export function addMessage(
     messageEl.appendChild(suggestionsEl);
   }
 
-  // Raisonnement agentique persistant : bloc repliable (ferme par defaut) accole
+  // Raisonnement agentique persistant : bloc repliable (ferme par défaut) accole
   // a la reponse. P1 ne le deplie jamais ; P2 l'ouvre pour auditer les etapes.
   if (reasoningSteps.length > 0 && role === 'assistant') {
     const details = document.createElement('details');

--- a/apps/builder-ia/src/chat/chat.ts
+++ b/apps/builder-ia/src/chat/chat.ts
@@ -10,6 +10,22 @@ import { SKILLS, getRelevantSkills, buildSkillsContext } from '../skills.js';
 import { applyChartConfig, resetChartPreview } from '../ui/chart-renderer.js';
 import { analyzeFields, updateFieldsList, updateRawData } from '../sources.js';
 import { fetchWithTimeout, httpErrorMessage, detectProvider, escapeHtml } from '@dsfr-data/shared';
+import { effectiveCapabilities } from '../ia/albert-capabilities.js';
+import { buildSystemPrompt, buildFewShot } from '../ia/system-prompt.js';
+import { runAgentLoop } from '../ia/agent-loop.js';
+import type { PostChat, OpenAIResponse } from '../ia/agent-loop.js';
+import { ACTION_JSON_SCHEMA, validateAction } from '../ia/action-schema.js';
+import type { ActionResult } from '../ia/action-schema.js';
+
+/**
+ * Resultat d'un appel IA.
+ * - `raw`    : reponse texte brute (chemins legacy / Gemini / Anthropic) — parsee
+ *              en aval par extractAction/repairAction.
+ * - `action` : action deja validee (chemins structured / tools) + texte a afficher.
+ */
+type AICallResult =
+  | { kind: 'raw'; raw: string }
+  | { kind: 'action'; action: ActionResult | null; text: string };
 
 /**
  * Add a message to the chat UI and state
@@ -82,6 +98,15 @@ export function addThinkingMessage(): HTMLElement {
 }
 
 /**
+ * Update the thinking indicator label (used by the agentic loop to surface
+ * intermediate steps like "Consultation : get_relevant_skills").
+ */
+export function updateThinkingMessage(label: string): void {
+  const el = document.getElementById('thinking-message');
+  if (el) el.innerHTML = `<i class="ri-loader-4-line"></i> ${escapeHtml(label)}`;
+}
+
+/**
  * Remove the thinking indicator
  */
 export function removeThinkingMessage(): void {
@@ -138,12 +163,21 @@ En attendant, je peux vous aider avec des commandes simples. Essayez :
   addThinkingMessage();
 
   try {
-    const response = await callAlbertAPI(message, config);
+    const result = await callAlbertAPI(message, config);
     removeThinkingMessage();
 
-    // Check if response contains an action
-    const action = extractAction(response);
-    const textWithoutJson = stripActionJson(response, action);
+    // Normalise both call paths into { action, textWithoutJson }:
+    //  - raw    : parse the assistant string (legacy / Gemini / Anthropic)
+    //  - action : already-validated action + text (structured / tools)
+    let action: Record<string, unknown> | null;
+    let textWithoutJson: string;
+    if (result.kind === 'raw') {
+      action = extractAction(result.raw);
+      textWithoutJson = stripActionJson(result.raw, action);
+    } else {
+      action = result.action as Record<string, unknown> | null;
+      textWithoutJson = result.text;
+    }
 
     if (action?.action === 'createChart' && action.config) {
       applyChartConfig(action.config as ChartConfig);
@@ -194,7 +228,7 @@ En attendant, je peux vous aider avec des commandes simples. Essayez :
         );
       }
     } else {
-      addMessage('assistant', response);
+      addMessage('assistant', result.kind === 'raw' ? result.raw : textWithoutJson);
     }
   } catch (error: unknown) {
     removeThinkingMessage();
@@ -210,10 +244,10 @@ En attendant, je peux vous aider avec des commandes simples. Essayez :
 }
 
 /**
- * Call the Albert API with the user message, conversation history, and skills context
+ * Build dataContext (field names + sample record) — essential, not fetchable
+ * by the model, so it stays in the prompt in every mode.
  */
-async function callAlbertAPI(userMessage: string, config: IAConfig): Promise<string> {
-  // Build context with data info
+function buildDataContext(): string {
   let dataContext = '';
   if (state.localData && state.fields.length > 0) {
     const detectedProvider = state.source?.apiUrl ? detectProvider(state.source.apiUrl).id : null;
@@ -236,12 +270,16 @@ async function callAlbertAPI(userMessage: string, config: IAConfig): Promise<str
 Champs : ${state.fields.map((f) => `${f.name} (${f.type})`).join(', ')}
 Exemple d'enregistrement : ${JSON.stringify(state.localData[0])}${paginationNote}${gristNote}`;
   }
+  return dataContext;
+}
 
-  // Inject relevant skills based on the user message
+/**
+ * Build the legacy full system prompt (everything stuffed in) — used by the
+ * legacy OpenAI path and by the Gemini / Anthropic branches (unchanged behavior).
+ */
+function buildLegacySystemPrompt(userMessage: string, config: IAConfig, dataContext: string): string {
   const relevantSkills = getRelevantSkills(userMessage, state.source);
   const skillsContext = buildSkillsContext(relevantSkills);
-
-  // Build available skills list for the system prompt
   const skillsList = Object.values(SKILLS)
     .map((s) => `- ${s.name}: ${s.description}`)
     .join('\n');
@@ -279,12 +317,27 @@ FACETTES : pas dans l'aperçu. Généré le createChart puis propose de génére
 CARTES : généré le createChart type map/map-reg. Si les données sont incompletes (100 lignes ODS), ajoute un texte prevenant que l'aperçu est partiel et propose le code embarquable.
 CHAMPS : utilise UNIQUEMENT les noms de champs listes dans "Données actuelles".`;
 
-  const systemPromptWithSkills =
-    config.systemPrompt +
-    `\n\nSKILLS DISPONIBLES (seront injectes si pertinents):\n${skillsList}` +
-    dataContext +
-    skillsContext +
-    actionReminder;
+  return buildSystemPrompt({
+    mode: 'legacy',
+    basePrompt: config.systemPrompt,
+    dataContext,
+    skillsList,
+    skillsContext,
+    actionReminder,
+  });
+}
+
+/** Default temperature for the structured/tools paths (low = deterministic JSON). */
+const STRUCTURED_DEFAULT_TEMPERATURE = 0.1;
+
+/**
+ * Call the Albert API. Returns either a raw assistant string (legacy / Gemini /
+ * Anthropic, parsed downstream) or an already-validated action (structured /
+ * tools paths). Capability gating applies ONLY to the OpenAI-compatible branch;
+ * Gemini and Anthropic keep their exact previous behavior.
+ */
+async function callAlbertAPI(userMessage: string, config: IAConfig): Promise<AICallResult> {
+  const dataContext = buildDataContext();
 
   // Detect provider from API URL (hostname match, not substring)
   let apiHostname = '';
@@ -297,49 +350,123 @@ CHAMPS : utilise UNIQUEMENT les noms de champs listes dans "Données actuelles".
   const isGemini =
     apiHostname === 'generativelanguage.googleapis.com' || apiHostname.endsWith('.googleapis.com');
 
+  // Server-default mode (no user token) is always OpenAI-compatible (Albert).
+  const useServerDefault = !config.token && isServerMode();
+  const isAlbert = useServerDefault || apiHostname.endsWith('etalab.gouv.fr');
+
   const conversationMessages = [
     ...state.messages.slice(-10).map((m) => ({
-      role: m.role === 'assistant' ? 'assistant' : 'user',
+      role: (m.role === 'assistant' ? 'assistant' : 'user') as 'assistant' | 'user',
       content: m.content,
     })),
-    { role: 'user', content: userMessage },
+    { role: 'user' as const, content: userMessage },
   ];
 
-  // Build request body adapted to the provider
-  let requestBody: Record<string, unknown>;
+  // -- Low-level transport: POST a body through the proxy, return parsed JSON ---
+  async function postProxy(
+    endpoint: string,
+    headers: Record<string, string>,
+    body: Record<string, unknown>,
+    timeout = 30000
+  ): Promise<Record<string, unknown>> {
+    const response = await fetchWithTimeout(
+      endpoint,
+      { method: 'POST', headers: { 'Content-Type': 'application/json', ...headers }, body: JSON.stringify(body) },
+      timeout
+    );
+    if (!response.ok) {
+      let detail = '';
+      try {
+        const errBody = await response.json();
+        detail =
+          errBody?.error?.message || errBody?.error?.type || JSON.stringify(errBody?.error) || '';
+      } catch {
+        /* ignore parse errors */
+      }
+      throw new Error(
+        detail ? `${httpErrorMessage(response.status)} (${detail})` : httpErrorMessage(response.status)
+      );
+    }
+    return response.json();
+  }
 
+  // -- OpenAI-compatible transport (server-default OR user token) --------------
+  function postOpenAI(timeout = 30000): PostChat {
+    return async (body: Record<string, unknown>) => {
+      const endpoint = useServerDefault ? '/ia-proxy-default' : '/ia-proxy';
+      const headers: Record<string, string> = useServerDefault
+        ? {}
+        : { 'X-Target-URL': config.apiUrl, Authorization: `Bearer ${config.token}` };
+      const data = await postProxy(endpoint, headers, body, timeout);
+      return data as unknown as OpenAIResponse;
+    };
+  }
+
+  // -- Resolve OpenAI/Albert inference params from extraParams -----------------
+  // temperature/seed are pulled out so we can set sensible defaults that the
+  // user can still override; max_tokens is mapped to Albert's max_completion_tokens.
+  function resolveOpenAIParams(): {
+    extra: Record<string, unknown>;
+    temperature?: number;
+    seed?: number;
+  } {
+    const extra: Record<string, unknown> = {};
+    let temperature: number | undefined;
+    let seed: number | undefined;
+    for (const [key, val] of Object.entries(config.extraParams || {})) {
+      const num = Number(val);
+      const parsed = !isNaN(num) && val !== '' ? num : val;
+      if (key === 'temperature') {
+        if (typeof parsed === 'number') temperature = parsed;
+        continue;
+      }
+      if (key === 'seed') {
+        if (typeof parsed === 'number') seed = parsed;
+        continue;
+      }
+      if (key === 'max_tokens' && isAlbert) {
+        extra.max_completion_tokens = parsed;
+        continue;
+      }
+      extra[key] = parsed;
+    }
+    return { extra, temperature, seed };
+  }
+
+  // === Gemini (user mode) — unchanged behavior ===============================
   if (isGemini) {
-    // Gemini API: contents with role user/model, systemInstruction separate
+    const systemPromptWithSkills = buildLegacySystemPrompt(userMessage, config, dataContext);
     const geminiContents = conversationMessages.map((m) => ({
       role: m.role === 'assistant' ? 'model' : 'user',
       parts: [{ text: m.content }],
     }));
-    requestBody = {
+    const requestBody: Record<string, unknown> = {
       contents: geminiContents,
       systemInstruction: { parts: [{ text: systemPromptWithSkills }] },
     };
-    // Map extra params into generationConfig
     const generationConfig: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(config.extraParams || {})) {
       const num = Number(val);
       const parsed = !isNaN(num) && val !== '' ? num : val;
-      if (key === 'max_tokens' || key === 'maxOutputTokens') {
-        generationConfig.maxOutputTokens = parsed;
-      } else if (key === 'top_p') {
-        generationConfig.topP = parsed;
-      } else if (key === 'top_k') {
-        generationConfig.topK = parsed;
-      } else {
-        // temperature, topP, topK, etc. pass through as-is
-        generationConfig[key] = parsed;
-      }
+      if (key === 'max_tokens' || key === 'maxOutputTokens') generationConfig.maxOutputTokens = parsed;
+      else if (key === 'top_p') generationConfig.topP = parsed;
+      else if (key === 'top_k') generationConfig.topK = parsed;
+      else generationConfig[key] = parsed;
     }
-    if (Object.keys(generationConfig).length > 0) {
-      requestBody.generationConfig = generationConfig;
-    }
-  } else if (isAnthropic) {
-    // Anthropic Messages API: system is a top-level field, not in messages
-    requestBody = {
+    if (Object.keys(generationConfig).length > 0) requestBody.generationConfig = generationConfig;
+
+    const separator = config.apiUrl.includes('?') ? '&' : '?';
+    const data = await postProxy('/ia-proxy', {
+      'X-Target-URL': `${config.apiUrl}${separator}key=${config.token}`,
+    }, requestBody);
+    const candidates = data.candidates as { content: { parts: { text: string }[] } }[];
+    return { kind: 'raw', raw: candidates[0].content.parts[0].text };
+  }
+
+  // === Anthropic (user mode) — unchanged behavior ============================
+  if (isAnthropic) {
+    const systemPromptWithSkills = buildLegacySystemPrompt(userMessage, config, dataContext);
+    const requestBody: Record<string, unknown> = {
       model: config.model,
       system: systemPromptWithSkills,
       messages: conversationMessages,
@@ -348,100 +475,85 @@ CHAMPS : utilise UNIQUEMENT les noms de champs listes dans "Données actuelles".
       const num = Number(val);
       requestBody[key] = !isNaN(num) && val !== '' ? num : val;
     }
-  } else {
-    // OpenAI-compatible: system prompt is the first message
-    requestBody = {
+    const data = await postProxy('/ia-proxy', {
+      'X-Target-URL': config.apiUrl,
+      'x-api-key': config.token,
+      'anthropic-version': '2023-06-01',
+    }, requestBody);
+    const content = data.content as { text: string }[];
+    return { kind: 'raw', raw: content[0].text };
+  }
+
+  // === OpenAI-compatible (Albert) — capability-gated =========================
+  const caps = effectiveCapabilities();
+  const { extra, temperature, seed } = resolveOpenAIParams();
+
+  // --- Tools / agentic loop -------------------------------------------------
+  if (caps.toolCalling) {
+    const systemPrompt = buildSystemPrompt({ mode: 'tools', basePrompt: config.systemPrompt, dataContext });
+    const result = await runAgentLoop({
+      conversation: conversationMessages,
+      systemPrompt,
+      source: state.source,
+      post: postOpenAI(45000),
+      onProgress: (label) => updateThinkingMessage(label),
       model: config.model,
-      messages: [{ role: 'system', content: systemPromptWithSkills }, ...conversationMessages],
-    };
-    for (const [key, val] of Object.entries(config.extraParams || {})) {
-      const num = Number(val);
-      requestBody[key] = !isNaN(num) && val !== '' ? num : val;
-    }
+      temperature: temperature ?? STRUCTURED_DEFAULT_TEMPERATURE,
+      seed,
+      extra,
+    });
+    return { kind: 'action', action: result.action, text: result.text };
   }
 
-  // Server-default mode: use /ia-proxy-default (token injected server-side)
-  const useServerDefault = !config.token && isServerMode();
-
-  let response: Response;
-
-  if (useServerDefault) {
-    // Server mode: always OpenAI-compatible (Albert), no auth header needed
-    response = await fetchWithTimeout(
-      '/ia-proxy-default',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(requestBody),
+  // --- Structured outputs (json_schema) -------------------------------------
+  if (caps.jsonSchema) {
+    const systemPrompt = buildSystemPrompt({
+      mode: 'structured',
+      basePrompt: config.systemPrompt,
+      dataContext,
+    });
+    const requestBody: Record<string, unknown> = {
+      model: config.model,
+      messages: [
+        { role: 'system', content: systemPrompt },
+        ...buildFewShot('structured'),
+        ...conversationMessages,
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: { name: 'builder_action', schema: ACTION_JSON_SCHEMA, strict: true },
       },
-      30000
-    );
-  } else {
-    // User-config mode: existing behavior with X-Target-URL and auth headers
-    let targetUrl = config.apiUrl;
-    if (isGemini) {
-      const separator = targetUrl.includes('?') ? '&' : '?';
-      targetUrl = `${targetUrl}${separator}key=${config.token}`;
-    }
-
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-      'X-Target-URL': targetUrl,
+      temperature: temperature ?? STRUCTURED_DEFAULT_TEMPERATURE,
+      ...(seed !== undefined ? { seed } : {}),
+      ...extra,
     };
-
-    if (isAnthropic) {
-      headers['x-api-key'] = config.token;
-      headers['anthropic-version'] = '2023-06-01';
-    } else if (!isGemini) {
-      headers['Authorization'] = `Bearer ${config.token}`;
-    }
-
-    response = await fetchWithTimeout(
-      '/ia-proxy',
-      {
-        method: 'POST',
-        headers,
-        body: JSON.stringify(requestBody),
-      },
-      30000
-    );
-  }
-
-  if (!response.ok) {
-    // Try to extract the actual error message from the provider
-    let detail = '';
+    const data = await postOpenAI()(requestBody);
+    const content = data.choices?.[0]?.message?.content ?? '';
+    let parsed: unknown = null;
     try {
-      const errBody = await response.json();
-      detail =
-        errBody?.error?.message || errBody?.error?.type || JSON.stringify(errBody?.error) || '';
+      parsed = JSON.parse(content);
     } catch {
-      /* ignore parse errors */
+      /* leave null — validateAction returns null, downstream shows text */
     }
-    throw new Error(
-      detail
-        ? `${httpErrorMessage(response.status)} (${detail})`
-        : httpErrorMessage(response.status)
-    );
+    const action = validateAction(parsed);
+    const text =
+      parsed && typeof (parsed as Record<string, unknown>).message === 'string'
+        ? ((parsed as Record<string, unknown>).message as string)
+        : '';
+    return { kind: 'action', action, text };
   }
 
-  const data = await response.json();
-
-  // Server-default mode is always OpenAI-compatible (Albert)
-  if (useServerDefault) {
-    return data.choices[0].message.content;
-  }
-
-  // Parse response based on provider format
-  if (isGemini) {
-    // Gemini: { candidates: [{ content: { parts: [{ text: "..." }] } }] }
-    return data.candidates[0].content.parts[0].text;
-  }
-  if (isAnthropic) {
-    // Anthropic: { content: [{ type: "text", text: "..." }] }
-    return data.content[0].text;
-  }
-  // OpenAI-compatible: { choices: [{ message: { content: "..." } }] }
-  return data.choices[0].message.content;
+  // --- Legacy (no advanced capability) — identical to previous behavior ------
+  const systemPromptWithSkills = buildLegacySystemPrompt(userMessage, config, dataContext);
+  const requestBody: Record<string, unknown> = {
+    model: config.model,
+    messages: [{ role: 'system', content: systemPromptWithSkills }, ...conversationMessages],
+    ...(temperature !== undefined ? { temperature } : {}),
+    ...(seed !== undefined ? { seed } : {}),
+    ...extra,
+  };
+  const data = await postOpenAI()(requestBody);
+  return { kind: 'raw', raw: data.choices[0].message.content ?? '' };
 }
 
 /**

--- a/apps/builder-ia/src/ia/action-schema.ts
+++ b/apps/builder-ia/src/ia/action-schema.ts
@@ -2,11 +2,11 @@
  * Contrat d'action de l'assistant builder-ia — source unique de verite.
  *
  * Le LLM n'ecrit jamais de HTML : son seul job est de produire un objet action
- * que l'app applique de facon deterministe (apercu via chart-renderer, code
+ * que l'app applique de facon deterministe (aperçu via chart-renderer, code
  * embarquable via code-generator). C'est le cas d'usage ideal des Structured
  * Outputs d'Albert (response_format:{type:"json_schema"}).
  *
- * Ce module exporte le contrat en deux representations a partir des memes
+ * Ce module exporte le contrat en deux representations a partir des mêmes
  * fragments :
  *   - ACTION_JSON_SCHEMA   : pour response_format (chemin single-shot structure)
  *   - *_TOOL / FINAL_ACTION_TOOLS : pour tools/function-calling (boucle agentique)
@@ -14,7 +14,7 @@
  * le handler de sendMessage ({ action, config?/query?, message }).
  *
  * L'enum `type` du config DOIT rester alignee sur ChartConfig['type']
- * (state.ts) — un test d'alignement le verifie (meme esprit que skills.test.ts).
+ * (state.ts) — un test d'alignement le vérifie (même esprit que skills.test.ts).
  */
 
 import type { ChartConfig } from '../state.js';
@@ -64,14 +64,15 @@ export const CONFIG_SCHEMA = {
   type: 'object',
   properties: {
     type: { type: 'string', enum: [...CHART_TYPES], description: 'Type de visualisation' },
-    valueField: { type: 'string', description: 'Champ numerique a mesurer (obligatoire)' },
-    labelField: { type: 'string', description: "Champ d'etiquette (axe horizontal / categories)" },
+    valueField: { type: 'string', description: 'Champ numérique a mesurer (obligatoire)' },
+    labelField: { type: 'string', description: "Champ d'etiquette (axe horizontal / catégories)" },
     valueField2: { type: 'string', description: 'Second champ valeur (bar-line, scatter)' },
     codeField: { type: 'string', description: 'Champ code INSEE (cartes departement/region)' },
-    aggregation: { type: 'string', enum: [...AGGREGATIONS], description: "Fonction d'agregation" },
+    aggregation: { type: 'string', enum: [...AGGREGATIONS], description: "Fonction d'agrégation" },
     where: {
       type: 'string',
-      description: 'Filtre, syntaxe "champ:operateur:valeur" (eq, neq, gt, gte, lt, lte, contains, in)',
+      description:
+        'Filtre, syntaxe "champ:operateur:valeur" (eq, neq, gt, gte, lt, lte, contains, in)',
     },
     limit: { type: 'integer', description: 'Nombre max de resultats' },
     sortOrder: { type: 'string', enum: [...SORT_ORDERS] },
@@ -86,7 +87,10 @@ export const CONFIG_SCHEMA = {
       description:
         'categorical | sequentialAscending | sequentialDescending | divergentAscending | divergentDescending | neutral',
     },
-    colonnes: { type: 'string', description: 'Colonnes du tableau (datalist), separees par virgule' },
+    colonnes: {
+      type: 'string',
+      description: 'Colonnes du tableau (datalist), separees par virgule',
+    },
     pagination: { type: 'integer', description: 'Lignes par page (datalist)' },
   },
   required: ['type', 'valueField'],
@@ -116,8 +120,11 @@ export const QUERY_SCHEMA = {
 export const ACTION_JSON_SCHEMA = {
   type: 'object',
   properties: {
-    action: { type: 'string', enum: [...ACTIONS], description: "Action a executer" },
-    message: { type: 'string', description: "Phrase courte en francais a afficher a l'utilisateur" },
+    action: { type: 'string', enum: [...ACTIONS], description: 'Action a executer' },
+    message: {
+      type: 'string',
+      description: "Phrase courte en francais a afficher a l'utilisateur",
+    },
     config: CONFIG_SCHEMA,
     query: QUERY_SCHEMA,
   },
@@ -126,7 +133,7 @@ export const ACTION_JSON_SCHEMA = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// Tools (function-calling) — memes fragments
+// Tools (function-calling) — mêmes fragments
 // ---------------------------------------------------------------------------
 
 const MESSAGE_PROP = {
@@ -140,7 +147,7 @@ export const FINAL_ACTION_TOOLS = [
     function: {
       name: 'create_chart',
       description:
-        "Cree/met a jour la visualisation dans l'apercu. Utilise les noms de champs EXACTS du contexte de donnees.",
+        "Crée/met a jour la visualisation dans l'aperçu. Utilise les noms de champs EXACTS du contexte de données.",
       parameters: {
         type: 'object',
         properties: { ...MESSAGE_PROP, config: CONFIG_SCHEMA },
@@ -153,7 +160,7 @@ export const FINAL_ACTION_TOOLS = [
     type: 'function' as const,
     function: {
       name: 'reload_data',
-      description: 'Recharge les donnees depuis la source avec des filtres ODSQL serveur.',
+      description: 'Recharge les données depuis la source avec des filtres ODSQL serveur.',
       parameters: {
         type: 'object',
         properties: { ...MESSAGE_PROP, query: QUERY_SCHEMA },
@@ -166,7 +173,7 @@ export const FINAL_ACTION_TOOLS = [
     type: 'function' as const,
     function: {
       name: 'reset_chart',
-      description: "Efface l'apercu et repart de zero.",
+      description: "Efface l'aperçu et repart de zero.",
       parameters: {
         type: 'object',
         properties: { ...MESSAGE_PROP },
@@ -183,11 +190,11 @@ export const SKILL_LOOKUP_TOOLS = [
     function: {
       name: 'get_relevant_skills',
       description:
-        'Recupere les fiches (skills) pertinentes pour un message utilisateur (matching par mots-cles). A appeler quand tu as besoin des details d\'un composant avant de generer.',
+        "Recupere les fiches (skills) pertinentes pour un message utilisateur (matching par mots-clés). A appeler quand tu as besoin des details d'un composant avant de générer.",
       parameters: {
         type: 'object',
         properties: {
-          message: { type: 'string', description: "Message ou intention a faire matcher" },
+          message: { type: 'string', description: 'Message ou intention a faire matcher' },
         },
         required: ['message'],
         additionalProperties: false,
@@ -198,7 +205,7 @@ export const SKILL_LOOKUP_TOOLS = [
     type: 'function' as const,
     function: {
       name: 'get_skill',
-      description: 'Recupere le contenu complet d\'une fiche (skill) par son id.',
+      description: "Recupere le contenu complet d'une fiche (skill) par son id.",
       parameters: {
         type: 'object',
         properties: { skill_id: { type: 'string', description: 'Id de la skill' } },
@@ -239,7 +246,7 @@ const TYPE_SET = new Set<string>(CHART_TYPES);
  *
  * Tolere les deux formes :
  *   - structured output plat : { action, message, config?, query? }
- *   - tool call deja resolu :  { action, message, config?/query? }
+ *   - tool call déjà resolu :  { action, message, config?/query? }
  */
 export function validateAction(obj: unknown): ActionResult | null {
   if (!obj || typeof obj !== 'object') return null;

--- a/apps/builder-ia/src/ia/action-schema.ts
+++ b/apps/builder-ia/src/ia/action-schema.ts
@@ -1,0 +1,270 @@
+/**
+ * Contrat d'action de l'assistant builder-ia — source unique de verite.
+ *
+ * Le LLM n'ecrit jamais de HTML : son seul job est de produire un objet action
+ * que l'app applique de facon deterministe (apercu via chart-renderer, code
+ * embarquable via code-generator). C'est le cas d'usage ideal des Structured
+ * Outputs d'Albert (response_format:{type:"json_schema"}).
+ *
+ * Ce module exporte le contrat en deux representations a partir des memes
+ * fragments :
+ *   - ACTION_JSON_SCHEMA   : pour response_format (chemin single-shot structure)
+ *   - *_TOOL / FINAL_ACTION_TOOLS : pour tools/function-calling (boucle agentique)
+ * Plus validateAction() : garde runtime qui normalise vers la forme attendue par
+ * le handler de sendMessage ({ action, config?/query?, message }).
+ *
+ * L'enum `type` du config DOIT rester alignee sur ChartConfig['type']
+ * (state.ts) — un test d'alignement le verifie (meme esprit que skills.test.ts).
+ */
+
+import type { ChartConfig } from '../state.js';
+
+/** Types de graphiques supportes — aligne sur ChartConfig['type']. */
+export const CHART_TYPES = [
+  'bar',
+  'line',
+  'pie',
+  'doughnut',
+  'radar',
+  'horizontalBar',
+  'scatter',
+  'gauge',
+  'kpi',
+  'map',
+  'bar-line',
+  'map-reg',
+  'datalist',
+  'podium',
+] as const;
+
+export const AGGREGATIONS = ['sum', 'avg', 'count', 'min', 'max'] as const;
+export const SORT_ORDERS = ['desc', 'asc'] as const;
+export const VARIANTS = ['info', 'success', 'warning', 'error'] as const;
+export const ACTIONS = ['createChart', 'reloadData', 'resetChart'] as const;
+
+export type ActionName = (typeof ACTIONS)[number];
+
+/** Resultat normalise consomme par sendMessage. */
+export interface ActionResult {
+  action: ActionName;
+  /** Texte FR court que l'assistant "dit" (champ message du schema). */
+  message?: string;
+  /** Present pour createChart. */
+  config?: Partial<ChartConfig>;
+  /** Present pour reloadData. */
+  query?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Fragments de schema (JSON Schema standard, compatible vLLM guided decoding)
+// ---------------------------------------------------------------------------
+
+/** Schema du config de createChart, calque sur ChartConfig. */
+export const CONFIG_SCHEMA = {
+  type: 'object',
+  properties: {
+    type: { type: 'string', enum: [...CHART_TYPES], description: 'Type de visualisation' },
+    valueField: { type: 'string', description: 'Champ numerique a mesurer (obligatoire)' },
+    labelField: { type: 'string', description: "Champ d'etiquette (axe horizontal / categories)" },
+    valueField2: { type: 'string', description: 'Second champ valeur (bar-line, scatter)' },
+    codeField: { type: 'string', description: 'Champ code INSEE (cartes departement/region)' },
+    aggregation: { type: 'string', enum: [...AGGREGATIONS], description: "Fonction d'agregation" },
+    where: {
+      type: 'string',
+      description: 'Filtre, syntaxe "champ:operateur:valeur" (eq, neq, gt, gte, lt, lte, contains, in)',
+    },
+    limit: { type: 'integer', description: 'Nombre max de resultats' },
+    sortOrder: { type: 'string', enum: [...SORT_ORDERS] },
+    title: { type: 'string' },
+    subtitle: { type: 'string' },
+    color: { type: 'string' },
+    color2: { type: 'string' },
+    variant: { type: 'string', enum: [...VARIANTS], description: 'Couleur semantique du KPI' },
+    unit: { type: 'string' },
+    palette: {
+      type: 'string',
+      description:
+        'categorical | sequentialAscending | sequentialDescending | divergentAscending | divergentDescending | neutral',
+    },
+    colonnes: { type: 'string', description: 'Colonnes du tableau (datalist), separees par virgule' },
+    pagination: { type: 'integer', description: 'Lignes par page (datalist)' },
+  },
+  required: ['type', 'valueField'],
+  additionalProperties: false,
+} as const;
+
+/** Schema du query de reloadData (ODSQL serveur). */
+export const QUERY_SCHEMA = {
+  type: 'object',
+  properties: {
+    select: { type: 'string' },
+    where: { type: 'string', description: 'Syntaxe ODSQL SQL-like, ex: population > 10000' },
+    group_by: { type: 'string' },
+    order_by: { type: 'string' },
+    limit: { type: 'integer' },
+  },
+  additionalProperties: false,
+} as const;
+
+/**
+ * Schema d'action complet (forme PLATE) pour response_format json_schema.
+ * Choix de la forme plate (action enum + config/query optionnels) plutot que
+ * oneOf discrimine : plus robuste sur le guided-decoding vLLM. `config`/`query`
+ * sont conditionnels par convention (le prompt l'explique) ; on ne force pas
+ * oneOf pour eviter les rejets xgrammar.
+ */
+export const ACTION_JSON_SCHEMA = {
+  type: 'object',
+  properties: {
+    action: { type: 'string', enum: [...ACTIONS], description: "Action a executer" },
+    message: { type: 'string', description: "Phrase courte en francais a afficher a l'utilisateur" },
+    config: CONFIG_SCHEMA,
+    query: QUERY_SCHEMA,
+  },
+  required: ['action', 'message'],
+  additionalProperties: false,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Tools (function-calling) — memes fragments
+// ---------------------------------------------------------------------------
+
+const MESSAGE_PROP = {
+  message: { type: 'string', description: "Phrase courte en francais a afficher a l'utilisateur" },
+} as const;
+
+/** Tools finaux : un appel a l'un d'eux TERMINE la boucle agentique. */
+export const FINAL_ACTION_TOOLS = [
+  {
+    type: 'function' as const,
+    function: {
+      name: 'create_chart',
+      description:
+        "Cree/met a jour la visualisation dans l'apercu. Utilise les noms de champs EXACTS du contexte de donnees.",
+      parameters: {
+        type: 'object',
+        properties: { ...MESSAGE_PROP, config: CONFIG_SCHEMA },
+        required: ['config'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'reload_data',
+      description: 'Recharge les donnees depuis la source avec des filtres ODSQL serveur.',
+      parameters: {
+        type: 'object',
+        properties: { ...MESSAGE_PROP, query: QUERY_SCHEMA },
+        required: ['query'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'reset_chart',
+      description: "Efface l'apercu et repart de zero.",
+      parameters: {
+        type: 'object',
+        properties: { ...MESSAGE_PROP },
+        additionalProperties: false,
+      },
+    },
+  },
+] as const;
+
+/** Tools de recuperation de skills (n'arretent pas la boucle). */
+export const SKILL_LOOKUP_TOOLS = [
+  {
+    type: 'function' as const,
+    function: {
+      name: 'get_relevant_skills',
+      description:
+        'Recupere les fiches (skills) pertinentes pour un message utilisateur (matching par mots-cles). A appeler quand tu as besoin des details d\'un composant avant de generer.',
+      parameters: {
+        type: 'object',
+        properties: {
+          message: { type: 'string', description: "Message ou intention a faire matcher" },
+        },
+        required: ['message'],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'get_skill',
+      description: 'Recupere le contenu complet d\'une fiche (skill) par son id.',
+      parameters: {
+        type: 'object',
+        properties: { skill_id: { type: 'string', description: 'Id de la skill' } },
+        required: ['skill_id'],
+        additionalProperties: false,
+      },
+    },
+  },
+] as const;
+
+/** Noms des tools terminaux (un appel termine la boucle). */
+export const FINAL_TOOL_NAMES = new Set<string>(FINAL_ACTION_TOOLS.map((t) => t.function.name));
+
+/** Mappe le nom d'un tool terminal vers l'action correspondante. */
+export function toolNameToAction(name: string): ActionName | null {
+  switch (name) {
+    case 'create_chart':
+      return 'createChart';
+    case 'reload_data':
+      return 'reloadData';
+    case 'reset_chart':
+      return 'resetChart';
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Validation runtime
+// ---------------------------------------------------------------------------
+
+const ACTION_SET = new Set<string>(ACTIONS);
+const TYPE_SET = new Set<string>(CHART_TYPES);
+
+/**
+ * Garde runtime : valide/normalise un objet (issu de structured output ou d'un
+ * tool call) vers ActionResult. Retourne null si invalide.
+ *
+ * Tolere les deux formes :
+ *   - structured output plat : { action, message, config?, query? }
+ *   - tool call deja resolu :  { action, message, config?/query? }
+ */
+export function validateAction(obj: unknown): ActionResult | null {
+  if (!obj || typeof obj !== 'object') return null;
+  const o = obj as Record<string, unknown>;
+
+  const action = typeof o.action === 'string' ? o.action : '';
+  if (!ACTION_SET.has(action)) return null;
+
+  const message = typeof o.message === 'string' ? o.message : undefined;
+
+  if (action === 'createChart') {
+    const config = o.config;
+    if (!config || typeof config !== 'object') return null;
+    const c = config as Record<string, unknown>;
+    if (typeof c.type !== 'string' || !TYPE_SET.has(c.type)) return null;
+    if (typeof c.valueField !== 'string' || c.valueField.length === 0) return null;
+    return { action: 'createChart', message, config: c as Partial<ChartConfig> };
+  }
+
+  if (action === 'reloadData') {
+    const query = o.query;
+    if (!query || typeof query !== 'object') return null;
+    return { action: 'reloadData', message, query: query as Record<string, unknown> };
+  }
+
+  // resetChart
+  return { action: 'resetChart', message };
+}

--- a/apps/builder-ia/src/ia/agent-loop.ts
+++ b/apps/builder-ia/src/ia/agent-loop.ts
@@ -51,8 +51,8 @@ export interface AgentLoopOptions {
   systemPrompt: string;
   source: Source | null;
   post: PostChat;
-  /** Callback de progression (mute l'indicateur "Reflexion..."). */
-  onProgress?: (label: string) => void;
+  /** Callback de progression : recoit la liste cumulative des etapes franchies. */
+  onProgress?: (steps: string[]) => void;
   model: string;
   temperature: number;
   seed?: number;
@@ -63,6 +63,22 @@ export interface AgentLoopOptions {
 export interface AgentLoopResult {
   action: ActionResult | null;
   text: string;
+  /** Etapes de raisonnement franchies (humanisees), pour affichage persistant. */
+  steps: string[];
+}
+
+/** Humanise un appel d'outil de lookup pour l'affichage utilisateur. */
+function humanizeStep(name: string, args: Record<string, unknown>): string {
+  switch (name) {
+    case 'get_relevant_skills':
+      return 'Je cherche les bons reglages…';
+    case 'get_skill': {
+      const id = typeof args.skill_id === 'string' ? args.skill_id : '';
+      return id ? `Je consulte la fiche « ${id} »…` : 'Je consulte la documentation du composant…';
+    }
+    default:
+      return `Consultation : ${name}`;
+  }
 }
 
 const MAX_ROUNDS = 3;
@@ -71,7 +87,11 @@ const ALL_TOOLS = [...SKILL_LOOKUP_TOOLS, ...FINAL_ACTION_TOOLS];
 /**
  * Dispatch d'un outil de lookup. Renvoie le texte a remettre au modele.
  */
-function dispatchLookup(name: string, args: Record<string, unknown>, source: Source | null): string {
+function dispatchLookup(
+  name: string,
+  args: Record<string, unknown>,
+  source: Source | null
+): string {
   if (name === 'get_relevant_skills') {
     const message = typeof args.message === 'string' ? args.message : '';
     const matched = getRelevantSkills(message, source);
@@ -107,7 +127,8 @@ function parseArgs(raw: string): Record<string, unknown> {
  * afficher, ou {action:null, text} pour une reponse purement conversationnelle.
  */
 export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentLoopResult> {
-  const { conversation, systemPrompt, source, post, onProgress, model, temperature, seed, extra } = opts;
+  const { conversation, systemPrompt, source, post, onProgress, model, temperature, seed, extra } =
+    opts;
 
   const messages: ChatMessage[] = [
     { role: 'system', content: systemPrompt },
@@ -116,6 +137,8 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentLoopRes
 
   // Garde-fou anti-boucle : ne pas rappeler indefiniment le meme lookup.
   const lookupCalls = new Set<string>();
+  // Etapes de raisonnement franchies (humanisees), conservees pour affichage.
+  const steps: string[] = [];
   let lastContent = '';
 
   for (let round = 0; round < MAX_ROUNDS; round++) {
@@ -131,13 +154,13 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentLoopRes
 
     const data = await post(body);
     const msg = data.choices?.[0]?.message;
-    if (!msg) return { action: null, text: lastContent };
+    if (!msg) return { action: null, text: lastContent, steps };
     lastContent = msg.content ?? lastContent;
 
     const toolCalls = msg.tool_calls ?? [];
     if (toolCalls.length === 0) {
       // Reponse conversationnelle pure (pas d'action).
-      return { action: null, text: msg.content ?? '' };
+      return { action: null, text: msg.content ?? '', steps };
     }
 
     // Empile le message assistant porteur des tool_calls.
@@ -150,7 +173,7 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentLoopRes
         const args = parseArgs(call.function.arguments);
         const result = validateAction({ action: actionName, ...args });
         const text = (typeof args.message === 'string' && args.message) || msg.content || '';
-        return { action: result, text };
+        return { action: result, text, steps };
       }
     }
 
@@ -158,10 +181,12 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentLoopRes
     for (const call of toolCalls) {
       const key = `${call.function.name}:${call.function.arguments}`;
       const args = parseArgs(call.function.arguments);
-      onProgress?.(`Consultation : ${call.function.name}`);
+      // Accumule l'etape humanisee et notifie la progression (liste cumulative).
+      steps.push(humanizeStep(call.function.name, args));
+      onProgress?.(steps);
       let result: string;
       if (lookupCalls.has(key)) {
-        result = 'Deja fourni ci-dessus. Genere maintenant l\'action finale.';
+        result = "Deja fourni ci-dessus. Genere maintenant l'action finale.";
       } else {
         lookupCalls.add(key);
         result = dispatchLookup(call.function.name, args, source);
@@ -171,5 +196,5 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentLoopRes
   }
 
   // Budget de rounds epuise sans action finale.
-  return { action: null, text: lastContent };
+  return { action: null, text: lastContent, steps };
 }

--- a/apps/builder-ia/src/ia/agent-loop.ts
+++ b/apps/builder-ia/src/ia/agent-loop.ts
@@ -5,10 +5,10 @@
  * modele appelle a la demande (get_relevant_skills / get_skill) avant d'appeler
  * l'outil final (create_chart / reload_data / reset_chart) qui termine la boucle.
  * C'est l'analogue navigateur du MCP server (mcp-server/src/index.ts), qui sert
- * le meme pattern a Claude.
+ * le même pattern a Claude.
  *
  * Le transport HTTP est injecte (`post`) : chat.ts garde la propriete du choix
- * serveur-defaut vs config-utilisateur, et la boucle reste testable (post mocke).
+ * serveur-défaut vs config-utilisateur, et la boucle reste testable (post mocke).
  */
 
 import type { Source } from '../state.js';
@@ -46,7 +46,7 @@ export interface OpenAIResponse {
 export type PostChat = (body: Record<string, unknown>) => Promise<OpenAIResponse>;
 
 export interface AgentLoopOptions {
-  /** Conversation deja construite (sans le system), ex: state.messages.slice(-10). */
+  /** Conversation déjà construite (sans le system), ex: state.messages.slice(-10). */
   conversation: { role: 'user' | 'assistant'; content: string }[];
   systemPrompt: string;
   source: Source | null;
@@ -71,7 +71,7 @@ export interface AgentLoopResult {
 function humanizeStep(name: string, args: Record<string, unknown>): string {
   switch (name) {
     case 'get_relevant_skills':
-      return 'Je cherche les bons reglages…';
+      return 'Je cherche les bons réglages…';
     case 'get_skill': {
       const id = typeof args.skill_id === 'string' ? args.skill_id : '';
       return id ? `Je consulte la fiche « ${id} »…` : 'Je consulte la documentation du composant…';
@@ -96,7 +96,7 @@ function dispatchLookup(
     const message = typeof args.message === 'string' ? args.message : '';
     const matched = getRelevantSkills(message, source);
     if (matched.length === 0) {
-      return 'Aucune skill ne correspond. Essaie des mots-cles plus larges ou get_skill par id.';
+      return 'Aucune skill ne correspond. Essaie des mots-clés plus larges ou get_skill par id.';
     }
     return buildSkillsContext(matched);
   }
@@ -135,7 +135,7 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentLoopRes
     ...conversation.map((m) => ({ role: m.role, content: m.content }) as ChatMessage),
   ];
 
-  // Garde-fou anti-boucle : ne pas rappeler indefiniment le meme lookup.
+  // Garde-fou anti-boucle : ne pas rappeler indefiniment le même lookup.
   const lookupCalls = new Set<string>();
   // Etapes de raisonnement franchies (humanisees), conservees pour affichage.
   const steps: string[] = [];
@@ -186,7 +186,7 @@ export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentLoopRes
       onProgress?.(steps);
       let result: string;
       if (lookupCalls.has(key)) {
-        result = "Deja fourni ci-dessus. Genere maintenant l'action finale.";
+        result = "Déjà fourni ci-dessus. Génère maintenant l'action finale.";
       } else {
         lookupCalls.add(key);
         result = dispatchLookup(call.function.name, args, source);

--- a/apps/builder-ia/src/ia/agent-loop.ts
+++ b/apps/builder-ia/src/ia/agent-loop.ts
@@ -1,0 +1,175 @@
+/**
+ * Boucle agentique incrementale pour la branche OpenAI-compatible (Albert).
+ *
+ * Au lieu d'empiler tous les skills dans le prompt, on expose des outils que le
+ * modele appelle a la demande (get_relevant_skills / get_skill) avant d'appeler
+ * l'outil final (create_chart / reload_data / reset_chart) qui termine la boucle.
+ * C'est l'analogue navigateur du MCP server (mcp-server/src/index.ts), qui sert
+ * le meme pattern a Claude.
+ *
+ * Le transport HTTP est injecte (`post`) : chat.ts garde la propriete du choix
+ * serveur-defaut vs config-utilisateur, et la boucle reste testable (post mocke).
+ */
+
+import type { Source } from '../state.js';
+import { SKILLS, getRelevantSkills, buildSkillsContext } from '../skills.js';
+import {
+  SKILL_LOOKUP_TOOLS,
+  FINAL_ACTION_TOOLS,
+  FINAL_TOOL_NAMES,
+  toolNameToAction,
+  validateAction,
+  type ActionResult,
+} from './action-schema.js';
+
+/** Forme minimale d'un tool_call OpenAI. */
+interface ToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
+/** Forme minimale d'un message de reponse OpenAI. */
+interface ChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | null;
+  tool_calls?: ToolCall[];
+  tool_call_id?: string;
+}
+
+/** Forme minimale d'une reponse chat/completions OpenAI-compatible. */
+export interface OpenAIResponse {
+  choices: { message: ChatMessage }[];
+}
+
+/** Fonction de transport injectee : POST le body et renvoie la reponse parsee. */
+export type PostChat = (body: Record<string, unknown>) => Promise<OpenAIResponse>;
+
+export interface AgentLoopOptions {
+  /** Conversation deja construite (sans le system), ex: state.messages.slice(-10). */
+  conversation: { role: 'user' | 'assistant'; content: string }[];
+  systemPrompt: string;
+  source: Source | null;
+  post: PostChat;
+  /** Callback de progression (mute l'indicateur "Reflexion..."). */
+  onProgress?: (label: string) => void;
+  model: string;
+  temperature: number;
+  seed?: number;
+  /** Parametres extra (max_completion_tokens, etc.) fusionnes dans le body. */
+  extra?: Record<string, unknown>;
+}
+
+export interface AgentLoopResult {
+  action: ActionResult | null;
+  text: string;
+}
+
+const MAX_ROUNDS = 3;
+const ALL_TOOLS = [...SKILL_LOOKUP_TOOLS, ...FINAL_ACTION_TOOLS];
+
+/**
+ * Dispatch d'un outil de lookup. Renvoie le texte a remettre au modele.
+ */
+function dispatchLookup(name: string, args: Record<string, unknown>, source: Source | null): string {
+  if (name === 'get_relevant_skills') {
+    const message = typeof args.message === 'string' ? args.message : '';
+    const matched = getRelevantSkills(message, source);
+    if (matched.length === 0) {
+      return 'Aucune skill ne correspond. Essaie des mots-cles plus larges ou get_skill par id.';
+    }
+    return buildSkillsContext(matched);
+  }
+  if (name === 'get_skill') {
+    const id = typeof args.skill_id === 'string' ? args.skill_id : '';
+    const skill = SKILLS[id];
+    if (!skill) {
+      const ids = Object.keys(SKILLS).join(', ');
+      return `Skill "${id}" introuvable. Ids disponibles : ${ids}`;
+    }
+    return skill.content;
+  }
+  return `Outil inconnu : ${name}`;
+}
+
+/** Parse les arguments JSON d'un tool_call de facon tolerante. */
+function parseArgs(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw || '{}');
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Execute la boucle agentique. Retourne l'action finale (validee) + le texte a
+ * afficher, ou {action:null, text} pour une reponse purement conversationnelle.
+ */
+export async function runAgentLoop(opts: AgentLoopOptions): Promise<AgentLoopResult> {
+  const { conversation, systemPrompt, source, post, onProgress, model, temperature, seed, extra } = opts;
+
+  const messages: ChatMessage[] = [
+    { role: 'system', content: systemPrompt },
+    ...conversation.map((m) => ({ role: m.role, content: m.content }) as ChatMessage),
+  ];
+
+  // Garde-fou anti-boucle : ne pas rappeler indefiniment le meme lookup.
+  const lookupCalls = new Set<string>();
+  let lastContent = '';
+
+  for (let round = 0; round < MAX_ROUNDS; round++) {
+    const body: Record<string, unknown> = {
+      model,
+      messages,
+      tools: ALL_TOOLS,
+      tool_choice: 'auto',
+      temperature,
+      ...(seed !== undefined ? { seed } : {}),
+      ...(extra ?? {}),
+    };
+
+    const data = await post(body);
+    const msg = data.choices?.[0]?.message;
+    if (!msg) return { action: null, text: lastContent };
+    lastContent = msg.content ?? lastContent;
+
+    const toolCalls = msg.tool_calls ?? [];
+    if (toolCalls.length === 0) {
+      // Reponse conversationnelle pure (pas d'action).
+      return { action: null, text: msg.content ?? '' };
+    }
+
+    // Empile le message assistant porteur des tool_calls.
+    messages.push({ role: 'assistant', content: msg.content ?? '', tool_calls: toolCalls });
+
+    // 1) Un tool_call final termine la boucle.
+    for (const call of toolCalls) {
+      if (FINAL_TOOL_NAMES.has(call.function.name)) {
+        const actionName = toolNameToAction(call.function.name);
+        const args = parseArgs(call.function.arguments);
+        const result = validateAction({ action: actionName, ...args });
+        const text = (typeof args.message === 'string' && args.message) || msg.content || '';
+        return { action: result, text };
+      }
+    }
+
+    // 2) Sinon, ce sont des lookups : on repond a chacun et on reboucle.
+    for (const call of toolCalls) {
+      const key = `${call.function.name}:${call.function.arguments}`;
+      const args = parseArgs(call.function.arguments);
+      onProgress?.(`Consultation : ${call.function.name}`);
+      let result: string;
+      if (lookupCalls.has(key)) {
+        result = 'Deja fourni ci-dessus. Genere maintenant l\'action finale.';
+      } else {
+        lookupCalls.add(key);
+        result = dispatchLookup(call.function.name, args, source);
+      }
+      messages.push({ role: 'tool', content: result, tool_call_id: call.id });
+    }
+  }
+
+  // Budget de rounds epuise sans action finale.
+  return { action: null, text: lastContent };
+}

--- a/apps/builder-ia/src/ia/albert-capabilities.ts
+++ b/apps/builder-ia/src/ia/albert-capabilities.ts
@@ -6,7 +6,7 @@
  * schema ne garantit pas qu'il fonctionne de bout en bout sur leur deploiement
  * vLLM (le tool-calling gpt-oss/vLLM exige des flags serveur). On garde donc un
  * descriptif de capacites, sonde empiriquement (cf. scripts/probe-albert.ts),
- * avec un defaut conservateur : sans preuve, on retombe sur le chemin legacy
+ * avec un défaut conservateur : sans preuve, on retombe sur le chemin legacy
  * (extractAction/repairAction) qui marche partout.
  *
  * Ces capacites ne s'appliquent QU'a la branche OpenAI-compatible de
@@ -25,7 +25,7 @@ export interface AlbertCapabilities {
 }
 
 /**
- * Defaut conservateur : aucune capacite avancee presumee. Tant qu'une sonde
+ * Défaut conservateur : aucune capacité avancée présumée. Tant qu'une sonde
  * n'a pas confirme json_schema / toolCalling, on sert le comportement actuel.
  */
 export const DEFAULT_CAPABILITIES: AlbertCapabilities = {
@@ -73,7 +73,7 @@ export function setCapabilities(caps: AlbertCapabilities): void {
   }
 }
 
-/** Efface les capacites memorisees (retour au defaut conservateur). */
+/** Efface les capacités mémorisées (retour au défaut conservateur). */
 export function resetCapabilities(): void {
   cached = null;
   try {
@@ -85,7 +85,7 @@ export function resetCapabilities(): void {
 
 /**
  * Capacites effectives a utiliser dans callAlbertAPI : les capacites memorisees
- * si presentes, sinon le defaut conservateur.
+ * si presentes, sinon le défaut conservateur.
  */
 export function effectiveCapabilities(): AlbertCapabilities {
   return getCapabilities() ?? DEFAULT_CAPABILITIES;

--- a/apps/builder-ia/src/ia/albert-capabilities.ts
+++ b/apps/builder-ia/src/ia/albert-capabilities.ts
@@ -1,0 +1,92 @@
+/**
+ * Albert (OpenGateLLM) capability descriptor.
+ *
+ * Le gateway Albert expose dans son OpenAPI les parametres `response_format`
+ * (json_schema), `tools`/`tool_choice`, etc. MAIS qu'un parametre soit dans le
+ * schema ne garantit pas qu'il fonctionne de bout en bout sur leur deploiement
+ * vLLM (le tool-calling gpt-oss/vLLM exige des flags serveur). On garde donc un
+ * descriptif de capacites, sonde empiriquement (cf. scripts/probe-albert.ts),
+ * avec un defaut conservateur : sans preuve, on retombe sur le chemin legacy
+ * (extractAction/repairAction) qui marche partout.
+ *
+ * Ces capacites ne s'appliquent QU'a la branche OpenAI-compatible de
+ * callAlbertAPI. Gemini et Anthropic gardent leur chemin existant.
+ */
+
+export interface AlbertCapabilities {
+  /** Modele effectivement cible (alias resolu cote gateway si connu) */
+  model: string;
+  /** response_format:{type:"json_schema"} fonctionne de bout en bout */
+  jsonSchema: boolean;
+  /** tools / tool_choice fonctionne (boucle agentique possible) */
+  toolCalling: boolean;
+  /** Timestamp (ms) de la derniere sonde ; 0 si jamais sondee */
+  probedAt: number;
+}
+
+/**
+ * Defaut conservateur : aucune capacite avancee presumee. Tant qu'une sonde
+ * n'a pas confirme json_schema / toolCalling, on sert le comportement actuel.
+ */
+export const DEFAULT_CAPABILITIES: AlbertCapabilities = {
+  model: '',
+  jsonSchema: false,
+  toolCalling: false,
+  probedAt: 0,
+};
+
+const CAPABILITIES_KEY = 'dsfr-data-ia-capabilities';
+
+/** Cache en memoire (rempli depuis localStorage au premier acces). */
+let cached: AlbertCapabilities | null = null;
+
+/**
+ * Capacites courantes. Lit le cache memoire, sinon localStorage, sinon retourne
+ * null (l'appelant utilisera DEFAULT_CAPABILITIES). On ne sonde JAMAIS pendant un
+ * tour de chat (latence) : la sonde est un script/action explicite.
+ */
+export function getCapabilities(): AlbertCapabilities | null {
+  if (cached !== null) return cached;
+  try {
+    const raw = localStorage.getItem(CAPABILITIES_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<AlbertCapabilities>;
+    cached = {
+      model: typeof parsed.model === 'string' ? parsed.model : '',
+      jsonSchema: parsed.jsonSchema === true,
+      toolCalling: parsed.toolCalling === true,
+      probedAt: typeof parsed.probedAt === 'number' ? parsed.probedAt : 0,
+    };
+    return cached;
+  } catch {
+    return null;
+  }
+}
+
+/** Persiste les capacites (cache memoire + localStorage). */
+export function setCapabilities(caps: AlbertCapabilities): void {
+  cached = caps;
+  try {
+    localStorage.setItem(CAPABILITIES_KEY, JSON.stringify(caps));
+  } catch {
+    /* localStorage indisponible : on garde au moins le cache memoire */
+  }
+}
+
+/** Efface les capacites memorisees (retour au defaut conservateur). */
+export function resetCapabilities(): void {
+  cached = null;
+  try {
+    localStorage.removeItem(CAPABILITIES_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Capacites effectives a utiliser dans callAlbertAPI : les capacites memorisees
+ * si presentes, sinon le defaut conservateur.
+ */
+export function effectiveCapabilities(): AlbertCapabilities {
+  return getCapabilities() ?? DEFAULT_CAPABILITIES;
+}

--- a/apps/builder-ia/src/ia/ia-config.ts
+++ b/apps/builder-ia/src/ia/ia-config.ts
@@ -28,8 +28,64 @@ export interface ServerIAConfig {
 
 const IA_CONFIG_KEY = 'dsfr-data-ia-config';
 
+/** Modele par defaut : openweight-large = gpt-oss-120b cote Albert. */
+export const DEFAULT_MODEL = 'openweight-large';
+
+/** Modeles proposes dans le dropdown (les autres passent par "Personnalise…"). */
+const MODEL_PRESETS = new Set([
+  'openweight-large',
+  'openweight-medium',
+  'openweight-small',
+  'albert-large',
+]);
+
 /** Cached server config (fetched once per session) */
 let serverConfig: ServerIAConfig | null = null;
+
+/**
+ * Lit le modele choisi : valeur du select, ou input "Personnalise…" si actif.
+ * Tolere l'absence du select custom (compat tests / anciens DOM).
+ */
+export function readModelValue(): string {
+  const select = document.getElementById('ia-model') as HTMLSelectElement | null;
+  if (!select) return DEFAULT_MODEL;
+  if (select.value === '__custom__') {
+    const custom = document.getElementById('ia-model-custom') as HTMLInputElement | null;
+    return custom?.value.trim() || DEFAULT_MODEL;
+  }
+  return select.value;
+}
+
+/**
+ * Applique un modele au select : preset -> selectionne l'option ; sinon ->
+ * bascule sur "Personnalise…" et remplit l'input texte.
+ */
+export function applyModelValue(model: string): void {
+  const select = document.getElementById('ia-model') as HTMLSelectElement | null;
+  const custom = document.getElementById('ia-model-custom') as HTMLInputElement | null;
+  if (!select) return;
+  if (MODEL_PRESETS.has(model)) {
+    select.value = model;
+    if (custom) {
+      custom.style.display = 'none';
+      custom.value = '';
+    }
+  } else {
+    select.value = '__custom__';
+    if (custom) {
+      custom.value = model;
+      custom.style.display = '';
+    }
+  }
+}
+
+/** Affiche/masque l'input "Personnalise…" selon l'option choisie. */
+export function onModelSelectChange(): void {
+  const select = document.getElementById('ia-model') as HTMLSelectElement | null;
+  const custom = document.getElementById('ia-model-custom') as HTMLInputElement | null;
+  if (!select || !custom) return;
+  custom.style.display = select.value === '__custom__' ? '' : 'none';
+}
 
 /** Check if user has their own config with a token in localStorage */
 export function hasUserConfig(): boolean {
@@ -90,13 +146,12 @@ export function resetIAConfig(): void {
 
   // Reset form fields to defaults
   const apiUrlEl = document.getElementById('ia-api-url') as HTMLInputElement;
-  const modelEl = document.getElementById('ia-model') as HTMLInputElement;
   const tokenEl = document.getElementById('ia-token') as HTMLInputElement;
 
   if (apiUrlEl)
     apiUrlEl.value =
       serverConfig?.apiUrl || 'https://albert.api.etalab.gouv.fr/v1/chat/completions';
-  if (modelEl) modelEl.value = serverConfig?.model || 'albert-large';
+  applyModelValue(serverConfig?.model || DEFAULT_MODEL);
   if (tokenEl) tokenEl.value = '';
 
   updateIAModeBadge();
@@ -177,7 +232,7 @@ export function loadIAConfig(): void {
       (document.getElementById('ia-api-url') as HTMLInputElement).value = config.apiUrl;
     }
     if (config.model) {
-      (document.getElementById('ia-model') as HTMLInputElement).value = config.model;
+      applyModelValue(config.model);
     }
     if (config.token) {
       (document.getElementById('ia-token') as HTMLInputElement).value = config.token;
@@ -200,7 +255,7 @@ export function loadIAConfig(): void {
 export function saveIAConfig(): void {
   const config: IAConfig = {
     apiUrl: (document.getElementById('ia-api-url') as HTMLInputElement).value,
-    model: (document.getElementById('ia-model') as HTMLInputElement).value,
+    model: readModelValue(),
     token: (document.getElementById('ia-token') as HTMLInputElement).value,
     systemPrompt: (document.getElementById('ia-system-prompt') as HTMLTextAreaElement).value,
     extraParams: getExtraParamsFromDOM(),
@@ -215,7 +270,7 @@ export function saveIAConfig(): void {
 export function getIAConfig(): IAConfig {
   return {
     apiUrl: (document.getElementById('ia-api-url') as HTMLInputElement).value,
-    model: (document.getElementById('ia-model') as HTMLInputElement).value,
+    model: readModelValue(),
     token: (document.getElementById('ia-token') as HTMLInputElement).value,
     systemPrompt: (document.getElementById('ia-system-prompt') as HTMLTextAreaElement).value,
     extraParams: getExtraParamsFromDOM(),

--- a/apps/builder-ia/src/ia/ia-config.ts
+++ b/apps/builder-ia/src/ia/ia-config.ts
@@ -28,7 +28,7 @@ export interface ServerIAConfig {
 
 const IA_CONFIG_KEY = 'dsfr-data-ia-config';
 
-/** Modele par defaut : openweight-large = gpt-oss-120b cote Albert. */
+/** Modele par défaut : openweight-large = gpt-oss-120b cote Albert. */
 export const DEFAULT_MODEL = 'openweight-large';
 
 /** Modeles proposes dans le dropdown (les autres passent par "Personnalise…"). */
@@ -57,7 +57,7 @@ export function readModelValue(): string {
 }
 
 /**
- * Applique un modele au select : preset -> selectionne l'option ; sinon ->
+ * Applique un modele au select : preset -> sélectionne l'option ; sinon ->
  * bascule sur "Personnalise…" et remplit l'input texte.
  */
 export function applyModelValue(model: string): void {

--- a/apps/builder-ia/src/ia/system-prompt.ts
+++ b/apps/builder-ia/src/ia/system-prompt.ts
@@ -1,0 +1,127 @@
+/**
+ * Construction du system prompt selon le mode d'exploitation des skills.
+ *
+ * - legacy    : prompt actuel verbatim (tout empile). Comportement identique
+ *               quand le gateway ne supporte ni json_schema ni tools.
+ * - structured: prompt court + note "reponds par un seul objet action" +
+ *               dataContext + skill createChart (central, petit). Le contrat de
+ *               sortie est garanti par response_format json_schema, donc on
+ *               supprime la liste complete des skills, buildSkillsContext et le
+ *               gros actionReminder en MAJUSCULES.
+ * - tools     : prompt court + consigne d'aller chercher les skills a la demande
+ *               (get_relevant_skills / get_skill) + dataContext + skill
+ *               createChart. C'est le mode incremental/agentique (mirroir MCP).
+ *
+ * Sortir les chaines de prompt de chat.ts permet de les tester et de les faire
+ * evoluer sans toucher a la logique d'appel.
+ */
+
+import { SKILLS } from '../skills.js';
+
+export type PromptMode = 'legacy' | 'structured' | 'tools';
+
+export interface BuildSystemPromptOptions {
+  mode: PromptMode;
+  /** Preambule de role — le textarea utilisateur (config.systemPrompt). */
+  basePrompt: string;
+  /** Contexte de donnees (noms de champs, exemple d'enregistrement). Non fetchable. */
+  dataContext: string;
+  /** Liste des skills disponibles — utilise uniquement en mode legacy. */
+  skillsList?: string;
+  /** Skills injectees integralement — utilise uniquement en mode legacy. */
+  skillsContext?: string;
+  /** Rappel de format — utilise uniquement en mode legacy. */
+  actionReminder?: string;
+}
+
+/** Skill createChart : centrale et petite, gardee dans tous les modes avances. */
+const CREATE_CHART_SKILL = SKILLS.createChartAction?.content ?? '';
+
+const STRUCTURED_NOTE = `
+
+---
+FORMAT DE REPONSE : reponds par UN SEUL objet action conforme au schema impose.
+Champs : "action" ("createChart" | "reloadData" | "resetChart"), "message" (phrase
+courte en francais affichee a l'utilisateur), et selon l'action "config" (createChart)
+ou "query" (reloadData). N'invente jamais de nom de champ : utilise EXACTEMENT ceux du
+contexte de donnees. Pour changer la couleur/palette d'un graphique existant, regenere
+un createChart avec la palette voulue.`;
+
+const TOOLS_NOTE = `
+
+---
+TU DISPOSES D'OUTILS. Quand tu as besoin du detail d'un composant, d'un type de
+graphique ou d'une syntaxe avant de generer, appelle d'abord get_relevant_skills
+(matching par mots-cles) ou get_skill (par id) — ne devine pas. Quand tu es pret,
+appelle l'outil final create_chart, reload_data ou reset_chart. Chaque outil final
+prend un champ "message" (phrase courte en francais). N'invente jamais de nom de
+champ : utilise EXACTEMENT ceux du contexte de donnees.`;
+
+/**
+ * Assemble le system prompt pour le mode demande.
+ *
+ * En mode legacy l'ordre de concatenation reproduit exactement l'assemblage
+ * historique de chat.ts (basePrompt + skillsList + dataContext + skillsContext
+ * + actionReminder) pour garantir l'absence de regression.
+ */
+export function buildSystemPrompt(opts: BuildSystemPromptOptions): string {
+  const { mode, basePrompt, dataContext } = opts;
+
+  if (mode === 'legacy') {
+    return (
+      basePrompt +
+      `\n\nSKILLS DISPONIBLES (seront injectes si pertinents):\n${opts.skillsList ?? ''}` +
+      dataContext +
+      (opts.skillsContext ?? '') +
+      (opts.actionReminder ?? '')
+    );
+  }
+
+  const note = mode === 'tools' ? TOOLS_NOTE : STRUCTURED_NOTE;
+  return (
+    basePrompt +
+    note +
+    dataContext +
+    '\n\n---\nReference (action createChart) :\n' +
+    CREATE_CHART_SKILL
+  );
+}
+
+export interface FewShotMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+/**
+ * Exemples few-shot (tours user/assistant prefixes a la conversation).
+ *
+ * Fournis uniquement pour le mode `structured` : l'assistant y demontre la
+ * sortie attendue (objet action JSON avec message). En mode `tools`, demontrer
+ * un appel d'outil necessiterait une sequence assistant(tool_calls)+tool(result)
+ * fragile a injecter — la consigne textuelle de TOOLS_NOTE est preferee.
+ */
+export function buildFewShot(mode: PromptMode): FewShotMessage[] {
+  if (mode !== 'structured') return [];
+  return [
+    {
+      role: 'user',
+      content: 'Un diagramme en barres de la population par region, top 5.',
+    },
+    {
+      role: 'assistant',
+      content: JSON.stringify({
+        action: 'createChart',
+        message: 'Voici le top 5 des regions par population.',
+        config: {
+          type: 'bar',
+          labelField: 'region',
+          valueField: 'population',
+          aggregation: 'sum',
+          limit: 5,
+          sortOrder: 'desc',
+          title: 'Top 5 regions par population',
+        },
+      }),
+    },
+  ];
+}

--- a/apps/builder-ia/src/ia/system-prompt.ts
+++ b/apps/builder-ia/src/ia/system-prompt.ts
@@ -24,7 +24,7 @@ export interface BuildSystemPromptOptions {
   mode: PromptMode;
   /** Preambule de role — le textarea utilisateur (config.systemPrompt). */
   basePrompt: string;
-  /** Contexte de donnees (noms de champs, exemple d'enregistrement). Non fetchable. */
+  /** Contexte de données (noms de champs, exemple d'enregistrement). Non fetchable. */
   dataContext: string;
   /** Liste des skills disponibles — utilise uniquement en mode legacy. */
   skillsList?: string;
@@ -44,18 +44,18 @@ FORMAT DE REPONSE : reponds par UN SEUL objet action conforme au schema impose.
 Champs : "action" ("createChart" | "reloadData" | "resetChart"), "message" (phrase
 courte en francais affichee a l'utilisateur), et selon l'action "config" (createChart)
 ou "query" (reloadData). N'invente jamais de nom de champ : utilise EXACTEMENT ceux du
-contexte de donnees. Pour changer la couleur/palette d'un graphique existant, regenere
+contexte de données. Pour changer la couleur/palette d'un graphique existant, regenere
 un createChart avec la palette voulue.`;
 
 const TOOLS_NOTE = `
 
 ---
 TU DISPOSES D'OUTILS. Quand tu as besoin du detail d'un composant, d'un type de
-graphique ou d'une syntaxe avant de generer, appelle d'abord get_relevant_skills
-(matching par mots-cles) ou get_skill (par id) — ne devine pas. Quand tu es pret,
+graphique ou d'une syntaxe avant de générer, appelle d'abord get_relevant_skills
+(matching par mots-clés) ou get_skill (par id) — ne devine pas. Quand tu es pret,
 appelle l'outil final create_chart, reload_data ou reset_chart. Chaque outil final
 prend un champ "message" (phrase courte en francais). N'invente jamais de nom de
-champ : utilise EXACTEMENT ceux du contexte de donnees.`;
+champ : utilise EXACTEMENT ceux du contexte de données.`;
 
 /**
  * Assemble le system prompt pour le mode demande.

--- a/apps/builder-ia/src/main.ts
+++ b/apps/builder-ia/src/main.ts
@@ -24,6 +24,7 @@ import {
   fetchServerConfig,
   updateIAModeBadge,
   resetIAConfig,
+  onModelSelectChange,
 } from './ia/ia-config.js';
 import { addMessage, sendMessage } from './chat/chat.js';
 import {
@@ -43,6 +44,7 @@ import { state } from './state.js';
 };
 (window as unknown as Record<string, unknown>).resetIAConfig = resetIAConfig;
 (window as unknown as Record<string, unknown>).addExtraParam = addExtraParam;
+(window as unknown as Record<string, unknown>).onModelSelectChange = onModelSelectChange;
 (window as unknown as Record<string, unknown>).loadSavedSourceData = loadSavedSourceData;
 (window as unknown as Record<string, unknown>).sendMessage = sendMessage;
 (window as unknown as Record<string, unknown>).copyCode = copyCode;

--- a/apps/builder-ia/src/sources.ts
+++ b/apps/builder-ia/src/sources.ts
@@ -15,6 +15,7 @@ import {
 import { state } from './state.js';
 import type { Source, Field } from './state.js';
 import { addMessage } from './chat/chat.js';
+import { collapseSection } from './ui/ui-helpers.js';
 
 /**
  * Load saved sources from localStorage and populate the dropdown
@@ -161,6 +162,12 @@ export function handleSourceChange(): void {
         '<button class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline source-btn" id="show-data-preview-btn"><i class="ri-database-2-line"></i> Voir</button>';
       document.getElementById('show-data-preview-btn')?.addEventListener('click', showDataPreview);
     }
+
+    // Source chargee : on replie la section pour rendre la hauteur au chat, et
+    // on resume la source dans le titre (visible meme replie).
+    const summaryEl = document.getElementById('source-summary');
+    if (summaryEl) summaryEl.textContent = `· ${source.name}`;
+    collapseSection('section-source');
   }
 }
 

--- a/apps/builder-ia/src/sources.ts
+++ b/apps/builder-ia/src/sources.ts
@@ -164,7 +164,7 @@ export function handleSourceChange(): void {
     }
 
     // Source chargee : on replie la section pour rendre la hauteur au chat, et
-    // on resume la source dans le titre (visible meme replie).
+    // on resume la source dans le titre (visible même replie).
     const summaryEl = document.getElementById('source-summary');
     if (summaryEl) summaryEl.textContent = `· ${source.name}`;
     collapseSection('section-source');

--- a/apps/builder-ia/src/styles/builder-ia.css
+++ b/apps/builder-ia/src/styles/builder-ia.css
@@ -6,9 +6,14 @@
 
 body {
   margin: 0;
-  min-height: 100vh;
+  /* Hauteur DEFINIE (pas seulement min-height) : sans ca, app-layout-builder
+     (flex:1) grandit jusqu'a son contenu et la page scrolle. Avec height:100vh,
+     la chaine flex est plafonnee et le scroll vit dans .chat-messages (pattern
+     chat IA moderne). */
+  height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
   background: var(--background-alt-grey);
 }
 
@@ -30,6 +35,10 @@ body {
 /* PANNEAU GAUCHE : CONFIG + CHAT */
 /* ============================================ */
 .builder-config-panel {
+  /* Remplit toute la hauteur de la colonne gauche pour que .chat-container
+     (flex:1) absorbe l'espace restant sous les sections de config et que le
+     scroll vive dans .chat-messages, pas dans la colonne. */
+  flex: 1;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -47,6 +56,17 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+/* Resume de section (ex: nom de la source) affiche dans le titre, surtout utile
+   quand la section est repliee. */
+.config-section-summary {
+  font-weight: 400;
+  font-size: 0.8rem;
+  color: var(--text-mention-grey);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .step-number {
@@ -141,6 +161,9 @@ body {
 }
 
 .chat-messages {
+  /* Pattern chat IA moderne : zone bornee qui remplit l'espace dispo et scrolle
+     en interne ; les anciens messages defilent par le haut, le dernier reste
+     visible pres de l'input (autoscroll cote JS). */
   flex: 1;
   overflow-y: auto;
   padding: 1rem;
@@ -213,7 +236,40 @@ body {
   color: white;
 }
 
-/* Input zone */
+/* Etapes agentiques live (dans l'indicateur de reflexion) */
+.chat-step {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--text-mention-grey);
+  padding: 0.1rem 0;
+}
+
+/* Raisonnement agentique persistant, replie sous la reponse finale */
+.chat-reasoning {
+  margin-top: 0.5rem;
+  font-size: 0.78rem;
+}
+
+.chat-reasoning summary {
+  cursor: pointer;
+  color: var(--text-mention-grey);
+  user-select: none;
+}
+
+.chat-reasoning ul {
+  margin: 0.4rem 0 0;
+  padding-left: 1.1rem;
+  color: var(--text-mention-grey);
+}
+
+.chat-reasoning li {
+  margin: 0.15rem 0;
+}
+
+/* Input zone — epinglee en bas de la zone de chat (le scroll vit dans
+   .chat-messages au-dessus). */
 .chat-input-container {
   padding: 1rem;
   border-top: 1px solid var(--border-default-grey);

--- a/apps/builder-ia/src/ui/ui-helpers.ts
+++ b/apps/builder-ia/src/ui/ui-helpers.ts
@@ -35,6 +35,15 @@ export function toggleSection(sectionId: string): void {
 }
 
 /**
+ * Collapse a section deterministically (no-op if already collapsed). Used to
+ * fold "Source de données" once a source is loaded, freeing vertical space for
+ * the chat (modern chat pattern).
+ */
+export function collapseSection(sectionId: string): void {
+  document.getElementById(sectionId)?.classList.add('collapsed');
+}
+
+/**
  * Copy generated code to clipboard
  */
 export function copyCode(): void {

--- a/scripts/ia-default-server.js
+++ b/scripts/ia-default-server.js
@@ -19,7 +19,7 @@ const { request, EnvHttpProxyAgent, setGlobalDispatcher } = require('undici');
 const TOKEN = process.env.IA_DEFAULT_TOKEN || '';
 const API_URL =
   process.env.IA_DEFAULT_API_URL || 'https://albert.api.etalab.gouv.fr/v1/chat/completions';
-const MODEL = process.env.IA_DEFAULT_MODEL || 'albert-large';
+const MODEL = process.env.IA_DEFAULT_MODEL || 'openweight-large';
 const PORT = 3003;
 
 // Active le proxy HTTP sortant si HTTP_PROXY ou HTTPS_PROXY est défini.

--- a/scripts/probe-albert.ts
+++ b/scripts/probe-albert.ts
@@ -1,0 +1,209 @@
+/**
+ * Sonde empirique des capacites du gateway Albert (OpenGateLLM).
+ *
+ * Un parametre present dans l'OpenAPI d'Albert (tools, response_format
+ * json_schema...) ne garantit pas qu'il fonctionne de bout en bout sur leur
+ * deploiement vLLM. Ce script verifie, avec un vrai token, ce qui marche
+ * REELLEMENT, pour decider quelles capacites activer dans builder-ia
+ * (cf. apps/builder-ia/src/ia/albert-capabilities.ts).
+ *
+ * READ-ONLY : n'ecrit aucun fichier, imprime sur stdout.
+ *
+ * Usage :
+ *   npx tsx scripts/probe-albert.ts --token <TOKEN> [--url <chat-url>] [--model openweight-large]
+ *   IA_DEFAULT_TOKEN=xxx npx tsx scripts/probe-albert.ts
+ */
+
+function getArg(name: string): string | undefined {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : undefined;
+}
+
+const TOKEN = getArg('--token') ?? process.env.IA_DEFAULT_TOKEN ?? '';
+const CHAT_URL =
+  getArg('--url') ?? 'https://albert.api.etalab.gouv.fr/v1/chat/completions';
+const MODEL = getArg('--model') ?? 'openweight-large';
+
+if (!TOKEN) {
+  console.error('Erreur : token requis (--token <T> ou IA_DEFAULT_TOKEN).');
+  process.exit(1);
+}
+
+const ORIGIN = (() => {
+  try {
+    return new URL(CHAT_URL).origin;
+  } catch {
+    return 'https://albert.api.etalab.gouv.fr';
+  }
+})();
+
+const AUTH = { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' };
+
+interface ChatResult {
+  ok: boolean;
+  status: number;
+  ms: number;
+  body: Record<string, unknown> | null;
+  error?: string;
+}
+
+async function chat(payload: Record<string, unknown>): Promise<ChatResult> {
+  const start = Date.now();
+  try {
+    const res = await fetch(CHAT_URL, {
+      method: 'POST',
+      headers: AUTH,
+      body: JSON.stringify(payload),
+    });
+    const ms = Date.now() - start;
+    let body: Record<string, unknown> | null = null;
+    try {
+      body = (await res.json()) as Record<string, unknown>;
+    } catch {
+      /* non-JSON */
+    }
+    return { ok: res.ok, status: res.status, ms, body };
+  } catch (err) {
+    return { ok: false, status: 0, ms: Date.now() - start, body: null, error: String(err) };
+  }
+}
+
+function contentOf(r: ChatResult): string {
+  const choices = (r.body?.choices as { message?: { content?: string } }[]) ?? [];
+  return choices[0]?.message?.content ?? '';
+}
+
+function toolCallsOf(r: ChatResult): unknown[] {
+  const choices = (r.body?.choices as { message?: { tool_calls?: unknown[] } }[]) ?? [];
+  return choices[0]?.message?.tool_calls ?? [];
+}
+
+async function main() {
+  console.log(`\n=== Sonde Albert ===`);
+  console.log(`URL    : ${CHAT_URL}`);
+  console.log(`Modele : ${MODEL}\n`);
+
+  // 1) Identite modele / catalogue
+  let resolved = MODEL;
+  try {
+    const res = await fetch(`${ORIGIN}/v1/models`, { headers: AUTH });
+    if (res.ok) {
+      const data = (await res.json()) as { data?: { id: string }[] };
+      const ids = (data.data ?? []).map((m) => m.id);
+      console.log(`1. Modeles disponibles (${ids.length}) : ${ids.join(', ') || '(liste vide)'}`);
+      const match = ids.find((id) => id === MODEL || id.includes(MODEL));
+      if (match) resolved = match;
+    } else {
+      console.log(`1. GET /v1/models -> HTTP ${res.status} (catalogue non lisible)`);
+    }
+  } catch (err) {
+    console.log(`1. GET /v1/models -> erreur ${err}`);
+  }
+
+  // 2) Completion simple + latence
+  const ping = await chat({
+    model: MODEL,
+    messages: [{ role: 'user', content: 'ping' }],
+    max_completion_tokens: 5,
+  });
+  console.log(
+    `2. Completion simple : ${ping.ok ? 'OK' : 'ECHEC'} (HTTP ${ping.status}, ${ping.ms} ms)` +
+      (ping.error ? ` — ${ping.error}` : '')
+  );
+
+  // 3) response_format json_schema (Structured Outputs)
+  const schema = {
+    type: 'object',
+    properties: { ok: { type: 'boolean' } },
+    required: ['ok'],
+    additionalProperties: false,
+  };
+  const js = await chat({
+    model: MODEL,
+    messages: [{ role: 'user', content: 'Reponds avec {"ok": true}.' }],
+    max_completion_tokens: 50,
+    response_format: { type: 'json_schema', json_schema: { name: 'probe', schema, strict: true } },
+  });
+  let jsonSchema = false;
+  if (js.ok) {
+    try {
+      const parsed = JSON.parse(contentOf(js));
+      jsonSchema = typeof parsed === 'object' && parsed !== null && 'ok' in parsed;
+    } catch {
+      /* sortie non conforme */
+    }
+  }
+  console.log(`3. response_format json_schema : ${jsonSchema ? 'OK' : 'ECHEC'} (HTTP ${js.status})`);
+
+  // 3b) response_format json_object (echelon de repli)
+  const jo = await chat({
+    model: MODEL,
+    messages: [{ role: 'user', content: 'Reponds en JSON : {"ok": true}.' }],
+    max_completion_tokens: 50,
+    response_format: { type: 'json_object' },
+  });
+  let jsonObject = false;
+  if (jo.ok) {
+    try {
+      JSON.parse(contentOf(jo));
+      jsonObject = true;
+    } catch {
+      /* */
+    }
+  }
+  console.log(`   (repli) response_format json_object : ${jsonObject ? 'OK' : 'ECHEC'} (HTTP ${jo.status})`);
+
+  // 4) Tool calling (auto puis force)
+  const tool = {
+    type: 'function',
+    function: {
+      name: 'ping',
+      description: 'Repond ping',
+      parameters: { type: 'object', properties: {}, additionalProperties: false },
+    },
+  };
+  const auto = await chat({
+    model: MODEL,
+    messages: [{ role: 'user', content: 'Appelle l outil ping.' }],
+    max_completion_tokens: 50,
+    tools: [tool],
+    tool_choice: 'auto',
+  });
+  const autoOk = auto.ok && toolCallsOf(auto).length > 0;
+  const forced = await chat({
+    model: MODEL,
+    messages: [{ role: 'user', content: 'Appelle l outil ping.' }],
+    max_completion_tokens: 50,
+    tools: [tool],
+    tool_choice: { type: 'function', function: { name: 'ping' } },
+  });
+  const forcedOk = forced.ok && toolCallsOf(forced).length > 0;
+  console.log(
+    `4. Tool calling : auto=${autoOk ? 'OK' : 'ECHEC'} (HTTP ${auto.status}), force=${forcedOk ? 'OK' : 'ECHEC'} (HTTP ${forced.status})`
+  );
+
+  // Synthese : ligne AlbertCapabilities copiable
+  const toolCalling = autoOk || forcedOk;
+  console.log(`\n--- Synthese ---`);
+  console.log(`Modele resolu : ${resolved}`);
+  console.log(`A coller dans setCapabilities(...) ou pour decider du defaut serveur :`);
+  console.log(
+    JSON.stringify({ model: resolved, jsonSchema, toolCalling, probedAt: 0 }, null, 0)
+  );
+  console.log(
+    `\nRecommandation : ${
+      toolCalling
+        ? 'tool-calling actif -> mode agentique incremental possible.'
+        : jsonSchema
+          ? 'structured outputs actif -> mode structure (boucle agentique indispo).'
+          : jsonObject
+            ? 'seul json_object marche -> rester sur le mode structure/legacy avec prudence.'
+            : 'aucune capacite avancee confirmee -> mode legacy (parsing regex).'
+    }`
+  );
+}
+
+main().catch((err) => {
+  console.error('Sonde : erreur fatale', err);
+  process.exit(1);
+});

--- a/tests/apps/builder-ia/action-schema.test.ts
+++ b/tests/apps/builder-ia/action-schema.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CHART_TYPES,
+  ACTION_JSON_SCHEMA,
+  CONFIG_SCHEMA,
+  FINAL_ACTION_TOOLS,
+  SKILL_LOOKUP_TOOLS,
+  FINAL_TOOL_NAMES,
+  toolNameToAction,
+  validateAction,
+} from '../../../apps/builder-ia/src/ia/action-schema';
+
+describe('builder-ia action-schema', () => {
+  describe('alignement avec ChartConfig', () => {
+    it("l'enum type du schema couvre exactement les types de ChartConfig", () => {
+      // Source de verite : les types declares dans state.ts ChartConfig.
+      const chartConfigTypes = [
+        'bar',
+        'line',
+        'pie',
+        'doughnut',
+        'radar',
+        'horizontalBar',
+        'scatter',
+        'gauge',
+        'kpi',
+        'map',
+        'bar-line',
+        'map-reg',
+        'datalist',
+        'podium',
+      ];
+      expect([...CHART_TYPES].sort()).toEqual([...chartConfigTypes].sort());
+      expect(CONFIG_SCHEMA.properties.type.enum).toEqual([...CHART_TYPES]);
+    });
+
+    it('le schema exige action + message au minimum', () => {
+      expect(ACTION_JSON_SCHEMA.required).toContain('action');
+      expect(ACTION_JSON_SCHEMA.required).toContain('message');
+      expect(ACTION_JSON_SCHEMA.additionalProperties).toBe(false);
+    });
+  });
+
+  describe('validateAction', () => {
+    it('accepte un createChart canonique (exemple de skill)', () => {
+      const result = validateAction({
+        action: 'createChart',
+        message: 'Top 5 regions',
+        config: {
+          type: 'bar',
+          labelField: 'region',
+          valueField: 'population',
+          aggregation: 'sum',
+          limit: 5,
+          sortOrder: 'desc',
+        },
+      });
+      expect(result).not.toBeNull();
+      expect(result?.action).toBe('createChart');
+      expect(result?.config?.type).toBe('bar');
+      expect(result?.message).toBe('Top 5 regions');
+    });
+
+    it('accepte un reloadData canonique', () => {
+      const result = validateAction({
+        action: 'reloadData',
+        message: 'Prix moyen par region',
+        query: { where: 'prix > 50', group_by: 'region' },
+      });
+      expect(result?.action).toBe('reloadData');
+      expect(result?.query).toEqual({ where: 'prix > 50', group_by: 'region' });
+    });
+
+    it('accepte resetChart sans payload', () => {
+      const result = validateAction({ action: 'resetChart', message: 'On repart de zero' });
+      expect(result?.action).toBe('resetChart');
+    });
+
+    it('rejette une action hallucinee', () => {
+      expect(validateAction({ action: 'table', config: { type: 'bar' } })).toBeNull();
+      expect(validateAction({ action: 'filter' })).toBeNull();
+    });
+
+    it('rejette createChart avec un type invalide', () => {
+      expect(
+        validateAction({ action: 'createChart', config: { type: 'pyramide', valueField: 'x' } })
+      ).toBeNull();
+    });
+
+    it('rejette createChart sans valueField', () => {
+      expect(validateAction({ action: 'createChart', config: { type: 'bar' } })).toBeNull();
+    });
+
+    it('rejette les entrees non-objet', () => {
+      expect(validateAction(null)).toBeNull();
+      expect(validateAction('createChart')).toBeNull();
+      expect(validateAction(42)).toBeNull();
+    });
+  });
+
+  describe('tools', () => {
+    it('expose les 3 tools finaux et 2 tools de lookup', () => {
+      const finalNames = FINAL_ACTION_TOOLS.map((t) => t.function.name);
+      expect(finalNames).toEqual(['create_chart', 'reload_data', 'reset_chart']);
+      const lookupNames = SKILL_LOOKUP_TOOLS.map((t) => t.function.name);
+      expect(lookupNames).toEqual(['get_relevant_skills', 'get_skill']);
+    });
+
+    it('FINAL_TOOL_NAMES contient les tools terminaux', () => {
+      expect(FINAL_TOOL_NAMES.has('create_chart')).toBe(true);
+      expect(FINAL_TOOL_NAMES.has('get_skill')).toBe(false);
+    });
+
+    it('toolNameToAction mappe correctement', () => {
+      expect(toolNameToAction('create_chart')).toBe('createChart');
+      expect(toolNameToAction('reload_data')).toBe('reloadData');
+      expect(toolNameToAction('reset_chart')).toBe('resetChart');
+      expect(toolNameToAction('get_skill')).toBeNull();
+    });
+  });
+});

--- a/tests/apps/builder-ia/agent-loop.test.ts
+++ b/tests/apps/builder-ia/agent-loop.test.ts
@@ -8,7 +8,11 @@ function toolCallMsg(name: string, args: unknown, content = '') {
         message: {
           content,
           tool_calls: [
-            { id: `call_${name}`, type: 'function', function: { name, arguments: JSON.stringify(args) } },
+            {
+              id: `call_${name}`,
+              type: 'function',
+              function: { name, arguments: JSON.stringify(args) },
+            },
           ],
         },
       },
@@ -32,24 +36,30 @@ describe('builder-ia agent-loop', () => {
       .mockResolvedValueOnce(
         toolCallMsg(
           'create_chart',
-          { message: 'Voici votre graphique', config: { type: 'bar', valueField: 'population', labelField: 'region' } },
+          {
+            message: 'Voici votre graphique',
+            config: { type: 'bar', valueField: 'population', labelField: 'region' },
+          },
           'Voici'
         )
       );
-    const progress: string[] = [];
+    let progress: string[] = [];
 
     const result = await runAgentLoop({
       ...baseOpts,
       post,
-      onProgress: (label) => progress.push(label),
+      onProgress: (steps) => {
+        progress = steps;
+      },
     });
 
     expect(post).toHaveBeenCalledTimes(2);
     expect(result.action?.action).toBe('createChart');
     expect(result.action?.config?.type).toBe('bar');
     expect(result.text).toBe('Voici votre graphique');
-    // L'indicateur de progression a signale la consultation du skill.
-    expect(progress).toContain('Consultation : get_relevant_skills');
+    // L'etape de consultation a ete humanisee, accumulee et exposee.
+    expect(progress).toContain('Je cherche les bons reglages…');
+    expect(result.steps).toContain('Je cherche les bons reglages…');
 
     // Le 2e appel contient un message role:"tool" (resultat du lookup) accumule.
     const secondBody = post.mock.calls[1][0] as { messages: { role: string }[] };

--- a/tests/apps/builder-ia/agent-loop.test.ts
+++ b/tests/apps/builder-ia/agent-loop.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runAgentLoop } from '../../../apps/builder-ia/src/ia/agent-loop';
+
+function toolCallMsg(name: string, args: unknown, content = '') {
+  return {
+    choices: [
+      {
+        message: {
+          content,
+          tool_calls: [
+            { id: `call_${name}`, type: 'function', function: { name, arguments: JSON.stringify(args) } },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+const baseOpts = {
+  conversation: [{ role: 'user' as const, content: 'barres population par region' }],
+  systemPrompt: 'system',
+  source: null,
+  model: 'openweight-large',
+  temperature: 0.1,
+};
+
+describe('builder-ia agent-loop', () => {
+  it('consulte un skill puis termine sur create_chart', async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(toolCallMsg('get_relevant_skills', { message: 'barres population' }))
+      .mockResolvedValueOnce(
+        toolCallMsg(
+          'create_chart',
+          { message: 'Voici votre graphique', config: { type: 'bar', valueField: 'population', labelField: 'region' } },
+          'Voici'
+        )
+      );
+    const progress: string[] = [];
+
+    const result = await runAgentLoop({
+      ...baseOpts,
+      post,
+      onProgress: (label) => progress.push(label),
+    });
+
+    expect(post).toHaveBeenCalledTimes(2);
+    expect(result.action?.action).toBe('createChart');
+    expect(result.action?.config?.type).toBe('bar');
+    expect(result.text).toBe('Voici votre graphique');
+    // L'indicateur de progression a signale la consultation du skill.
+    expect(progress).toContain('Consultation : get_relevant_skills');
+
+    // Le 2e appel contient un message role:"tool" (resultat du lookup) accumule.
+    const secondBody = post.mock.calls[1][0] as { messages: { role: string }[] };
+    expect(secondBody.messages.some((m) => m.role === 'tool')).toBe(true);
+    expect(secondBody.messages.some((m) => m.role === 'assistant')).toBe(true);
+  });
+
+  it('respecte MAX_ROUNDS si le modele boucle sur les lookups', async () => {
+    // Renvoie toujours un lookup different (sinon le garde anti-repetition coupe avant).
+    let n = 0;
+    const post = vi.fn().mockImplementation(() => {
+      n += 1;
+      return Promise.resolve(toolCallMsg('get_relevant_skills', { message: `essai ${n}` }));
+    });
+
+    const result = await runAgentLoop({ ...baseOpts, post });
+
+    expect(post).toHaveBeenCalledTimes(3); // MAX_ROUNDS
+    expect(result.action).toBeNull();
+  });
+
+  it('retourne une reponse conversationnelle quand pas de tool_call', async () => {
+    const post = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: 'Bonjour, que veux-tu visualiser ?', tool_calls: [] } }],
+    });
+
+    const result = await runAgentLoop({ ...baseOpts, post });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(result.action).toBeNull();
+    expect(result.text).toBe('Bonjour, que veux-tu visualiser ?');
+  });
+});

--- a/tests/apps/builder-ia/agent-loop.test.ts
+++ b/tests/apps/builder-ia/agent-loop.test.ts
@@ -58,8 +58,8 @@ describe('builder-ia agent-loop', () => {
     expect(result.action?.config?.type).toBe('bar');
     expect(result.text).toBe('Voici votre graphique');
     // L'etape de consultation a ete humanisee, accumulee et exposee.
-    expect(progress).toContain('Je cherche les bons reglages…');
-    expect(result.steps).toContain('Je cherche les bons reglages…');
+    expect(progress).toContain('Je cherche les bons réglages…');
+    expect(result.steps).toContain('Je cherche les bons réglages…');
 
     // Le 2e appel contient un message role:"tool" (resultat du lookup) accumule.
     const secondBody = post.mock.calls[1][0] as { messages: { role: string }[] };

--- a/tests/apps/builder-ia/albert-capabilities.test.ts
+++ b/tests/apps/builder-ia/albert-capabilities.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DEFAULT_CAPABILITIES,
+  getCapabilities,
+  setCapabilities,
+  resetCapabilities,
+  effectiveCapabilities,
+} from '../../../apps/builder-ia/src/ia/albert-capabilities';
+
+describe('builder-ia albert-capabilities', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetCapabilities();
+  });
+
+  it('defaut conservateur : aucune capacite avancee', () => {
+    expect(DEFAULT_CAPABILITIES.jsonSchema).toBe(false);
+    expect(DEFAULT_CAPABILITIES.toolCalling).toBe(false);
+  });
+
+  it('getCapabilities retourne null sans sonde', () => {
+    expect(getCapabilities()).toBeNull();
+  });
+
+  it('effectiveCapabilities retombe sur le defaut sans sonde', () => {
+    expect(effectiveCapabilities()).toEqual(DEFAULT_CAPABILITIES);
+  });
+
+  it('setCapabilities persiste et est relu', () => {
+    setCapabilities({ model: 'openweight-large', jsonSchema: true, toolCalling: true, probedAt: 123 });
+    const caps = getCapabilities();
+    expect(caps?.jsonSchema).toBe(true);
+    expect(caps?.toolCalling).toBe(true);
+    expect(caps?.model).toBe('openweight-large');
+    // Persiste en localStorage.
+    expect(localStorage.getItem('dsfr-data-ia-capabilities')).toContain('openweight-large');
+  });
+
+  it('resetCapabilities efface tout', () => {
+    setCapabilities({ model: 'm', jsonSchema: true, toolCalling: false, probedAt: 1 });
+    resetCapabilities();
+    expect(getCapabilities()).toBeNull();
+    expect(effectiveCapabilities()).toEqual(DEFAULT_CAPABILITIES);
+  });
+
+  it('tolere un localStorage corrompu', () => {
+    localStorage.setItem('dsfr-data-ia-capabilities', 'not-json');
+    expect(getCapabilities()).toBeNull();
+  });
+});

--- a/tests/apps/builder-ia/ia-model-select.test.ts
+++ b/tests/apps/builder-ia/ia-model-select.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DEFAULT_MODEL,
+  readModelValue,
+  applyModelValue,
+  onModelSelectChange,
+} from '../../../apps/builder-ia/src/ia/ia-config';
+
+function mountModelDom() {
+  document.body.innerHTML = `
+    <select id="ia-model">
+      <option value="openweight-large">openweight-large</option>
+      <option value="openweight-medium">openweight-medium</option>
+      <option value="openweight-small">openweight-small</option>
+      <option value="albert-large">albert-large</option>
+      <option value="__custom__">Personnalise…</option>
+    </select>
+    <input id="ia-model-custom" style="display:none;" />
+  `;
+}
+
+describe('builder-ia model select', () => {
+  beforeEach(mountModelDom);
+
+  it('DEFAULT_MODEL est openweight-large (gpt-oss-120b)', () => {
+    expect(DEFAULT_MODEL).toBe('openweight-large');
+  });
+
+  it('applyModelValue selectionne un preset et masque le custom', () => {
+    applyModelValue('openweight-medium');
+    const select = document.getElementById('ia-model') as HTMLSelectElement;
+    const custom = document.getElementById('ia-model-custom') as HTMLInputElement;
+    expect(select.value).toBe('openweight-medium');
+    expect(custom.style.display).toBe('none');
+    expect(readModelValue()).toBe('openweight-medium');
+  });
+
+  it('applyModelValue bascule en custom pour un modele hors-preset', () => {
+    applyModelValue('gpt-4o');
+    const select = document.getElementById('ia-model') as HTMLSelectElement;
+    const custom = document.getElementById('ia-model-custom') as HTMLInputElement;
+    expect(select.value).toBe('__custom__');
+    expect(custom.value).toBe('gpt-4o');
+    expect(custom.style.display).toBe('');
+    expect(readModelValue()).toBe('gpt-4o');
+  });
+
+  it('onModelSelectChange affiche/masque le champ custom', () => {
+    const select = document.getElementById('ia-model') as HTMLSelectElement;
+    const custom = document.getElementById('ia-model-custom') as HTMLInputElement;
+
+    select.value = '__custom__';
+    onModelSelectChange();
+    expect(custom.style.display).toBe('');
+
+    select.value = 'openweight-small';
+    onModelSelectChange();
+    expect(custom.style.display).toBe('none');
+  });
+
+  it('readModelValue retombe sur le defaut si le custom est vide', () => {
+    const select = document.getElementById('ia-model') as HTMLSelectElement;
+    select.value = '__custom__';
+    (document.getElementById('ia-model-custom') as HTMLInputElement).value = '   ';
+    expect(readModelValue()).toBe(DEFAULT_MODEL);
+  });
+});

--- a/tests/apps/builder-ia/system-prompt.test.ts
+++ b/tests/apps/builder-ia/system-prompt.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { buildSystemPrompt, buildFewShot } from '../../../apps/builder-ia/src/ia/system-prompt';
+
+const BASE = 'Tu es un assistant.';
+const DATA = '\n\nDonnees actuelles : Champs : region (texte), population (nombre)';
+
+describe('builder-ia system-prompt', () => {
+  describe('mode legacy', () => {
+    it('reproduit l ordre historique (base + skillsList + data + skillsContext + reminder)', () => {
+      const prompt = buildSystemPrompt({
+        mode: 'legacy',
+        basePrompt: BASE,
+        dataContext: DATA,
+        skillsList: '- skillA: desc',
+        skillsContext: '\n\nSKILLS INJECTES : ...',
+        actionReminder: '\n\nREGLE ABSOLUE ...',
+      });
+      expect(prompt).toContain('SKILLS DISPONIBLES');
+      expect(prompt).toContain('- skillA: desc');
+      expect(prompt).toContain('REGLE ABSOLUE');
+      expect(prompt.indexOf(BASE)).toBeLessThan(prompt.indexOf('SKILLS DISPONIBLES'));
+      expect(prompt.indexOf(DATA)).toBeLessThan(prompt.indexOf('REGLE ABSOLUE'));
+    });
+  });
+
+  describe('mode tools', () => {
+    it('exclut la liste complete des skills et le bloc CAPS, inclut la consigne outils', () => {
+      const prompt = buildSystemPrompt({ mode: 'tools', basePrompt: BASE, dataContext: DATA });
+      expect(prompt).not.toContain('SKILLS DISPONIBLES');
+      expect(prompt).not.toContain('REGLE ABSOLUE');
+      expect(prompt).toContain('get_relevant_skills');
+      expect(prompt).toContain('create_chart');
+      expect(prompt).toContain(DATA);
+    });
+  });
+
+  describe('mode structured', () => {
+    it('exclut le bloc CAPS, impose un objet action, garde le dataContext', () => {
+      const prompt = buildSystemPrompt({ mode: 'structured', basePrompt: BASE, dataContext: DATA });
+      expect(prompt).not.toContain('REGLE ABSOLUE');
+      expect(prompt).not.toContain('SKILLS DISPONIBLES');
+      expect(prompt).toContain('UN SEUL objet action');
+      expect(prompt).toContain(DATA);
+    });
+  });
+
+  describe('buildFewShot', () => {
+    it('fournit un exemple user/assistant en mode structured', () => {
+      const shots = buildFewShot('structured');
+      expect(shots.length).toBe(2);
+      expect(shots[0].role).toBe('user');
+      expect(shots[1].role).toBe('assistant');
+      const parsed = JSON.parse(shots[1].content);
+      expect(parsed.action).toBe('createChart');
+      expect(parsed.config.type).toBe('bar');
+    });
+
+    it('ne fournit pas de few-shot message en mode tools (consigne textuelle preferee)', () => {
+      expect(buildFewShot('tools')).toEqual([]);
+      expect(buildFewShot('legacy')).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Contexte

L'assistant IA embarqué (builder-ia → Albert) donnait des résultats nettement inférieurs au même corpus de skills exploité via le MCP + Claude. Diagnostic : l'écart venait surtout de **la façon dont les skills étaient exploitées** (un seul system prompt géant + parsing regex), pas du modèle. Cette PR aligne builder-ia sur le pattern du MCP et refond l'UX du chat.

## 1. Exploitation des capacités d'Albert (commit `2cf0fee`)

Capacités vérifiées sur l'OpenAPI réel d'Albert (OpenGateLLM) : `response_format` **json_schema** (Structured Outputs), `tools`/`tool_choice`, `seed`, `temperature`. Alias `openweight-large` = **gpt-oss-120b**.

- **Flag de capacité** (`albert-capabilities.ts`) + **sonde empirique** (`scripts/probe-albert.ts`) : qu'un paramètre soit dans le schéma ≠ qu'il marche de bout en bout sur le déploiement vLLM → on sonde et on dégrade proprement.
- **Structured Outputs** (`action-schema.ts`) : le contrat d'action (createChart/reloadData/resetChart, calqué sur `ChartConfig`, avec champ `message`) est garanti par `response_format: json_schema` au lieu d'être récupéré au regex.
- **Boucle agentique** (`agent-loop.ts`) : tools `get_relevant_skills`/`get_skill` récupérés à la demande (analogue navigateur du MCP) avant l'action finale — fini le prompt-stuffing.
- **Slim prompt + few-shot** (`system-prompt.ts`) : 3 modes (legacy / structured / tools). Le mode legacy reste **identique** au comportement actuel (zéro régression sans capacité).
- **Sélection de modèle** : dropdown (`openweight-large` par défaut), défauts serveur (`ia-default-server.js`, `.env.example`) basculés sur gpt-oss-120b, mapping `max_tokens`→`max_completion_tokens`.

Gemini/Anthropic : branches inchangées. Tout le nouveau code est gated par les flags de capacité.

## 2. Refonte UX du chat (commit `fa1334d`, suite audit `ui-auditor`)

- **Pattern chat IA moderne** : zone de conversation bornée qui remplit le viewport, input épinglé en bas, autoscroll vers le dernier message ; les anciens messages défilent par le haut. Fix de la chaîne de hauteur (`body height:100vh` + `.builder-config-panel flex:1`) — sans ça, `app-layout-builder` grandissait jusqu'à son contenu et le scroll interne ne s'activait jamais.
- **Raisonnement agentique persistant** : les étapes de la boucle d'outils sont accumulées et humanisées en live, puis conservées dans un `<details>` replié sous la réponse.
- **Repli auto de « Source de données »** une fois la source chargée (nom résumé dans le titre), pour rendre de la hauteur au chat.

## Vérification
- Tests : suite builder-ia + mcp verte (114 builder-ia + alignement skills), nouveaux tests `action-schema`, `agent-loop`, `system-prompt`, `albert-capabilities`, `ia-model-select`.
- typecheck + eslint OK.
- Layout vérifié au navigateur (Playwright) : split horizontal préservé, scroll interne, page non scrollée, repli source OK.
- **Étape suivante hors PR** : lancer `npx tsx scripts/probe-albert.ts --token <T>` pour activer json_schema/tools en prod selon ce que le gateway supporte réellement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)