### PR TITLE
feat(core): max-records configurable sur l'adapter ODS (#233)

### DIFF
--- a/.changeset/ods-max-records.md
+++ b/.changeset/ods-max-records.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': minor
+---
+
+Nouvel attribut `max-records` sur `dsfr-data-source` en mode adapter (#233) : le plafond fetchAll de l'adapter OpenDataSoft (1 000 records) était codé en dur — ce n'est **pas** une limite de l'API. Il est désormais configurable (`max-records="5000"`), avec le défaut conservé à 1 000 en garde-fou anti-surcharge ; à relever explicitement pour les dashboards « un seul fetch server-side, puis N agrégations côté client » (attention au nombre de requêtes en boucle et au poids mémoire — documenté dans la spec). Au passage, le warn « pagination incomplete » se déclenche enfin quand le plafond tronque un fetch-all (l'ancienne condition ne couvrait que les short-reads sous un `limit` explicite).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ Pour les cas sans transformation (datalist, display), dsfr-data-query peut etre 
 | serverOrderBy | oui | oui | oui | non | non |
 | serverGeo | oui | non | non | non | non |
 | whereFormat | odsql | colon | colon | colon | colon |
-| plafond fetchAll (#286) | 1 000 (10×100) | 25 000 (500×50) | illimite (1 requete) | 100 000 (100×1000) | n/a |
+| plafond fetchAll (#286) | 1 000 (10×100), relevable via `max-records` (#233) | 25 000 (500×50) | illimite (1 requete) | 100 000 (100×1000) | n/a |
 
 **Formats WHERE** :
 - **ODSQL** (OpenDataSoft) : syntaxe SQL-like — `population > 5000 AND status = 'active'`, clauses jointes par ` AND `
@@ -183,7 +183,7 @@ dsfr-data-source fonctionne en deux modes :
 
 **`cache-ttl` et le hook de cache (#307)** : la lib publiee n'appelle aucune API applicative. `cache-ttl` n'a d'effet que si la page hote enregistre un provider via `window.DSFR_DATA_CACHE_PROVIDER = { get(key), put(key, data, ttl) }` AVANT le chargement des composants (sans provider : no-op, embed anonyme). La cle inclut un hash du fingerprint de la requete (URL/params/where/page) — deux requetes differentes ne partagent jamais une entree. Les apps du repo enregistrent le provider `/api/cache` (mode DB) via `registerServerCacheProvider()` de `@dsfr-data/shared`, appele par `@dsfr-data/app-ui`.
 
-**Mode adapter** (api-type != generic ou base-url fourni) : `api-type`, `base-url`, `dataset-id`, `resource`, `where`, `select`, `group-by`, `aggregate`, `order-by`, `server-side`, `page-size`, `limit`
+**Mode adapter** (api-type != generic ou base-url fourni) : `api-type`, `base-url`, `dataset-id`, `resource`, `where`, `select`, `group-by`, `aggregate`, `order-by`, `server-side`, `page-size`, `limit`, `max-records` (#233 — plafond du fetchAll, 0 = defaut adapter ; a relever en connaissance de cause : requetes en boucle, memoire)
 
 ### Grist : mode Records vs SQL
 

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -221,6 +221,7 @@ tableau de données depuis la reponse. Le resultat DOIT etre un tableau d'objets
 | order-by | String | \`""\` | non | Tri serveur. Ex: \`"population:desc"\` |
 | server-side | Boolean | \`false\` | non | Active la pagination serveur page par page (datalist, tableaux). |
 | limit | Number | \`0\` | non | Limite du nombre de resultats (0 = pas de limite). |
+| max-records | Number | \`0\` | non | Plafond du fetchAll en mode adapter (#233). 0 = plafond par defaut de l'adapter (ODS : 1000). A relever explicitement pour les dashboards « un fetch, N agregations client » — attention au volume (requetes en boucle, memoire). |
 | data | String | \`""\` | non | Données JSON inline (pas de fetch). Ex: \`data='[{"x":1},{"x":2}]'\` |
 | use-proxy | Boolean | \`false\` | non | Force le passage par le proxy CORS generique. Utile pour les APIs externes sans CORS. |
 | api-key-ref | String | \`""\` | non | Reference vers une clé API dans window.DSFR_DATA_KEYS. Injecte la valeur comme header Authorization. |

--- a/packages/core/src/adapters/api-adapter.ts
+++ b/packages/core/src/adapters/api-adapter.ts
@@ -46,6 +46,13 @@ export interface AdapterParams {
   aggregate: string;
   orderBy: string;
   limit: number;
+  /**
+   * Plafond de records du fetchAll (#233) — 0/absent = plafond par defaut
+   * de l'adapter (garde-fou anti-surcharge). Ce n'est PAS une limite API :
+   * l'operateur le releve explicitement en connaissance de cause
+   * (requetes en boucle, poids memoire).
+   */
+  maxRecords?: number;
   transform: string;
   pageSize: number;
   /** Headers HTTP custom (ex: authentification, API key) */

--- a/packages/core/src/adapters/opendatasoft-adapter.ts
+++ b/packages/core/src/adapters/opendatasoft-adapter.ts
@@ -105,13 +105,20 @@ export class OpenDataSoftAdapter implements ApiAdapter {
    */
   async fetchAll(params: AdapterParams, signal: AbortSignal): Promise<FetchResult> {
     const fetchAllRecords = params.limit <= 0;
-    const requestedLimit = fetchAllRecords ? ODS_MAX_PAGES * ODS_PAGE_SIZE : params.limit;
+    // max-records (#233) : plafond configurable — le 1000 historique n'est
+    // PAS une limite de l'API ODS, defaut conserve en garde-fou
+    const maxRecords =
+      params.maxRecords && params.maxRecords > 0
+        ? params.maxRecords
+        : ODS_MAX_PAGES * ODS_PAGE_SIZE;
+    const maxPages = Math.ceil(maxRecords / ODS_PAGE_SIZE);
+    const requestedLimit = fetchAllRecords ? maxRecords : params.limit;
     const pageSize = ODS_PAGE_SIZE;
     let allResults: unknown[] = [];
     let offset = 0;
     let totalCount = -1;
 
-    for (let page = 0; page < ODS_MAX_PAGES; page++) {
+    for (let page = 0; page < maxPages; page++) {
       const remaining = requestedLimit - allResults.length;
       if (remaining <= 0) break;
 
@@ -137,11 +144,19 @@ export class OpenDataSoftAdapter implements ApiAdapter {
       offset += pageResults.length;
     }
 
-    // Avertir si pagination incomplete
-    if (totalCount >= 0 && allResults.length < totalCount && allResults.length < requestedLimit) {
+    // Avertir si la recuperation est incomplete : short-read sous un limit
+    // explicite (anomalie serveur, comportement historique) OU troncature
+    // par le plafond en fetch-all (#233 — l'ancienne condition ne se
+    // declenchait jamais quand le cap etait atteint pile). Un limit
+    // explicite atteint = troncature voulue, pas de warn.
+    const incomplete =
+      totalCount >= 0 &&
+      allResults.length < totalCount &&
+      (fetchAllRecords || allResults.length < requestedLimit);
+    if (incomplete) {
       console.warn(
         `[dsfr-data] opendatasoft: pagination incomplete - ${allResults.length}/${totalCount} resultats recuperes ` +
-          `(limite de securite: ${ODS_MAX_PAGES} pages de ${ODS_PAGE_SIZE})`
+          `(plafond max-records: ${maxRecords} — relevable via l'attribut max-records, #233)`
       );
     }
 

--- a/packages/core/src/components/dsfr-data-source.ts
+++ b/packages/core/src/components/dsfr-data-source.ts
@@ -130,6 +130,15 @@ export class DsfrDataSource extends LitElement {
   @property({ type: Number })
   limit = 0;
 
+  /**
+   * Plafond de records du fetchAll en mode adapter (#233). 0 = plafond par
+   * defaut de l'adapter (ODS : 1000). A relever explicitement pour les
+   * dashboards « un fetch, N agregations client » — attention au nombre de
+   * requetes en boucle et au poids memoire.
+   */
+  @property({ type: Number, attribute: 'max-records' })
+  maxRecords = 0;
+
   // --- Internal state ---
 
   @state()
@@ -722,6 +731,7 @@ export class DsfrDataSource extends LitElement {
       aggregate: this._aggregateOverlay || this.aggregate,
       orderBy: this._orderByOverlay || this.orderBy,
       limit: this.limit,
+      maxRecords: this.maxRecords,
       transform: this.transform,
       pageSize: this.pageSize,
       headers: parsedHeaders,

--- a/specs/components/dsfr-data-source.html
+++ b/specs/components/dsfr-data-source.html
@@ -149,6 +149,7 @@
             <tr><td><code>aggregate</code></td><td>String</td><td><code>"champ:fn"</code> ou <code>"champ:fn:alias"</code></td><td>Agregations server-side. Fonctions : <code>count</code> <code>sum</code> <code>avg</code> <code>min</code> <code>max</code>.</td></tr>
             <tr><td><code>order-by</code></td><td>String</td><td><code>"champ:asc"</code> ou <code>"champ:desc"</code></td><td>Tri des resultats. Peut etre surcharge dynamiquement par un <code>dsfr-data-list</code>.</td></tr>
             <tr><td><code>limit</code></td><td>Number</td><td>Entier positif. <code>0</code> = illimite</td><td>Nombre maximum de resultats</td></tr>
+            <tr><td><code>max-records</code></td><td>Number</td><td>Entier positif. <code>0</code> = plafond par defaut de l'adapter</td><td>Plafond du fetchAll en mode adapter (#233). Le defaut ODS (1 000) est un garde-fou, pas une limite API : le relever augmente le nombre de requetes en boucle et le poids memoire — a faire en connaissance de cause (dashboards « un fetch, N agregations client »).</td></tr>
             <tr><td><code>server-side</code></td><td>Boolean</td><td>Presence = <code>true</code></td><td>Mode pagination pilotable : charge une page a la fois, ecoute les commandes
               des composants en aval (<code>dsfr-data-list</code>, <code>dsfr-data-facets</code>, <code>dsfr-data-search</code>).</td></tr>
           </tbody>

--- a/tests/adapters/ods-max-records.test.ts
+++ b/tests/adapters/ods-max-records.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Tests #233 — max-records configurable sur l'adapter ODS.
+ *
+ * Le plafond « 1000 records » était codé en dur (ODS_MAX_PAGES=10 ×
+ * ODS_PAGE_SIZE=100) — ce n'est PAS une limite de l'API ODS. Il bloquait
+ * l'architecture « un seul fetch server-side, puis N agrégations côté
+ * client ». `max-records` le rend configurable, défaut conservé à 1000
+ * (garde-fou anti-surcharge).
+ */
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+import { OpenDataSoftAdapter } from '@/adapters/opendatasoft-adapter.js';
+import { DsfrDataSource } from '@/components/dsfr-data-source.js';
+
+/** Mocke une API ODS de `total` records servis par pages de 100 */
+function mockOdsDataset(total: number) {
+  mockFetch.mockReset();
+  mockFetch.mockImplementation(async (url: string) => {
+    const u = new URL(url);
+    const offset = parseInt(u.searchParams.get('offset') || '0', 10);
+    const limit = parseInt(u.searchParams.get('limit') || '100', 10);
+    const count = Math.max(0, Math.min(limit, total - offset));
+    return {
+      ok: true,
+      json: async () => ({
+        total_count: total,
+        results: Array.from({ length: count }, (_, i) => ({ id: offset + i })),
+      }),
+    };
+  });
+}
+
+const PARAMS = {
+  baseUrl: 'https://data.example.fr',
+  datasetId: 'ds',
+  resource: '',
+  select: '',
+  where: '',
+  filter: '',
+  groupBy: '',
+  aggregate: '',
+  orderBy: '',
+  limit: 0,
+  transform: '',
+  pageSize: 0,
+};
+
+describe('#233 — AC : max-records non défini → comportement actuel (cap 1000)', () => {
+  it('fetchAll plafonne à 1000 sur un dataset de 2500', async () => {
+    mockOdsDataset(2500);
+    const adapter = new OpenDataSoftAdapter();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await adapter.fetchAll(PARAMS, new AbortController().signal);
+
+    expect(result.data).toHaveLength(1000);
+    expect(mockFetch).toHaveBeenCalledTimes(10);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('pagination incomplete'));
+    warnSpy.mockRestore();
+  });
+});
+
+describe('#233 — AC : max-records="5000" → pagination jusqu’à 5000', () => {
+  it('fetchAll va au-delà du plafond historique', async () => {
+    mockOdsDataset(2500);
+    const adapter = new OpenDataSoftAdapter();
+
+    const result = await adapter.fetchAll(
+      { ...PARAMS, maxRecords: 5000 },
+      new AbortController().signal
+    );
+
+    // Le dataset n'a que 2500 lignes : tout est récupéré (25 pages)
+    expect(result.data).toHaveLength(2500);
+    expect(result.totalCount).toBe(2500);
+    expect(mockFetch).toHaveBeenCalledTimes(25);
+  });
+
+  it('max-records="150" plafonne en dessous du défaut', async () => {
+    mockOdsDataset(2500);
+    const adapter = new OpenDataSoftAdapter();
+
+    const result = await adapter.fetchAll(
+      { ...PARAMS, maxRecords: 150 },
+      new AbortController().signal
+    );
+
+    expect(result.data).toHaveLength(150);
+    expect(mockFetch).toHaveBeenCalledTimes(2); // 100 + 50
+  });
+
+  it('limit explicite garde la priorité sur max-records', async () => {
+    mockOdsDataset(2500);
+    const adapter = new OpenDataSoftAdapter();
+
+    const result = await adapter.fetchAll(
+      { ...PARAMS, limit: 120, maxRecords: 5000 },
+      new AbortController().signal
+    );
+
+    expect(result.data).toHaveLength(120);
+  });
+});
+
+describe('#233 — l’attribut max-records de dsfr-data-source est propagé', () => {
+  beforeEach(() => mockFetch.mockReset());
+
+  it('getAdapterParams() transmet maxRecords', () => {
+    const source = new DsfrDataSource();
+    source.id = 'mr-src';
+    source.apiType = 'opendatasoft';
+    source.baseUrl = 'https://data.example.fr';
+    source.datasetId = 'ds';
+    source.setAttribute('max-records', '5000');
+    (source as any).maxRecords = 5000;
+
+    expect(source.getAdapterParams().maxRecords).toBe(5000);
+  });
+
+  it('défaut : maxRecords absent/0 → cap historique', () => {
+    const source = new DsfrDataSource();
+    source.id = 'mr-src2';
+    expect(source.getAdapterParams().maxRecords ?? 0).toBe(0);
+  });
+});


### PR DESCRIPTION
## Quick win #233 (séparable de l'epic #224)

Le plafond fetchAll ODS (1 000 records) était codé en dur — **pas** une limite de l'API. Il bloquait le pattern « un seul fetch server-side → N agrégations côté client ».

- Nouvel attribut `max-records` sur `dsfr-data-source` (mode adapter), propagé via `AdapterParams.maxRecords` — **défaut conservé à 1 000** (garde-fou).
- Warn de troncature corrigé : il ne se déclenchait jamais quand le cap était atteint pile ; un `limit` explicite atteint reste silencieux (troncature voulue).
- Doc : spec (risques requêtes/mémoire), CLAUDE.md (table des plafonds #286), skill source (test d'alignement vert).
- 6 tests AC (`tests/adapters/ods-max-records.test.ts`) ; suite **3409/3409**, typecheck OK.
- Changeset **minor** (nouvel attribut).

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)