### PR TITLE
fix(tabular): fallback to client-side aggregation for unsafe field names

### DIFF
--- a/.changeset/tabular-server-fields-special-chars.md
+++ b/.changeset/tabular-server-fields-special-chars.md
@@ -1,0 +1,5 @@
+---
+"dsfr-data": patch
+---
+
+fix(tabular): retombe en agregation client-side quand les noms de colonnes contiennent des espaces ou de la ponctuation. La syntaxe a suffixe Tabular (`colonne__groupby`, `colonne__sum`) ne sait pas parser des colonnes comme "Date - Journee gaziere" ou "Inventaire LNG (m3 LNG)" et renvoyait une erreur "Malformed query" (HTTP 400). dsfr-data-query interroge desormais l'adapter via `supportsServerFields()` avant de deleguer group-by/aggregate/order-by au serveur.

--- a/packages/core/src/adapters/api-adapter.ts
+++ b/packages/core/src/adapters/api-adapter.ts
@@ -145,6 +145,21 @@ export interface ApiAdapter {
   ): Promise<FacetResult[]>;
 
   /**
+   * Indique si les champs donnes peuvent etre delegues cote serveur pour
+   * group-by / aggregate / order-by.
+   *
+   * Certains providers encodent ces operations via une syntaxe a suffixe dans
+   * la query string (Tabular : `colonne__groupby`, `colonne__sum`) qui ne
+   * supporte pas les noms de colonnes contenant des espaces ou de la
+   * ponctuation (ex. "Date - Journee gaziere"). Dans ce cas l'adapter retourne
+   * false et dsfr-data-query retombe sur un traitement client-side (qui fetch
+   * toutes les lignes brutes puis agrege localement — resultat identique).
+   *
+   * Non implemente = tous les champs sont delegables (comportement par defaut).
+   */
+  supportsServerFields?(fields: string[]): boolean;
+
+  /**
    * Retourne le search template par défaut pour cette API.
    * Ex: ODS retourne 'search("{q}")'.
    */

--- a/packages/core/src/adapters/tabular-adapter.ts
+++ b/packages/core/src/adapters/tabular-adapter.ts
@@ -28,6 +28,18 @@ function buildFetchOptions(
   return opts;
 }
 
+/**
+ * Un nom de colonne est utilisable dans la syntaxe a suffixe Tabular
+ * (`colonne__op`) seulement s'il ne contient que des lettres, chiffres et
+ * underscores. Les espaces, tirets et parentheses (ex. "Date - Journee
+ * gaziere", "Inventaire LNG (m3 LNG)") cassent le parser de l'API et
+ * provoquent un "Malformed query". Les noms d'agregats post-traitement
+ * (`population__sum`) restent valides (seulement lettres/chiffres/underscores).
+ */
+function isTabularServerFieldSafe(field: string): boolean {
+  return /^[\p{L}\p{N}_]+$/u.test(field);
+}
+
 /** Nombre max de records par requête Tabular (API max = 50) */
 const TABULAR_PAGE_SIZE = 50;
 
@@ -52,6 +64,17 @@ export class TabularAdapter implements ApiAdapter {
       return 'attribut "resource" requis pour les requêtes Tabular';
     }
     return null;
