### PR TITLE
fix(sources): format d'auth OpenDataSoft (Authorization: Apikey)

### DIFF
--- a/.changeset/cors-proxy-custom-header-apis.md
+++ b/.changeset/cors-proxy-custom-header-apis.md
@@ -19,3 +19,15 @@ INSEE) gardent leurs proxies dédiés ; le same-origin reste en fetch direct.
 Le gestionnaire de connexions API (test à l'enregistrement + chargement paginé)
 utilise désormais ce helper. Le preflight `/cors-proxy` (nginx + dev Vite)
 autorise les en-têtes custom arbitraires.
+
+Côté authentification OpenDataSoft : ODS n'authentifie qu'une clé passée via
+`Authorization: Apikey <clé>` (en-tête) ou `?apikey=` (query). Deux corrections :
+
+- Nouveau helper `normalizeProviderAuthHeaders(apiUrl, headers)` qui détecte une
+  clé fournie sous un en-tête mal nommé (`Apikey`, `api-key`, `x-api-key`) sur
+  une source ODS et la réécrit au format `Authorization: Apikey <clé>`. Sans
+  ça, ODS ignorait la clé et renvoyait un 404 trompeur (datasets privés masqués).
+  Appliqué au test à l'enregistrement (avec persistance) et au chargement.
+- `resolveSourceUrl` conserve désormais le param `apikey` collé dans l'URL lors
+  de la normalisation vers l'endpoint `/records` (les autres params restent
+  gérés par l'adapter), pour que la méthode `?apikey=` fonctionne aussi.

--- a/apps/sources/src/connections/api-explorer.ts
+++ b/apps/sources/src/connections/api-explorer.ts
@@ -10,6 +10,7 @@
 import {
   escapeHtml,
   buildProxiedRequest,
+  normalizeProviderAuthHeaders,
   httpErrorMessage,
   isUnsafeKey,
   saveToStorage,
@@ -361,9 +362,14 @@ export async function loadApiData(): Promise<void> {
     }
   }
 
+  // Adapte la cle au format d'auth du provider (ex. ODS attend
+  // `Authorization: Apikey <cle>`), y compris pour les connexions enregistrees
+  // avant cette correction.
+  const { headers: authHeaders } = normalizeProviderAuthHeaders(apiUrl, connHeaders);
+
   const ctx: LoadContext = {
     conn: connRecord,
-    connHeaders,
+    connHeaders: authHeaders,
     allData: [],
     nextUrl: apiUrl,
     pageCount: 0,

--- a/apps/sources/src/connections/connection-manager.ts
+++ b/apps/sources/src/connections/connection-manager.ts
@@ -21,6 +21,7 @@ import {
   isUnsafeKey,
   httpErrorMessage,
   resolveSourceUrl,
+  normalizeProviderAuthHeaders,
   parseDataGouvDataset,
   dataGouvDatasetApiUrl,
   looksLikeNumber,
@@ -332,7 +333,7 @@ export async function saveApiConnection(name: string): Promise<boolean> {
 
   const apiUrl = apiUrlEl?.value.trim() ?? '';
   const method = methodEl?.value ?? 'GET';
-  const headersText = headersEl?.value.trim() ?? '';
+  let headersText = headersEl?.value.trim() ?? '';
   const dataPath = dataPathEl?.value.trim() ?? '';
 
   if (!apiUrl) {
@@ -349,6 +350,17 @@ export async function saveApiConnection(name: string): Promise<boolean> {
       toastWarning('Les en-tetes doivent etre au format JSON valide');
       return false;
     }
+  }
+
+  // Adapte la cle au format d'auth du provider (ex. ODS : une cle fournie via un
+  // en-tete `Apikey`/`api-key` est ignoree par ODS, qui attend `Authorization:
+  // Apikey <cle>`). On persiste la correction pour que le chargement fonctionne.
+  const authNorm = normalizeProviderAuthHeaders(apiUrl, headers);
+  if (authNorm.changed) {
+    headers = authNorm.headers;
+    headersText = JSON.stringify(headers);
+    populateApiHeadersFromJson(headersText);
+    toastWarning("Cle reformatee en en-tete « Authorization: Apikey … » (format attendu par OpenDataSoft).");
   }
 
   const { url: testUrl, headers: reqHeaders } = buildProxiedRequest(apiUrl, headers);

--- a/apps/sources/src/connections/connection-manager.ts
+++ b/apps/sources/src/connections/connection-manager.ts
@@ -360,7 +360,9 @@ export async function saveApiConnection(name: string): Promise<boolean> {
     headers = authNorm.headers;
     headersText = JSON.stringify(headers);
     populateApiHeadersFromJson(headersText);
-    toastWarning("Cle reformatee en en-tete « Authorization: Apikey … » (format attendu par OpenDataSoft).");
+    toastWarning(
+      'Cle reformatee en en-tete « Authorization: Apikey … » (format attendu par OpenDataSoft).'
+    );
   }
 
   const { url: testUrl, headers: reqHeaders } = buildProxiedRequest(apiUrl, headers);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -139,6 +139,7 @@ export {
   detectProvider,
   extractResourceIds,
   resolveSourceUrl,
+  normalizeProviderAuthHeaders,
   parseDataGouvDataset,
   dataGouvDatasetApiUrl,
   extractDataGouvResources,

--- a/packages/shared/src/providers/index.ts
+++ b/packages/shared/src/providers/index.ts
@@ -127,6 +127,7 @@ export function resolveSourceUrl(rawUrl: string): ResolvedSourceUrl {
   const ids = provider.resource.extractIds(url);
 
   let apiUrl: string | null = null;
+  let canonical: string | null = null;
   if (ids && provider.resource.apiPathTemplate) {
     const apiBase =
       API_SAME_ORIGIN_AS_PAGE.has(provider.id) && baseUrl ? baseUrl : provider.defaultBaseUrl;
@@ -135,12 +136,74 @@ export function resolveSourceUrl(rawUrl: string): ResolvedSourceUrl {
       for (const [key, value] of Object.entries(ids)) {
         path = path.replace(`{${key}}`, encodeURIComponent(value));
       }
-      apiUrl = `${apiBase}${path}`;
+      canonical = `${apiBase}${path}`;
+      apiUrl = canonical;
+      // Conserver UNIQUEMENT le param d'authentification `apikey` collé dans
+      // l'URL : les autres params (limit/offset/where…) sont gérés par
+      // l'adapter et seraient redondants/conflictuels. Sans ça, coller une URL
+      // type `.../records?apikey=KEY` perdait la clé lors de la normalisation.
+      try {
+        const apikey = new URL(url).searchParams.get('apikey');
+        if (apikey) apiUrl = `${canonical}?apikey=${encodeURIComponent(apikey)}`;
+      } catch {
+        /* url non parseable → pas de query à préserver */
+      }
     }
   }
 
   const stripped = url.split(/[?#]/)[0].replace(/\/$/, '');
-  const normalized = apiUrl !== null && stripped !== apiUrl.replace(/\/$/, '');
+  // `normalized` reste calculé sur le chemin canonique (sans la query apikey)
+  // pour ne pas signaler une réécriture quand seul un `?apikey=` est présent.
+  const normalized = canonical !== null && stripped !== canonical.replace(/\/$/, '');
 
   return { provider, baseUrl, ids, apiUrl, normalized };
+}
+
+// ---------------------------------------------------------------------------
+// Normalisation des en-têtes d'authentification par provider
+// ---------------------------------------------------------------------------
+
+/** Noms d'en-tête (insensible à la casse) couramment mal employés pour une clé. */
+const APIKEY_HEADER_NAMES = new Set(['apikey', 'api-key', 'api_key', 'x-api-key']);
+
+/**
+ * Adapte les en-têtes d'authentification au format réellement attendu par le
+ * provider détecté à partir de `apiUrl`.
+ *
+ * Cas OpenDataSoft (`apikey-header`) : ODS n'authentifie PAS un en-tête nommé
+ * `Apikey` (ou `api-key`, `x-api-key`). La clé doit être envoyée via
+ * `Authorization: Apikey <clé>`. Une clé fournie sous un mauvais nom d'en-tête
+ * est donc silencieusement ignorée → ODS renvoie 404 (datasets privés masqués).
+ * Cette fonction détecte ce cas et réécrit l'en-tête au bon format.
+ *
+ * Renvoie les en-têtes ajustés et un flag `changed` pour permettre à l'UI de
+ * persister la correction et d'en informer l'utilisateur. Idempotente :
+ * ne touche à rien si un en-tête `Authorization` est déjà présent.
+ */
+export function normalizeProviderAuthHeaders(
+  apiUrl: string,
+  headers: Record<string, string>
+): { headers: Record<string, string>; changed: boolean } {
+  const provider = detectProvider(apiUrl);
+  if (provider.defaultAuthType !== 'apikey-header' || provider.id !== 'opendatasoft') {
+    return { headers, changed: false };
+  }
+
+  // Déjà un Authorization → l'utilisateur sait ce qu'il fait, on n'écrase pas.
+  const hasAuthorization = Object.keys(headers).some((k) => k.toLowerCase() === 'authorization');
+  if (hasAuthorization) return { headers, changed: false };
+
+  let apikey: string | null = null;
+  const out: Record<string, string> = {};
+  for (const [name, value] of Object.entries(headers)) {
+    if (apikey === null && APIKEY_HEADER_NAMES.has(name.toLowerCase()) && value) {
+      apikey = value;
+      continue; // on retire l'en-tête mal nommé
+    }
+    out[name] = value;
+  }
+
+  if (apikey === null) return { headers, changed: false };
+  out['Authorization'] = `Apikey ${apikey}`;
+  return { headers: out, changed: true };
 }

--- a/tests/shared/providers.test.ts
+++ b/tests/shared/providers.test.ts
@@ -3,6 +3,7 @@ import {
   detectProvider,
   extractResourceIds,
   resolveSourceUrl,
+  normalizeProviderAuthHeaders,
   parseDataGouvDataset,
   dataGouvDatasetApiUrl,
   extractDataGouvResources,
@@ -479,6 +480,84 @@ describe('resolveSourceUrl', () => {
     expect(r.provider.id).toBe('generic');
     expect(r.baseUrl).toBeNull();
     expect(r.apiUrl).toBeNull();
+  });
+
+  it('preserves the apikey query param on an ODS records URL (normalized=false)', () => {
+    const r = resolveSourceUrl(
+      'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/ccsf/records?apikey=SECRET'
+    );
+    expect(r.apiUrl).toBe(
+      'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/ccsf/records?apikey=SECRET'
+    );
+    expect(r.normalized).toBe(false);
+  });
+
+  it('preserves the apikey query param when normalizing an ODS page URL', () => {
+    const r = resolveSourceUrl(
+      'https://data.economie.gouv.fr/explore/dataset/ccsf/table/?apikey=SECRET'
+    );
+    expect(r.apiUrl).toBe(
+      'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/ccsf/records?apikey=SECRET'
+    );
+    expect(r.normalized).toBe(true);
+  });
+
+  it('drops non-auth query params (limit) but keeps the path canonical', () => {
+    const r = resolveSourceUrl(
+      'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/test/records?limit=15'
+    );
+    expect(r.apiUrl).toBe(
+      'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/test/records'
+    );
+    expect(r.normalized).toBe(false);
+  });
+});
+
+// =========================================================================
+// normalizeProviderAuthHeaders (ODS apikey → Authorization: Apikey <key>)
+// =========================================================================
+
+describe('normalizeProviderAuthHeaders', () => {
+  const odsUrl = 'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/x/records';
+
+  it('rewrites a misnamed ODS apikey header into Authorization: Apikey', () => {
+    const r = normalizeProviderAuthHeaders(odsUrl, { Apikey: 'KEY' });
+    expect(r.changed).toBe(true);
+    expect(r.headers).toEqual({ Authorization: 'Apikey KEY' });
+  });
+
+  it('also handles api-key / x-api-key variants', () => {
+    expect(normalizeProviderAuthHeaders(odsUrl, { 'api-key': 'K' }).headers).toEqual({
+      Authorization: 'Apikey K',
+    });
+    expect(normalizeProviderAuthHeaders(odsUrl, { 'X-API-Key': 'K' }).headers).toEqual({
+      Authorization: 'Apikey K',
+    });
+  });
+
+  it('leaves an existing Authorization header untouched', () => {
+    const headers = { Authorization: 'Apikey EXISTING', Apikey: 'IGNORED' };
+    const r = normalizeProviderAuthHeaders(odsUrl, headers);
+    expect(r.changed).toBe(false);
+    expect(r.headers).toBe(headers);
+  });
+
+  it('preserves other headers while moving the key', () => {
+    const r = normalizeProviderAuthHeaders(odsUrl, { Apikey: 'KEY', Accept: 'application/json' });
+    expect(r.headers).toEqual({ Accept: 'application/json', Authorization: 'Apikey KEY' });
+  });
+
+  it('does nothing for non-ODS providers (Tabular)', () => {
+    const r = normalizeProviderAuthHeaders('https://tabular-api.data.gouv.fr/api/resources/abc/data/', {
+      Apikey: 'KEY',
+    });
+    expect(r.changed).toBe(false);
+    expect(r.headers).toEqual({ Apikey: 'KEY' });
+  });
+
+  it('does nothing when ODS has no apikey-like header', () => {
+    const r = normalizeProviderAuthHeaders(odsUrl, { 'X-Custom': 'v' });
+    expect(r.changed).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Contexte

Suite de #252 (fix CORS, déjà mergé). Même après le routage via le proxy CORS, une connexion manuelle vers un dataset **privé** OpenDataSoft renvoyait un **404 trompeur** (`NotFoundResource`) à l'enregistrement comme au chargement.

Raison : ODS n'authentifie qu'une clé passée via `Authorization: Apikey <clé>` (en-tête) ou `?apikey=` (query). Or :
- un en-tête nommé `Apikey` (le plus intuitif) est **silencieusement ignoré** par ODS → 404 (les datasets privés sont masqués) ;
- un `?apikey=` collé dans l'URL était **jeté** lors de la normalisation auto de l'URL vers l'endpoint `/records`.

## Corrections

- **`normalizeProviderAuthHeaders(apiUrl, headers)`** (`packages/shared`) : sur une source ODS, détecte une clé fournie sous un en-tête mal nommé (`Apikey`, `api-key`, `x-api-key`) et la réécrit au format attendu `Authorization: Apikey <clé>`. Idempotent (ne touche rien si `Authorization` est déjà présent ; n'affecte pas les autres providers). Appliqué :
  - au **test à l'enregistrement** (`connection-manager`), avec persistance de la correction dans la connexion + l'éditeur d'en-têtes et un toast d'info ;
  - au **chargement** (`api-explorer`), donc compatible avec les connexions déjà enregistrées avec un en-tête `Apikey`.
- **`resolveSourceUrl`** conserve désormais le param `apikey` collé dans l'URL lors de la normalisation vers `/records` (les autres params `limit`/`offset`/`where` restent gérés par l'adapter, comportement inchangé — test existant préservé).
- Tests unitaires ajoutés pour les deux fonctions.

## Déploiement

Changements côté **app** (`apps/sources`) + `@dsfr-data/shared`. Après merge : rebuild + redéploiement de l'app (le volet nginx du fix CORS de #252 est indépendant).

https://claude.ai/code/session_01ERGVFx4bBEkgBGMQR6wHsk

---
_Generated by [Claude Code](https://claude.ai/code/session_01ERGVFx4bBEkgBGMQR6wHsk)_