### PR TITLE
chore(deploy): couche de déploiement agnostique VibeLab

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,8 @@ tests
 .env.*
 Dockerfile
 docker-compose.yml
+compose.yml
+deploy.sh
+.spawn-override.yml
+.spawn-meta
 .dockerignore

--- a/.env.example
+++ b/.env.example
@@ -19,9 +19,15 @@
 # Domaine de production [REQUISE pour Traefik / deploy]
 # ---------------------------------------------------------------------------
 # Nom de domaine sur lequel l'application est deployee.
-# Utilise par Traefik (docker-compose.yml) et les scripts de deploiement.
-# Sert aussi de valeur par defaut pour VITE_PROXY_URL et APP_URL via les
-# scripts deploy.sh / deploy-server.sh.
+# Utilise par Traefik (docker/docker-compose.yml) et les scripts legacy
+# docker/deploy.sh / docker/deploy-server.sh. Sert aussi de valeur par defaut
+# pour VITE_PROXY_URL et APP_URL.
+#
+# NOTE deploiement agnostique (racine compose.yml + deploy.sh, plateforme
+# VibeLab) : le domaine n'est PAS lu ici mais fourni a l'execution par
+# l'orchestrateur `spawn` via la variable DOMAIN. Le deploy.sh racine en
+# derive VITE_PROXY_URL / APP_URL / SMTP_FROM et genere les secrets. Dans ce
+# mode, ne pas definir APP_DOMAIN ci-dessous.
 APP_DOMAIN=chartsbuilder.matge.com
 
 # ---------------------------------------------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,7 +257,31 @@ Si un attribut est ajoute a un composant sans maj du skill, le test echouera.
 
 ## Deploiement serveur (VPS)
 
