### PR TITLE
feat(guide): toggle pour masquer les jeux de données de démo dans les builders

### DIFF
--- a/.changeset/demo-datasets-guide-toggle.md
+++ b/.changeset/demo-datasets-guide-toggle.md
@@ -1,0 +1,7 @@
+---
+"dsfr-data": minor
+---
+
+feat(guide): permet de masquer les jeux de donnees de demonstration depuis la page Guide
+
+Ajoute un interrupteur "Masquer les jeux de donnees de demonstration" sur la page Guide, a cote du reglage d'activation/desactivation des visites guidees. Quand il est active, les jeux de donnees d'exemple (regions de France, evolution annuelle, catalogue de services) n'apparaissent plus dans les selecteurs de source du Builder et du Builder IA. Le reglage est persiste par utilisateur (localStorage + synchronisation serveur via `users.tour_state`, comme les visites guidees) et expose via `isDemoDatasetsDisabled()` / `setDemoDatasetsDisabled()` dans `@dsfr-data/shared`. Les demos restent affichees par defaut.

--- a/apps/builder-ia/src/sources.ts
+++ b/apps/builder-ia/src/sources.ts
@@ -11,6 +11,7 @@ import {
   setupModalOverlayClose,
   migrateSource,
   SAMPLE_DATASETS,
+  isDemoDatasetsDisabled,
 } from '@dsfr-data/shared';
 import { state } from './state.js';
 import type { Source, Field } from './state.js';
@@ -30,24 +31,26 @@ export function loadSavedSources(): void {
     return s ? migrateSource(s) : null;
   })();
 
-  // 1. Pr\u00e9enregistr\u00e9 (jeux de donn\u00e9es d'exemple).
-  const sampleGroup = document.createElement('optgroup');
-  sampleGroup.label = 'Pr\u00e9enregistr\u00e9';
-  SAMPLE_DATASETS.forEach((ds) => {
-    const option = document.createElement('option');
-    option.value = `sample:${ds.id}`;
-    option.textContent = sourceOptionLabel(ds.name, ds.rows.length);
-    const sampleSource: Source = {
-      id: `sample-${ds.id}`,
-      name: ds.name,
-      type: 'manual',
-      data: ds.rows as Record<string, unknown>[],
-      recordCount: ds.rows.length,
-    };
-    option.dataset.source = JSON.stringify(sampleSource);
-    sampleGroup.appendChild(option);
-  });
-  select.appendChild(sampleGroup);
+  // 1. Pr\u00e9enregistr\u00e9 (jeux de donn\u00e9es d'exemple) \u2014 masquable depuis /guide.
+  if (!isDemoDatasetsDisabled()) {
+    const sampleGroup = document.createElement('optgroup');
+    sampleGroup.label = 'Pr\u00e9enregistr\u00e9';
+    SAMPLE_DATASETS.forEach((ds) => {
+      const option = document.createElement('option');
+      option.value = `sample:${ds.id}`;
+      option.textContent = sourceOptionLabel(ds.name, ds.rows.length);
+      const sampleSource: Source = {
+        id: `sample-${ds.id}`,
+        name: ds.name,
+        type: 'manual',
+        data: ds.rows as Record<string, unknown>[],
+        recordCount: ds.rows.length,
+      };
+      option.dataset.source = JSON.stringify(sampleSource);
+      sampleGroup.appendChild(option);
+    });
+    select.appendChild(sampleGroup);
+  }
 
   // La source r\u00e9cemment ouverte (depuis sources.html), si absente de la liste.
   const allSources = [...sources];

--- a/apps/builder/src/sources.ts
+++ b/apps/builder/src/sources.ts
@@ -16,6 +16,7 @@ import {
   setupModalOverlayClose,
   migrateSource,
   SAMPLE_DATASETS,
+  isDemoDatasetsDisabled,
   isUnsafeKey,
 } from '@dsfr-data/shared';
 import { state, type ChartType, type Source, type Field } from './state.js';
