### PR TITLE
feat(proxy): support custom headers for unknown API hosts via CORS proxy

### DIFF
--- a/.changeset/cors-proxy-custom-header-apis.md
+++ b/.changeset/cors-proxy-custom-header-apis.md
@@ -1,0 +1,21 @@
+---
+"dsfr-data": minor
+---
+
+feat(proxy): route les API tierces à clé en en-tête via le proxy CORS générique
+
+Une connexion API manuelle vers un hôte inconnu (ex. une instance OpenDataSoft
+comme `data.economie.gouv.fr`) avec une clé en en-tête (`Apikey`, `Authorization`…)
+échouait à l'enregistrement avec « CORS Missing Allow Header ». L'en-tête custom
+rend la requête « non-simple » et déclenche un preflight `OPTIONS` que l'API
+distante ne sait pas honorer, car la requête partait en direct du navigateur
+(`getProxiedUrl` ne réécrivait que les hôtes connus).
+
+Nouveau helper `buildProxiedRequest(url, headers)` qui renvoie `{ url, headers }`
+et route les hôtes inconnus cross-origin via le proxy CORS générique
+(`/cors-proxy` + en-tête `X-Target-URL`), où c'est nginx (côté serveur) qui
+transmet l'en-tête custom à la cible. Les hôtes connus (Tabular, Grist, Albert,
+INSEE) gardent leurs proxies dédiés ; le same-origin reste en fetch direct.
+Le gestionnaire de connexions API (test à l'enregistrement + chargement paginé)
+utilise désormais ce helper. Le preflight `/cors-proxy` (nginx + dev Vite)
+autorise les en-têtes custom arbitraires.

--- a/apps/sources/src/connections/api-explorer.ts
+++ b/apps/sources/src/connections/api-explorer.ts
@@ -9,7 +9,7 @@
 
 import {
   escapeHtml,
-  getProxiedUrl,
+  buildProxiedRequest,
   httpErrorMessage,
   isUnsafeKey,
   saveToStorage,
@@ -224,11 +224,15 @@ function renderPaginationBanner(opts: {
 // Core fetch loop
 // ============================================================
 
-async function fetchOnePage(ctx: LoadContext, url: string): Promise<Response> {
+async function fetchOnePage(ctx: LoadContext, rawUrl: string): Promise<Response> {
   const method = (ctx.conn.method as string) || 'GET';
+  // `rawUrl` est l'URL cible brute (non proxifiée). On la route au moment du
+  // fetch via le proxy adéquat (dédié, direct ou CORS générique) en injectant
+  // les en-têtes utilisateur — indispensable pour les API à clé en en-tête.
+  const { url, headers } = buildProxiedRequest(rawUrl, ctx.connHeaders);
   return fetch(url, {
     method,
-    headers: ctx.connHeaders,
+    headers,
     signal: ctx.controller.signal,
   });
 }
@@ -267,8 +271,8 @@ async function runFetchLoop(ctx: LoadContext, maxAdditionalPages: number): Promi
     }
 
     ctx.pageCount++;
-    const detected = detectNextUrl(jsonResponse, ctx.nextUrl, ctx.conn);
-    ctx.nextUrl = detected ? getProxiedUrl(detected) : null;
+    // On stocke l'URL de page suivante BRUTE : fetchOnePage la proxifiera.
+    ctx.nextUrl = detectNextUrl(jsonResponse, ctx.nextUrl, ctx.conn);
   }
 }
 
@@ -361,7 +365,7 @@ export async function loadApiData(): Promise<void> {
     conn: connRecord,
     connHeaders,
     allData: [],
-    nextUrl: getProxiedUrl(apiUrl),
+    nextUrl: apiUrl,
     pageCount: 0,
     apiTotalCount: -1,
     controller: new AbortController(),

--- a/apps/sources/src/connections/connection-manager.ts
+++ b/apps/sources/src/connections/connection-manager.ts
@@ -8,7 +8,7 @@ import {
   STORAGE_KEYS,
   openModal,
   closeModal,
-  getProxiedUrl,
+  buildProxiedRequest,
   getProxyUrl,
   buildGristHeaders,
   isViteDevMode,
@@ -351,7 +351,8 @@ export async function saveApiConnection(name: string): Promise<boolean> {
     }
   }
 
-  const response = await fetch(getProxiedUrl(apiUrl), { method, headers });
+  const { url: testUrl, headers: reqHeaders } = buildProxiedRequest(apiUrl, headers);
+  const response = await fetch(testUrl, { method, headers: reqHeaders });
 
   if (!response.ok) {
     throw new Error(httpErrorMessage(response.status));

--- a/docker/nginx-db.conf
+++ b/docker/nginx-db.conf
@@ -382,7 +382,11 @@ server {
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, X-Target-URL' always;
+            # Wildcard : autorise tout en-tete custom (Apikey, x-api-key, etc.)
+            # afin que le preflight passe meme pour les connexions API a cle en
+            # en-tete. `Authorization` doit etre liste explicitement car exclu
+            # du wildcard `*` par la spec CORS (requetes sans credentials).
+            add_header 'Access-Control-Allow-Headers' '*, Authorization' always;
             add_header 'Access-Control-Max-Age' 86400 always;
             return 204;
         }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -354,7 +354,11 @@ server {
         if ($request_method = 'OPTIONS') {
             add_header 'Access-Control-Allow-Origin' '*' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
-            add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, X-Target-URL' always;
+            # Wildcard : autorise tout en-tete custom (Apikey, x-api-key, etc.)
+            # afin que le preflight passe meme pour les connexions API a cle en
+            # en-tete. `Authorization` doit etre liste explicitement car exclu
+            # du wildcard `*` par la spec CORS (requetes sans credentials).
+            add_header 'Access-Control-Allow-Headers' '*, Authorization' always;
             add_header 'Access-Control-Max-Age' 86400 always;
             return 204;
         }

--- a/packages/shared/src/api/proxy.ts
+++ b/packages/shared/src/api/proxy.ts
@@ -3,6 +3,7 @@
  */
 
 import { getProxyConfig } from './proxy-config.js';
+import type { ProxyConfig } from './proxy-config.js';
 
 /**
  * Get proxied URL for a Grist API endpoint
@@ -28,24 +29,10 @@ export function getProxyUrl(gristUrl: string, endpoint: string): string {
 }
 
 /**
- * Get proxied URL for any external API URL
- * Handles known APIs (tabular, grist, albert) by routing through dedicated proxies.
- * Unknown cross-origin URLs are routed through the generic CORS proxy.
- * Works in all environments: dev (Vite proxy), production, CodePen embeds, etc.
+ * If `parsed` matches a known API host, return the URL rewritten to its
+ * dedicated (CORS-enabled) proxy endpoint. Otherwise return `null`.
  */
-export function getProxiedUrl(url: string): string {
-  if (!url) {
-    throw new Error('getProxiedUrl: url is required');
-  }
-  const config = getProxyConfig();
-
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return url;
-  }
-
+function rewriteKnownHost(parsed: URL, config: ProxyConfig): string | null {
   const rewrites: Array<[string, string]> = [
     ['tabular-api.data.gouv.fr', config.endpoints.tabular],
     ['docs.getgrist.com', config.endpoints.grist],
@@ -60,7 +47,81 @@ export function getProxiedUrl(url: string): string {
     }
   }
 
-  return url;
+  return null;
+}
+
+/**
+ * Get proxied URL for any external API URL
+ * Handles known APIs (tabular, grist, albert) by routing through dedicated proxies.
+ * Unknown hosts are returned unchanged (direct fetch).
+ * Works in all environments: dev (Vite proxy), production, CodePen embeds, etc.
+ *
+ * Note : pour router *aussi* les hôtes inconnus via le proxy CORS générique
+ * (nécessaire dès qu'on envoie un en-tête custom comme `Apikey` qui déclenche
+ * un preflight), utiliser `buildProxiedRequest` qui renvoie url + en-têtes.
+ */
+export function getProxiedUrl(url: string): string {
+  if (!url) {
+    throw new Error('getProxiedUrl: url is required');
+  }
+  const config = getProxyConfig();
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  return rewriteKnownHost(parsed, config) ?? url;
+}
+
+/**
+ * Construit la requête (url + en-têtes) pour atteindre n'importe quelle API
+ * externe sans buter sur CORS :
+ *   - hôte connu (tabular, grist, albert, insee) → proxy dédié, en-têtes inchangés ;
+ *   - même origine que l'app → URL inchangée, en-têtes inchangés ;
+ *   - hôte inconnu cross-origin → proxy CORS générique via l'en-tête `X-Target-URL`.
+ *
+ * Indispensable quand la requête porte un en-tête custom (ex. `Apikey`), qui
+ * rend la requête "non-simple" et déclenche un preflight OPTIONS que les API
+ * tierces (OpenDataSoft, etc.) ne savent pas honorer. En passant par le proxy,
+ * c'est nginx (côté serveur) qui transmet l'en-tête à la cible.
+ */
+export function buildProxiedRequest(
+  url: string,
+  extraHeaders: Record<string, string> = {}
+): { url: string; headers: Record<string, string> } {
+  if (!url) {
+    throw new Error('buildProxiedRequest: url is required');
+  }
+  const headers: Record<string, string> = { ...extraHeaders };
+  const config = getProxyConfig();
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url, typeof window !== 'undefined' ? window.location.href : undefined);
+  } catch {
+    // URL relative ou invalide → on laisse tel quel (same-origin)
+    return { url, headers };
+  }
+
+  // Hôtes connus : proxies dédiés déjà configurés pour CORS
+  const known = rewriteKnownHost(parsed, config);
+  if (known) {
+    return { url: known, headers };
+  }
+
+  // Même origine que l'app : aucun problème de CORS, fetch direct
+  if (typeof window !== 'undefined' && parsed.origin === window.location.origin) {
+    return { url, headers };
+  }
+
+  // Hôte inconnu cross-origin : proxy CORS générique (X-Target-URL)
+  return {
+    url: `${config.baseUrl}${config.endpoints.corsProxy}`,
+    headers: { ...headers, 'X-Target-URL': parsed.href },
+  };
 }
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -42,7 +42,12 @@ export {
   LIB_URL,
 } from './api/proxy-config.js';
 export type { ProxyConfig } from './api/proxy-config.js';
-export { getProxyUrl, getProxiedUrl, buildCorsProxyRequest } from './api/proxy.js';
+export {
+  getProxyUrl,
+  getProxiedUrl,
+  buildCorsProxyRequest,
+  buildProxiedRequest,
+} from './api/proxy.js';
 export { fetchWithTimeout, httpErrorMessage } from './api/fetch-helpers.js';
 export { buildGristHeaders } from './api/grist.js';
 

--- a/proxy/nginx/nginx.conf
+++ b/proxy/nginx/nginx.conf
@@ -279,7 +279,11 @@ http {
             if ($request_method = 'OPTIONS') {
                 add_header 'Access-Control-Allow-Origin' '*' always;
                 add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
-                add_header 'Access-Control-Allow-Headers' 'Content-Type, Authorization, X-Target-URL' always;
+                # Wildcard : autorise tout en-tete custom (Apikey, x-api-key, etc.)
+                # afin que le preflight passe meme pour les connexions API a cle en
+                # en-tete. `Authorization` doit etre liste explicitement car exclu
+                # du wildcard `*` par la spec CORS (requetes sans credentials).
+                add_header 'Access-Control-Allow-Headers' '*, Authorization' always;
                 add_header 'Access-Control-Max-Age' 86400 always;
                 return 204;
             }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -251,10 +251,16 @@ export default defineConfig({
         // et forwarde la requete cote serveur (contourne CORS)
         server.middlewares.use('/cors-proxy', (req, res) => {
           if (req.method === 'OPTIONS') {
+            // Echo des en-tetes demandes : autorise tout en-tete custom
+            // (Apikey, x-api-key, etc.) afin que le preflight passe pour les
+            // connexions API a cle en en-tete (parite avec nginx prod).
+            const reqHeaders =
+              (req.headers['access-control-request-headers'] as string) ||
+              'Content-Type, Authorization, X-Target-URL';
             res.writeHead(204, {
               'Access-Control-Allow-Origin': '*',
               'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
-              'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-Target-URL',
+              'Access-Control-Allow-Headers': reqHeaders,
             });
             res.end();
             return;


### PR DESCRIPTION
## Summary

Adds support for API connections with custom headers (e.g., `Apikey`, `Authorization`) to unknown/third-party hosts by routing them through the generic CORS proxy instead of direct fetch. This solves CORS preflight failures when custom headers trigger non-simple requests.

## Key Changes

- **New `buildProxiedRequest()` helper** in `packages/shared/src/api/proxy.ts`:
  - Returns `{ url, headers }` tuple for proxied requests
  - Routes known hosts (Tabular, Grist, Albert, INSEE) to dedicated proxies
  - Routes unknown cross-origin hosts to generic CORS proxy via `X-Target-URL` header
  - Keeps same-origin requests as direct fetch
  - Extracted host-rewriting logic into `rewriteKnownHost()` helper function

- **Updated API explorer** (`apps/sources/src/connections/api-explorer.ts`):
  - Uses `buildProxiedRequest()` in `fetchOnePage()` to inject user headers at fetch time
  - Stores raw (non-proxified) URLs in pagination loop; proxification happens per-request
  - Ensures custom headers are transmitted through the appropriate proxy

- **Updated connection manager** (`apps/sources/src/connections/connection-manager.ts`):
  - Uses `buildProxiedRequest()` for API connection test requests
  - Properly routes test requests through CORS proxy when needed

- **CORS configuration updates** (nginx + Vite dev):
  - Changed `Access-Control-Allow-Headers` from explicit list to wildcard `*, Authorization`
  - Allows arbitrary custom headers in preflight responses
  - Applied to: `docker/nginx.conf`, `docker/nginx-db.conf`, `proxy/nginx/nginx.conf`, `vite.config.ts`
  - Vite dev server now echoes requested headers from preflight to match production behavior

- **Export updates** (`packages/shared/src/index.ts`):
  - Exports new `buildProxiedRequest` function alongside existing proxy utilities

## Implementation Details

The solution leverages the existing generic CORS proxy infrastructure (`/cors-proxy` endpoint) which nginx forwards to the target URL specified in the `X-Target-URL` header. This allows the server to transmit custom headers that would otherwise trigger CORS preflight failures when sent directly from the browser.

The approach maintains backward compatibility: known hosts continue using dedicated proxies, same-origin requests bypass proxying entirely, and only unknown cross-origin requests with custom headers are routed through the generic CORS proxy.

Changeset added for `dsfr-data` minor version bump.

https://claude.ai/code/session_01ERGVFx4bBEkgBGMQR6wHsk