-Le repo s'appelle `dsfr-data` mais le projet Docker s'appelle `datasource-charts-webcomponents` (ancien nom).
+### Deploiement agnostique (plateforme VibeLab — production miweb.run)
+
+Mode canonique depuis la migration vers VibeLab. Le repo expose a la **racine** :
+- `compose.yml` — stack mode DB (service `web` + `mariadb`), agnostique :
+  reseau `proxy` externe, labels Traefik en `${APP_NAME}`/`${DOMAIN}`, aucun
+  domaine/hebergeur code en dur, pas de `container_name` fige.
+- `deploy.sh` — equivalent agnostique de `docker/deploy-server.sh` : genere les
+  secrets/`.env` (une seule fois), derive `VITE_PROXY_URL`/`APP_URL`/`SMTP_FROM`
+  du `DOMAIN`, build + up sous `-p ${APP_NAME}`.
+
+L'orchestrateur `spawn` (cf. skill `vps-spawn`) cherche le compose racine, exporte
+`APP_NAME`/`DOMAIN`/`MAIL_HOST`/`MAIL_PORT` et lance `./deploy.sh`. Deploiement type :
+
+```bash
+ssh vps "spawn up chartsbuilder git@github.com:bmatge/dsfr-data.git --dns api --mail real --keep"
+# → https://chartsbuilder.miweb.run (cert dedie DKIM, mail reel signe)
+```
+
+DB **vierge** : le premier compte inscrit recoit le role admin. Les secrets
+generes (`ENCRYPTION_KEY`, `JWT_SECRET`, `DB_*`) vivent dans `/opt/apps/chartsbuilder/.env`
+sur le VPS — a sauvegarder hors serveur, ne JAMAIS les regenerer en place.
+
+### Deploiement legacy (ancien VPS, dual-mode)
+
+Le repo s'appelle `dsfr-data` mais le projet Docker historique s'appelle `datasource-charts-webcomponents` (ancien nom).
 Le `.env` doit contenir `COMPOSE_PROJECT_NAME=datasource-charts-webcomponents` pour que Docker reuse les volumes existants.
 
 ```bash
@@ -266,7 +290,7 @@ cp ~/datasource-charts-webcomponents/.env .env
 echo "COMPOSE_PROJECT_NAME=datasource-charts-webcomponents" >> .env
 
 # Deploiement (arrete les conteneurs, git pull, build, redemarre)
-./deploy-server.sh
+./docker/deploy-server.sh   # ou ./docker/deploy.sh en mode statique
 ```
 
 **Configuration self-hosted** (domaine arbitraire, proxy d'entreprise, reverse externe gerant les routes de proxying) : la procedure complete est dans [`docs/DEPLOYMENT.md` §"Configuration self-hosted"](docs/DEPLOYMENT.md#configuration-self-hosted). Elle couvre les 3 scenarios + le contrat exhaustif des chemins de proxying (`/grist-proxy/`, `/tabular-proxy/`, `/albert-proxy/`, etc.) pour qu'un operateur tiers puisse les repliquer derriere son propre reverse. Chaque bloc `location /*-proxy/` dans `docker/nginx.conf` et `nginx-db.conf` est annote `DESACTIVABLE` avec un renvoi vers cette section.

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,113 @@
+# Déploiement agnostique (plateforme VibeLab — production miweb.run).
+#
+# Contrat : APP_NAME, DOMAIN, MAIL_HOST, MAIL_PORT sont fournis par
+# l'orchestrateur `spawn` à l'exécution. Aucun domaine, réseau d'hébergeur ni
+# nom de conteneur n'est codé en dur ici → le repo est redéployable n'importe
+# où. Le service applicatif s'appelle `web` (contrat vibelab-starter, requis
+# pour que l'override réseau mail de spawn `--mail` s'attache au bon service).
+#
+# Mode unique : DB (nginx + Express + MariaDB, auth JWT, données chiffrées).
+# Les secrets et les variables dérivées du domaine sont gérés par ./deploy.sh.
+#
+# Pour les déploiements legacy / locaux dual-mode (statique vs serveur sur
+# l'ancien `ecosystem-network`), voir docker/docker-compose*.yml + docker/.
+services:
+  web:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.db
+      args:
+        # Variables build-time consommées par Vite (cf. issue #168 / #180).
+        # Lues depuis .env via `--env-file .env` côté deploy.sh.
+        VITE_PROXY_URL: ${VITE_PROXY_URL:-}
+        VITE_PROXY_URL_EMBED: ${VITE_PROXY_URL_EMBED:-}
+        VITE_BEACON_URL: ${VITE_BEACON_URL:-}
+        VITE_LIB_URL: ${VITE_LIB_URL:-}
+        # Hash court du commit (footer) — calculé par deploy.sh (.git hors
+        # contexte Docker).
+        DSFR_DATA_COMMIT: ${DSFR_DATA_COMMIT:-}
+        # Proxy HTTP sortant build-time (npm ci + apk add derrière un proxy).
+        HTTP_PROXY: ${HTTP_PROXY:-}
+        HTTPS_PROXY: ${HTTPS_PROXY:-}
+        NO_PROXY: ${NO_PROXY:-}
+    restart: unless-stopped
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    # Persiste les beacon logs (monitoring) entre redémarrages.
+    volumes:
+      - beacon-logs:/var/log/nginx
+    environment:
+      - GOUV_WIDGETS_MODE=database
+      - JWT_SECRET=${JWT_SECRET}
+      - DB_HOST=mariadb
+      - DB_PORT=3306
+      - DB_NAME=${DB_NAME:-dsfr_data}
+      - DB_USER=${DB_USER:-dsfr_data}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      # URL absolue dans les liens d'emails — dérivée de DOMAIN par deploy.sh.
+      - APP_URL=${APP_URL:-https://localhost}
+      # SMTP : hostname/port fournis par spawn (`--mail dev|real`). Sans
+      # --mail, fallback Mailpit local. SMTP_FROM dérivé du domaine parent.
+      - SMTP_HOST=${MAIL_HOST:-mailer}
+      - SMTP_PORT=${MAIL_PORT:-1025}
+      - SMTP_FROM=${SMTP_FROM:-noreply@localhost}
+      # Derrière le reverse proxy de la plateforme (Traefik) : 1 hop.
+      - TRUST_PROXY=${TRUST_PROXY:-1}
+      - REQUIRE_EMAIL_VERIFICATION=${REQUIRE_EMAIL_VERIFICATION:-}
+      - CORS_ORIGIN=${CORS_ORIGIN:-}
+      - CORS_ALLOW_SUBDOMAINS_OF=${CORS_ALLOW_SUBDOMAINS_OF:-}
+      # Bootstrap admin temporaire (vides → inactif).
+      - SEED_ADMIN_EMAIL=${SEED_ADMIN_EMAIL:-}
+      - SEED_ADMIN_PASSWORD=${SEED_ADMIN_PASSWORD:-}
+      # Proxy IA Albert par défaut (token reste côté serveur).
+      - IA_DEFAULT_TOKEN=${IA_DEFAULT_TOKEN:-}
+      - IA_DEFAULT_API_URL=${IA_DEFAULT_API_URL:-https://albert.api.etalab.gouv.fr/v1/chat/completions}
+      - IA_DEFAULT_MODEL=${IA_DEFAULT_MODEL:-openweight-large}
+      # Proxy HTTP sortant runtime (ia-default-server + mcp-server).
+      - HTTP_PROXY=${HTTP_PROXY:-}
+      - HTTPS_PROXY=${HTTPS_PROXY:-}
+      - NO_PROXY=${NO_PROXY:-}
+    networks:
+      - internal
+      - proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=proxy"
+      - "traefik.http.routers.${APP_NAME:-chartsbuilder}.rule=Host(`${DOMAIN:-chartsbuilder.localhost}`)"
+      - "traefik.http.routers.${APP_NAME:-chartsbuilder}.entrypoints=websecure"
+      - "traefik.http.routers.${APP_NAME:-chartsbuilder}.tls=true"
+      - "traefik.http.routers.${APP_NAME:-chartsbuilder}.tls.certresolver=letsencrypt"
+      # nginx non-root écoute sur 8080 (cf. docker/Dockerfile.db, finding #66).
+      - "traefik.http.services.${APP_NAME:-chartsbuilder}.loadbalancer.server.port=8080"
+
+  mariadb:
+    image: mariadb:11
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME:-dsfr_data}
+      MYSQL_USER: ${DB_USER:-dsfr_data}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # MariaDB n'est jamais exposée : réseau interne uniquement.
+    networks:
+      - internal
+
+volumes:
+  beacon-logs:
+  mariadb-data:
+
+networks:
+  # Réseau privé app ↔ base.
+  internal:
+  # Réseau d'entrée HTTP fourni par la plateforme hôte (Traefik), externe.
+  proxy:
+    external: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,3 +1,66 @@
-#!/bin/bash
-# Wrapper — redirige vers docker/deploy.sh
-exec "$(dirname "$0")/docker/deploy.sh" "$@"
+#!/usr/bin/env bash
+# Déploiement agnostique — mode SERVEUR/DB (nginx + Express + MariaDB, auth JWT,
+# données chiffrées). C'est le mode de CE projet (équivalent agnostique de
+# docker/deploy-server.sh, mais sans réseau/domaine/hébergeur codé en dur, et
+# sans réutilisation des volumes de l'ancien nom de projet).
+#
+# Lancé par l'orchestrateur `spawn`, qui exporte avant l'appel :
+#   APP_NAME, DOMAIN        → routage Traefik (labels du compose.yml)
+#   MAIL_HOST, MAIL_PORT    → SMTP (si déployé avec --mail dev|real)
+#   COMPOSE_FILE            → compose.yml [+ .spawn-override.yml réseau mail]
+#
+# Idempotent : les secrets persistants ne sont générés qu'une seule fois.
+#
+# Pour le déploiement legacy local (ancien `ecosystem-network`, dual-mode
+# statique/serveur, réutilisation des volumes historiques via
+# COMPOSE_PROJECT_NAME), utiliser docker/deploy.sh ou docker/deploy-server.sh.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+
+APP_NAME="${APP_NAME:-chartsbuilder}"
+DOMAIN="${DOMAIN:-chartsbuilder.localhost}"
+# Domaine parent (chartsbuilder.miweb.run → miweb.run) pour l'adresse From
+# d'envoi, alignée sur la signature DKIM du smarthost (cf. ADR-039).
+PARENT_DOMAIN="${DOMAIN#*.}"
+export COMPOSE_FILE="${COMPOSE_FILE:-compose.yml}"
+
+# --- .env : secrets persistants + variables dérivées du domaine ------------
+# Générés une seule fois. NE JAMAIS les régénérer en place : JWT_SECRET
+# invalide les sessions, ENCRYPTION_KEY rend les clés API stockées illisibles.
+[ -f .env ] || : > .env
+ensure() { # $1=clé $2=valeur — n'écrit que si la clé est absente
+  if ! grep -qE "^$1=" .env; then
+    printf '%s=%s\n' "$1" "$2" >> .env
+    echo -e "  ${GREEN}+ $1${NC}"
+  fi
+}
+echo -e "${YELLOW}Secrets & config (.env)${NC}"
+ensure JWT_SECRET       "$(openssl rand -hex 32)"
+ensure DB_PASSWORD      "$(openssl rand -hex 16)"
+ensure DB_ROOT_PASSWORD "$(openssl rand -hex 16)"
+ensure ENCRYPTION_KEY   "$(openssl rand -hex 32)"
+# Dérivées du domaine fourni par le contrat (build-time + runtime).
+ensure VITE_PROXY_URL   "https://${DOMAIN}"
+ensure APP_URL          "https://${DOMAIN}"
+ensure SMTP_FROM        "noreply@${PARENT_DOMAIN}"
+ensure TRUST_PROXY      "1"
+
+# Hash du commit déployé (footer). .git exclu du contexte Docker → passé en
+# build-arg via le compose.
+export DSFR_DATA_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo '')"
+
+COMPOSE="docker compose -p ${APP_NAME} --env-file .env"
+
+echo -e "${YELLOW}Build${NC} — app=${APP_NAME} domain=${DOMAIN} (${COMPOSE_FILE})"
+$COMPOSE build
+
+echo -e "${YELLOW}Up${NC}"
+$COMPOSE up -d
+
+echo ""
+$COMPOSE ps
+echo ""
+echo -e "${GREEN}Déploiement serveur terminé : https://${DOMAIN}${NC}"
+echo "Le premier compte inscrit reçoit le rôle admin."


### PR DESCRIPTION
## Contexte

Migration de `chartsbuilder.matge.com` (ancien VPS, `ecosystem-network`) vers la plateforme **VibeLab** → `https://chartsbuilder.miweb.run`. Conforme au contrat `spawn` (cf. ADR-038).

## Changements

Couche de déploiement **agnostique additive** à la racine, sans toucher aux scripts `docker/` legacy :

- **`compose.yml`** — stack mode DB (`web` nginx+Express+MariaDB + `mariadb`) :
  - service applicatif nommé `web` (requis pour l'override réseau mail de `spawn --mail`)
  - réseau `proxy` externe + `traefik.docker.network=proxy`
  - labels Traefik en `${APP_NAME}` / `${DOMAIN}`, `certresolver=letsencrypt`, port `8080`
  - aucun domaine / hébergeur / `container_name` codé en dur
  - MariaDB sur réseau `internal` uniquement
- **`deploy.sh`** (remplace le wrapper statique) — équivalent agnostique de `docker/deploy-server.sh` :
  - génère les secrets (`JWT_SECRET`, `DB_*`, `ENCRYPTION_KEY`) **une seule fois**
  - dérive `VITE_PROXY_URL` / `APP_URL` / `SMTP_FROM` du `DOMAIN` fourni par l'orchestrateur
  - build + up sous `-p ${APP_NAME}` — **pas** de réutilisation des volumes de l'ancien nom de projet
- **`.dockerignore`** — exclut les fichiers de déploiement du contexte de build
- **Docs** — section déploiement du `CLAUDE.md` (mode agnostique canonique + legacy) et note dans `.env.example`

## Déploiement

```bash
ssh vps "spawn up chartsbuilder git@github.com:bmatge/dsfr-data.git --dns api --mail real --keep"
```

DB **vierge** : 1er compte inscrit = admin. La migration best-effort des comptes depuis l'ancienne prod est une passe séparée (phase 2).

## Validation

- `docker compose config` OK (sans override, et avec l'override mail `--mail real` simulé : `web` rejoint le réseau `mail`, `SMTP_HOST=smtp-relay:25`).
- Les scripts `docker/deploy*.sh` + `docker/docker-compose*.yml` restent inchangés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)