### PR TITLE
fix(builder-ia): hauteur mini + scroll au lieu du 100vh rigide

### DIFF
--- a/apps/builder-ia/src/styles/builder-ia.css
+++ b/apps/builder-ia/src/styles/builder-ia.css
@@ -6,15 +6,25 @@
 
 body {
   margin: 0;
-  /* Hauteur DEFINIE (pas seulement min-height) : sans ca, app-layout-builder
-     (flex:1) grandit jusqu'a son contenu et la page scrolle. Avec height:100vh,
-     la chaine flex est plafonnee et le scroll vit dans .chat-messages (pattern
-     chat IA moderne). */
-  height: 100vh;
+  /* Hauteur mini + scroll (comme builder-carto et les autres apps) : la zone de
+     travail remplit le viewport quand il y a la place, mais sur petit ecran la
+     PAGE defile et le footer passe dessous, au lieu d'ecraser le chat et l'apercu.
+     (Avant : height:100vh + overflow:hidden verrouillait tout dans le viewport.) */
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
   background: var(--background-alt-grey);
+}
+
+/* La page peut grandir au-dela du viewport : on relache le clipping du layout
+   partage (app-layout-builder force overflow:hidden), sinon le contenu est rogne
+   au lieu de faire defiler la page. Meme approche que apps/playground. */
+app-layout-builder {
+  overflow: visible !important;
+}
+.builder-layout-left,
+.builder-layout-right {
+  overflow: visible !important;
 }
 
 .builder-header {
@@ -35,13 +45,12 @@ body {
 /* PANNEAU GAUCHE : CONFIG + CHAT */
 /* ============================================ */
 .builder-config-panel {
-  /* Remplit toute la hauteur de la colonne gauche pour que .chat-container
-     (flex:1) absorbe l'espace restant sous les sections de config et que le
-     scroll vive dans .chat-messages, pas dans la colonne. */
+  /* Remplit la hauteur dispo, mais laisse le contenu deborder vers le scroll de
+     page (plus de clipping) : sur petit ecran la colonne grandit et la page defile. */
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: visible;
   min-height: 0;
 }
 
@@ -145,7 +154,7 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: visible;
   min-height: 0;
 }
 

--- a/apps/builder-ia/src/styles/builder-ia.css
+++ b/apps/builder-ia/src/styles/builder-ia.css
@@ -7,8 +7,8 @@
 body {
   margin: 0;
   /* Hauteur mini + scroll (comme builder-carto et les autres apps) : la zone de
-     travail remplit le viewport quand il y a la place, mais sur petit ecran la
-     PAGE defile et le footer passe dessous, au lieu d'ecraser le chat et l'apercu.
+     travail remplit le viewport quand il y a la place, mais sur petit écran la
+     PAGE défile et le footer passe dessous, au lieu d'écraser le chat et l'aperçu.
      (Avant : height:100vh + overflow:hidden verrouillait tout dans le viewport.) */
   min-height: 100vh;
   display: flex;
@@ -16,9 +16,9 @@ body {
   background: var(--background-alt-grey);
 }
 
-/* La page peut grandir au-dela du viewport : on relache le clipping du layout
-   partage (app-layout-builder force overflow:hidden), sinon le contenu est rogne
-   au lieu de faire defiler la page. Meme approche que apps/playground. */
+/* La page peut grandir au-delà du viewport : on relâche le clipping du layout
+   partagé (app-layout-builder force overflow:hidden), sinon le contenu est rogné
+   au lieu de faire défiler la page. Même approche que apps/playground. */
 app-layout-builder {
   overflow: visible !important;
 }
@@ -45,8 +45,8 @@ app-layout-builder {
 /* PANNEAU GAUCHE : CONFIG + CHAT */
 /* ============================================ */
 .builder-config-panel {
-  /* Remplit la hauteur dispo, mais laisse le contenu deborder vers le scroll de
-     page (plus de clipping) : sur petit ecran la colonne grandit et la page defile. */
+  /* Remplit la hauteur dispo, mais laisse le contenu déborder vers le scroll de
+     page (plus de clipping) : sur petit écran la colonne grandit et la page défile. */
   flex: 1;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Problème

Sur petit écran, l'Assistant IA était inutilisable : le layout verrouillé en `height:100vh; overflow:hidden` forçait header + zone de travail + footer DSFR (~180px) dans le viewport, **écrasant le chat et l'aperçu** sans possibilité de scroller.

## Fix (CSS only)

On adopte le pattern **hauteur mini + scroll** des autres apps (builder-carto, playground) :
- `body` : `height:100vh; overflow:hidden` → **`min-height:100vh`** (la page peut grandir et défiler).
- On relâche le clipping du layout partagé `app-layout-builder` (qui force `overflow:hidden`) + `.builder-layout-left/right`, ainsi que `.builder-config-panel` et `.chat-container`.

Résultat : la zone de travail remplit le viewport quand il y a la place ; sur petit écran, la **page défile** et le footer passe dessous, au lieu de comprimer le chat + l'aperçu.

> Le composant partagé `<app-footer>` n'est **pas** touché (on avait envisagé un footer compact, abandonné au profit de cette approche, cohérente avec builder-carto).

## Validation

- Build `builder-ia` OK. Changement **CSS uniquement** (1 fichier), pas de changeset (hors `packages/core`/`shared`).
- ⚠️ À confirmer visuellement sur petit écran (je peux lancer un screenshot via le dev server si tu veux avant merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)