@@ -59,24 +60,31 @@ export function loadSavedSources(): void {
     if (!panel.querySelector('.empty-sources-message')) {
       const emptyMsg = document.createElement('div');
       emptyMsg.className = 'empty-sources-message fr-mt-1w';
-      const sampleCards = SAMPLE_DATASETS.map(
-        (ds) => `
+
+      // Demo datasets can be hidden from the /guide page. When disabled, the
+      // empty state only invites the user to add their own data.
+      const demoHidden = isDemoDatasetsDisabled();
+      const sampleSection = demoHidden
+        ? ''
+        : `
+        <p class="empty-sources-desc">Essayez avec des donn\u00e9es d'exemple :</p>
+        <div class="sample-datasets-grid">${SAMPLE_DATASETS.map(
+          (ds) => `
         <button type="button" class="sample-dataset-card" data-sample-id="${ds.id}">
           <i class="${ds.icon}"></i>
           <span class="sample-dataset-name">${ds.name}</span>
           <span class="sample-dataset-desc">${ds.description}</span>
         </button>
       `
-      ).join('');
+        ).join('')}</div>`;
 
       emptyMsg.innerHTML = `
         <p><i class="ri-database-2-line" style="font-size: 2rem; display: block; margin-bottom: 0.5rem; opacity: 0.5;"></i></p>
         <p>Pas encore de donn\u00e9es\u00a0?</p>
-        <p class="empty-sources-desc">Essayez avec des donn\u00e9es d'exemple :</p>
-        <div class="sample-datasets-grid">${sampleCards}</div>
+        ${sampleSection}
         <div class="empty-sources-actions">
           <a href="${appHref('sources')}" class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-mt-1w">
-            <i class="ri-add-line"></i> Ou ajoutez vos propres donn\u00e9es
+            <i class="ri-add-line"></i> ${demoHidden ? 'Ajoutez vos propres donn\u00e9es' : 'Ou ajoutez vos propres donn\u00e9es'}
           </a>
         </div>
       `;
@@ -106,17 +114,19 @@ export function loadSavedSources(): void {
 
   select.innerHTML = '<option value="">\u2014 Choisir une source \u2014</option>';
 
-  // 1. Pr\u00e9enregistr\u00e9 (jeux de donn\u00e9es d'exemple).
-  const sampleGroup = document.createElement('optgroup');
-  sampleGroup.label = 'Pr\u00e9enregistr\u00e9';
-  SAMPLE_DATASETS.forEach((ds) => {
-    const option = document.createElement('option');
-    option.value = `sample:${ds.id}`;
-    option.textContent = sourceOptionLabel(ds.name, ds.rows.length);
-    option.dataset.sampleId = ds.id;
-    sampleGroup.appendChild(option);
-  });
-  select.appendChild(sampleGroup);
+  // 1. Pr\u00e9enregistr\u00e9 (jeux de donn\u00e9es d'exemple) \u2014 masquable depuis /guide.
+  if (!isDemoDatasetsDisabled()) {
+    const sampleGroup = document.createElement('optgroup');
+    sampleGroup.label = 'Pr\u00e9enregistr\u00e9';
+    SAMPLE_DATASETS.forEach((ds) => {
+      const option = document.createElement('option');
+      option.value = `sample:${ds.id}`;
+      option.textContent = sourceOptionLabel(ds.name, ds.rows.length);
+      option.dataset.sampleId = ds.id;
+      sampleGroup.appendChild(option);
+    });
+    select.appendChild(sampleGroup);
+  }
 
   // La source r\u00e9cemment ouverte depuis sources.html, si absente de la liste.
   const allSources = [...sources];

--- a/guide/guide-tours.js
+++ b/guide/guide-tours.js
@@ -3,7 +3,9 @@
  *
  * Reads/writes the tour state from localStorage under `dsfr-data-tours`
  * using the same schema as packages/shared/src/ui/product-tour.ts
- * (`{ disabled?: boolean, tours: { [id]: { at: ISO, version: number } } }`).
+ * (`{ disabled?: boolean, demoDatasetsDisabled?: boolean,
+ *    tours: { [id]: { at: ISO, version: number } } }`).
+ * The `demoDatasetsDisabled` flag toggles the sample datasets in the builders.
  *
  * Duplicates the storage logic deliberately: /guide is served as static HTML
  * (no bundler) so we avoid pulling the whole `@dsfr-data/shared` module just
@@ -34,7 +36,11 @@
     }
     if (!raw || typeof raw !== 'object') return { tours: {} };
     if (raw.tours && typeof raw.tours === 'object') {
-      return { disabled: raw.disabled === true, tours: raw.tours };
+      return {
+        disabled: raw.disabled === true,
+        demoDatasetsDisabled: raw.demoDatasetsDisabled === true,
+        tours: raw.tours,
+      };
     }
     // Old format: flat map of tourId → ISO — normalize.
     var tours = {};
@@ -216,8 +222,21 @@
     });
   }
 
+  function initDemoDatasetsToggle() {
+    var input = document.getElementById('demo-datasets-disabled-toggle');
+    if (!input) return;
+    var state = loadState();
+    input.checked = state.demoDatasetsDisabled === true;
+    input.addEventListener('change', function () {
+      var current = loadState();
+      current.demoDatasetsDisabled = input.checked;
+      saveState(current);
+    });
+  }
+
   function init() {
     initDisabledToggle();
+    initDemoDatasetsToggle();
     renderTable();
   }
 

--- a/guide/guide.html
+++ b/guide/guide.html
@@ -60,6 +60,18 @@
             </div>
             <div id="tours-table-container" class="fr-mt-3w"></div>
           </div>
+
+          <div class="fr-callout fr-mt-3w fr-mb-3w" id="demo-datasets-panel">
+            <h3 class="fr-callout__title">Jeux de donnees de demonstration</h3>
+            <p class="fr-callout__text">Le Builder et le Builder IA proposent des jeux de donnees d'exemple prets a l'emploi pour decouvrir l'outil sans connecter de source. Vous pouvez les masquer si vous ne souhaitez utiliser que vos propres donnees.</p>
+            <div class="fr-toggle fr-toggle--label-left fr-mt-2w">
+              <input type="checkbox" class="fr-toggle__input" id="demo-datasets-disabled-toggle">
+              <label class="fr-toggle__label" for="demo-datasets-disabled-toggle">
+                Masquer les jeux de donnees de demonstration
+                <span class="fr-hint-text">Les exemples n'apparaitront plus dans les selecteurs de source des builders. Effectif au prochain chargement d'un builder.</span>
+              </label>
+            </div>
+          </div>
           <script src="guide-tours.js"></script>
 
           <h2>L'interface</h2>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -171,6 +171,8 @@ export {
   getToursState,
   isToursDisabled,
   setToursDisabled,
+  isDemoDatasetsDisabled,
+  setDemoDatasetsDisabled,
 } from './ui/product-tour.js';
 export type { TourRegistryEntry } from './tour/tour-configs.js';
 export {

--- a/packages/shared/src/storage/api-storage-adapter.ts
+++ b/packages/shared/src/storage/api-storage-adapter.ts
@@ -192,9 +192,10 @@ function isEmptyTourState(data: unknown): boolean {
   if (!data || typeof data !== 'object') return true;
   const obj = data as Record<string, unknown>;
   const hasDisabled = typeof obj.disabled === 'boolean';
+  const hasDemoPref = typeof obj.demoDatasetsDisabled === 'boolean';
   const tours = obj.tours as Record<string, unknown> | undefined;
   const hasTours = tours && typeof tours === 'object' && Object.keys(tours).length > 0;
-  return !hasDisabled && !hasTours;
+  return !hasDisabled && !hasDemoPref && !hasTours;
 }
 
 export class ApiStorageAdapter implements StorageAdapter {

--- a/packages/shared/src/ui/product-tour.ts
+++ b/packages/shared/src/ui/product-tour.ts
@@ -46,10 +46,22 @@ export interface StoredTourEntry {
   version: number;
 }
 
-/** Full state persisted under STORAGE_KEYS.TOURS. */
+/**
+ * Full state persisted under STORAGE_KEYS.TOURS.
+ *
+ * This singleton doubles as a small per-user UI-preferences blob (synced to
+ * `users.tour_state`). Besides the product-tour fields, it also carries the
+ * "demo datasets" preference managed from the /guide page, alongside the
+ * product-tour enable/disable toggle.
+ */
 export interface TourState {
   /** If true, no tour auto-starts (the user can still manually restart one). */
   disabled?: boolean;
+  /**
+   * If true, the sample/demo datasets are hidden from the builders' source
+   * pickers. Managed from /guide, next to the product-tour toggle.
+   */
+  demoDatasetsDisabled?: boolean;
   /** Seen tours keyed by tour id. */
   tours: Record<string, StoredTourEntry>;
 }
@@ -102,7 +114,11 @@ function _normalizeState(raw: unknown): { state: TourState; migrated: boolean } 
       }
     }
     return {
-      state: { disabled: obj.disabled === true, tours },
+      state: {
+        disabled: obj.disabled === true,
+        demoDatasetsDisabled: obj.demoDatasetsDisabled === true,
+        tours,
+      },
       migrated: false,
     };
   }
@@ -171,6 +187,21 @@ export function isToursDisabled(): boolean {
 export function setToursDisabled(disabled: boolean): void {
   const state = _loadState();
   state.disabled = disabled;
+  _saveState(state);
+}
+
+/**
+ * Are the demo (sample) datasets hidden from the builders' source pickers?
+ * Defaults to false — demo datasets are shown unless explicitly disabled.
+ */
+export function isDemoDatasetsDisabled(): boolean {
+  return _loadState().demoDatasetsDisabled === true;
+}
+
+/** Show or hide the demo (sample) datasets in the builders. */
+export function setDemoDatasetsDisabled(disabled: boolean): void {
+  const state = _loadState();
+  state.demoDatasetsDisabled = disabled;
   _saveState(state);
 }
 

--- a/server/src/routes/tour-state.ts
+++ b/server/src/routes/tour-state.ts
@@ -20,6 +20,7 @@ interface StoredTourEntry {
 
 interface TourState {
   disabled?: boolean;
+  demoDatasetsDisabled?: boolean;
   tours: Record<string, StoredTourEntry>;
 }
 
@@ -41,6 +42,7 @@ function validate(body: unknown): TourState | null {
 
   const state: TourState = { tours: {} };
   if (obj.disabled === true) state.disabled = true;
+  if (obj.demoDatasetsDisabled === true) state.demoDatasetsDisabled = true;
 
   if (obj.tours && typeof obj.tours === 'object') {
     for (const [id, entry] of Object.entries(obj.tours as Record<string, unknown>)) {

--- a/tests/apps/builder/sources.test.ts
+++ b/tests/apps/builder/sources.test.ts
@@ -107,6 +107,39 @@ describe('builder sources', () => {
       expect(sourceOptions).toHaveLength(2);
     });
 
+    it('hides the sample optgroup when demo datasets are disabled', () => {
+      localStorage.setItem(
+        'dsfr-data-tours',
+        JSON.stringify({ demoDatasetsDisabled: true, tours: {} })
+      );
+      const sources: Source[] = [makeSource({ id: 'src-1', name: 'Source A', type: 'grist' })];
+      localStorage.setItem('dsfr-data-sources', JSON.stringify(sources));
+
+      loadSavedSources();
+
+      const select = document.getElementById('saved-source') as HTMLSelectElement;
+      // 1 default option + 1 source option (no sample optgroup)
+      expect(select.options).toHaveLength(2);
+      const groups = Array.from(select.querySelectorAll('optgroup')).map((g) => g.label);
+      expect(groups).not.toContain('Préenregistré');
+    });
+
+    it('hides sample cards in the empty state when demo datasets are disabled', () => {
+      localStorage.setItem(
+        'dsfr-data-tours',
+        JSON.stringify({ demoDatasetsDisabled: true, tours: {} })
+      );
+
+      loadSavedSources();
+
+      const panel = document.getElementById('source-panel-saved')!;
+      const emptyMsg = panel.querySelector('.empty-sources-message')!;
+      expect(emptyMsg).not.toBeNull();
+      // Still invites the user to add their own data, but no sample cards.
+      expect(emptyMsg.querySelectorAll('.sample-dataset-card')).toHaveLength(0);
+      expect(emptyMsg.textContent).toContain('Ajoutez vos propres donn');
+    });
+
     it('groups grist sources under "En ligne"', () => {
       const sources: Source[] = [makeSource({ id: 'g1', name: 'Grist Source', type: 'grist' })];
       localStorage.setItem('dsfr-data-sources', JSON.stringify(sources));

--- a/tests/product-tour.test.ts
+++ b/tests/product-tour.test.ts
@@ -7,6 +7,8 @@ import {
   getToursState,
   isToursDisabled,
   setToursDisabled,
+  isDemoDatasetsDisabled,
+  setDemoDatasetsDisabled,
 } from '@dsfr-data/shared';
 import { STORAGE_KEYS } from '@dsfr-data/shared';
 
@@ -72,6 +74,42 @@ describe('product-tour state', () => {
     expect(state.disabled).toBe(true);
     expect(state.tours.builder).toBeTruthy();
     expect(state.tours.builder.version).toBe(1);
+  });
+
+  it('isDemoDatasetsDisabled defaults to false when no state exists', () => {
+    expect(isDemoDatasetsDisabled()).toBe(false);
+  });
+
+  it('setDemoDatasetsDisabled toggles the demo datasets flag', () => {
+    setDemoDatasetsDisabled(true);
+    expect(isDemoDatasetsDisabled()).toBe(true);
+    setDemoDatasetsDisabled(false);
+    expect(isDemoDatasetsDisabled()).toBe(false);
+  });
+
+  it('demo datasets flag is independent from the tours disabled flag', () => {
+    setDemoDatasetsDisabled(true);
+    expect(isToursDisabled()).toBe(false);
+    expect(shouldShowTour('builder')).toBe(true);
+  });
+
+  it('demo datasets flag persists alongside tours state and disabled flag', () => {
+    markTourComplete('builder', 1);
+    setToursDisabled(true);
+    setDemoDatasetsDisabled(true);
+    const state = getToursState();
+    expect(state.disabled).toBe(true);
+    expect(state.demoDatasetsDisabled).toBe(true);
+    expect(state.tours.builder).toBeTruthy();
+  });
+
+  it('preserves demoDatasetsDisabled when reading the new format', async () => {
+    localStorage.setItem(
+      STORAGE_KEYS.TOURS,
+      JSON.stringify({ demoDatasetsDisabled: true, tours: {} })
+    );
+    const mod = await freshImport();
+    expect(mod.isDemoDatasetsDisabled()).toBe(true);
   });
 
   it('migrates legacy flat format { tourId: ISO } on first read', async () => {


### PR DESCRIPTION
## Contexte

Les jeux de données de démonstration (régions de France, évolution annuelle, catalogue de services) sont toujours présents dans les sélecteurs de source du Builder et du Builder IA. Cette PR permet de les **masquer depuis la page Guide**, au même endroit où l'on gère l'activation/désactivation des visites guidées (product tour).

## Comment ça marche

- **Même mécanisme que le product tour** : le réglage (`demoDatasetsDisabled`) est rangé dans le singleton `tour-state`, donc persisté en **localStorage + synchronisé serveur** (`users.tour_state`) — cross-device. Aucune migration DB nécessaire (la colonne JSON existe déjà).
- **Activées par défaut** : les démos ne disparaissent que si l'utilisateur coche explicitement la case. Zéro changement pour les utilisateurs actuels.
- Quand c'est activé, les jeux d'exemple disparaissent des sélecteurs de source du **Builder** (optgroup « Préenregistré » + cartes de l'état vide) et du **Builder IA** (optgroup). L'état vide du Builder bascule sur « Ajoutez vos propres données ».
- Lu **au chargement** d'un builder → effectif au prochain chargement (même comportement que le toggle des visites guidées).

## Fichiers touchés

| Zone | Changement |
|------|-----------|
| `packages/shared/.../product-tour.ts` | champ `demoDatasetsDisabled` + `isDemoDatasetsDisabled()` / `setDemoDatasetsDisabled()` (exportés) |
| `guide/guide.html` + `guide-tours.js` | nouveau toggle `#demo-datasets-disabled-toggle` |
| `apps/builder` + `apps/builder-ia` `sources.ts` | garde sur l'injection des démos |
| `server/.../tour-state.ts`, `api-storage-adapter.ts` | préservation du flag au round-trip serveur |
| Tests | +5 dans `product-tour.test.ts`, +2 dans `builder/sources.test.ts` |
| `.changeset/` | changeset `minor` |

## Vérifications

- Tests ciblés : `product-tour` (15 ✓), `builder/sources` (32 ✓), `builder-ia` (✓).
- ESLint + Prettier : propres.
- Typecheck des fichiers modifiés OK.

https://claude.ai/code/session_01RRXNqPaCbvnk7q58U2U6rr

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRXNqPaCbvnk7q58U2U6rr)_