+  }
+
+  /**
+   * Tabular delegue group-by/aggregate/order-by via une syntaxe a suffixe
+   * (`colonne__op`) qui ne tolere pas les noms de colonnes avec espaces ou
+   * ponctuation. On ne delegue cote serveur que si TOUS les champs sont "safe" ;
+   * sinon dsfr-data-query agrege client-side (resultat identique, sur toutes
+   * les lignes).
+   */
+  supportsServerFields(fields: string[]): boolean {
+    return fields.every((f) => isTabularServerFieldSafe(f));
   }
 
   /**

--- a/packages/core/src/components/dsfr-data-query.ts
+++ b/packages/core/src/components/dsfr-data-query.ts
@@ -350,23 +350,40 @@ export class DsfrDataQuery extends LitElement {
 
     const cmd: Record<string, string> = {};
 
+    // Certains adapters (Tabular) ne peuvent pas deleguer des champs dont le nom
+    // contient des espaces/ponctuation (syntaxe a suffixe `colonne__op`). On les
+    // interroge avant de deleguer ; sinon on retombe sur le client-side.
+    const canDelegateFields = (fields: string[]): boolean => {
+      const clean = fields.map((f) => f.trim()).filter(Boolean);
+      return adapter.supportsServerFields?.(clean) !== false;
+    };
+
     // Delegate group-by + aggregate together (they're coupled).
     // Don't override if source already has its own groupBy or aggregate.
     if (this.groupBy && caps.serverGroupBy && !sourceGroupBy && !sourceAggregate) {
-      cmd.groupBy = this.groupBy;
-      this._serverDelegated.groupBy = true;
+      const fields = [
+        ...this.groupBy.split(','),
+        ...this._parseAggregates(this.aggregate).map((a) => a.field),
+      ];
+      if (canDelegateFields(fields)) {
+        cmd.groupBy = this.groupBy;
+        this._serverDelegated.groupBy = true;
 
-      if (this.aggregate) {
-        cmd.aggregate = this.aggregate;
-        this._serverDelegated.aggregate = true;
+        if (this.aggregate) {
+          cmd.aggregate = this.aggregate;
+          this._serverDelegated.aggregate = true;
+        }
       }
     }
 
     // Delegate order-by
     const sourceOrderBy = sourceEl.orderBy || '';
     if (this.orderBy && caps.serverOrderBy && !sourceOrderBy) {
-      cmd.orderBy = this.orderBy;
-      this._serverDelegated.orderBy = true;
+      const orderField = this.orderBy.split(':')[0] || '';
+      if (canDelegateFields([orderField])) {
+        cmd.orderBy = this.orderBy;
+        this._serverDelegated.orderBy = true;
+      }
     }
 
     if (Object.keys(cmd).length > 0) {

--- a/tests/adapters/tabular-adapter.test.ts
+++ b/tests/adapters/tabular-adapter.test.ts
@@ -44,6 +44,36 @@ describe('TabularAdapter', () => {
     });
   });
 
+  describe('supportsServerFields', () => {
+    it('accepts simple identifier columns', () => {
+      expect(adapter.supportsServerFields(['region', 'population'])).toBe(true);
+    });
+
+    it('accepts accented single-token columns', () => {
+      expect(adapter.supportsServerFields(['methanier', 'Journée'])).toBe(true);
+    });
+
+    it('accepts post-aggregation alias columns with underscores', () => {
+      expect(adapter.supportsServerFields(['population__sum'])).toBe(true);
+    });
+
+    it('rejects columns containing spaces or hyphens', () => {
+      expect(adapter.supportsServerFields(['Date - Journée gazière'])).toBe(false);
+    });
+
+    it('rejects columns containing parentheses', () => {
+      expect(adapter.supportsServerFields(['Inventaire LNG (m3 LNG)'])).toBe(false);
+    });
+
+    it('rejects if ANY field is unsafe', () => {
+      expect(adapter.supportsServerFields(['region', 'Inventaire LNG (m3 LNG)'])).toBe(false);
+    });
+
+    it('accepts an empty field list', () => {
+      expect(adapter.supportsServerFields([])).toBe(true);
+    });
+  });
+
   describe('URL building', () => {
     it('builds base URL correctly', () => {
       const url = adapter.buildUrl(makeParams());

--- a/tests/dsfr-data-query.test.ts
+++ b/tests/dsfr-data-query.test.ts
@@ -501,6 +501,78 @@ describe('DsfrDataQuery', () => {
     });
   });
 
+  describe('server-side delegation negotiation', () => {
+    let mockSource: HTMLElement;
+    let commands: Array<Record<string, unknown>>;
+    let unsubscribe: () => void;
+
+    function setupSource(supportsServerFields?: (fields: string[]) => boolean) {
+      mockSource = document.createElement('div');
+      mockSource.id = 'neg-source';
+      (mockSource as any).getAdapter = () => ({
+        type: 'tabular',
+        capabilities: {
+          serverGroupBy: true,
+          serverOrderBy: true,
+          whereFormat: 'colon',
+        },
+        ...(supportsServerFields ? { supportsServerFields } : {}),
+      });
+      document.body.appendChild(mockSource);
+      query.source = 'neg-source';
+      commands = [];
+      unsubscribe = subscribeToSourceCommands('neg-source', (cmd) => commands.push(cmd));
+    }
+
+    afterEach(() => {
+      unsubscribe?.();
+      mockSource?.remove();
+    });
+
+    it('delegates group-by/aggregate server-side when fields are safe', () => {
+      setupSource((fields) => fields.every((f) => /^[\p{L}\p{N}_]+$/u.test(f)));
+      query.groupBy = 'region';
+      query.aggregate = 'population:sum';
+
+      (query as any)._negotiateServerSide();
+
+      expect((query as any)._serverDelegated.groupBy).toBe(true);
+      expect((query as any)._serverDelegated.aggregate).toBe(true);
+      expect(commands.some((c) => c.groupBy === 'region')).toBe(true);
+    });
+
+    it('falls back to client-side when a field name is unsafe (spaces/parens)', () => {
+      setupSource((fields) => fields.every((f) => /^[\p{L}\p{N}_]+$/u.test(f)));
+      query.groupBy = 'Date - Journée gazière';
+      query.aggregate = 'Inventaire LNG (m3 LNG):sum';
+
+      (query as any)._negotiateServerSide();
+
+      expect((query as any)._serverDelegated.groupBy).toBe(false);
+      expect((query as any)._serverDelegated.aggregate).toBe(false);
+      expect(commands.length).toBe(0);
+    });
+
+    it('delegates when adapter does not implement supportsServerFields (default)', () => {
+      setupSource(undefined);
+      query.groupBy = 'Date - Journée gazière';
+      query.aggregate = 'Inventaire LNG (m3 LNG):sum';
+
+      (query as any)._negotiateServerSide();
+
+      expect((query as any)._serverDelegated.groupBy).toBe(true);
+    });
+
+    it('does not delegate order-by on an unsafe field name', () => {
+      setupSource((fields) => fields.every((f) => /^[\p{L}\p{N}_]+$/u.test(f)));
+      query.orderBy = 'Inventaire LNG (m3 LNG):desc';
+
+      (query as any)._negotiateServerSide();
+
+      expect((query as any)._serverDelegated.orderBy).toBe(false);
+    });
+  });
+
   describe('Public API', () => {
     it('getData returns current data', () => {
       (query as any)._data = [{ test: 1 }];


### PR DESCRIPTION
## Summary

Tabular adapter now validates field names before delegating group-by/aggregate/order-by operations to the server. Field names containing spaces, hyphens, or parentheses (e.g., "Date - Journée gazière", "Inventaire LNG (m3 LNG)") are rejected for server-side delegation and fall back to client-side processing, preventing "Malformed query" HTTP 400 errors.

## Changes

- **ApiAdapter interface**: Added optional `supportsServerFields(fields: string[]): boolean` method to allow adapters to declare which field names can be safely delegated server-side
- **TabularAdapter**: Implemented `supportsServerFields()` using regex `/^[\p{L}\p{N}_]+$/u` to validate that field names contain only letters, digits, and underscores (safe for Tabular's suffix syntax like `colonne__groupby`, `colonne__sum`)
- **DsfrDataQuery**: Updated `_negotiateServerSide()` to:
  - Extract field names from `groupBy`, `aggregate`, and `orderBy` expressions
  - Call `adapter.supportsServerFields()` before delegating operations
  - Fall back to client-side processing when any field name is unsafe
  - Default to delegation if adapter doesn't implement the method (backward compatible)
- **Tests**: Added comprehensive test suites for both TabularAdapter and DsfrDataQuery covering safe identifiers, accented characters, unsafe characters (spaces, hyphens, parentheses), and edge cases

## Implementation Details

- Field validation uses Unicode-aware regex to accept accented characters (e.g., "Journée") while rejecting problematic punctuation
- Post-aggregation alias columns with underscores (e.g., "population__sum") remain valid
- Client-side fallback produces identical results to server-side delegation (all rows fetched and aggregated locally)
- Backward compatible: adapters that don't implement `supportsServerFields()` default to allowing delegation

https://claude.ai/code/session_014AiYWQzA4JsMwAnMsvQacS