### PR TITLE
chore(security): bump undici + nodemailer — répare la gate npm audit HIGH

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1100,9 +1100,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
-      "integrity": "sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6552,9 +6552,9 @@
       }
     },
     "node_modules/jsdom/node_modules/undici": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.0.tgz",
-      "integrity": "sha512-+t2Z/GwkZQDtu00813aP66ygViGtPHKhhoFZpQKpKrE+9jIgES+Zw+mFNaDWOVRKiuJjuqKHzD3B1sfGg8+ZOQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7865,6 +7865,15 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -10330,7 +10339,7 @@
         "helmet": "^8.2.0",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.22.5",
-        "nodemailer": "^9.0.0",
+        "nodemailer": "^9.0.1",
         "uuid": "^14.0.0"
       },
       "devDependencies": {
@@ -10576,15 +10585,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "server/node_modules/nodemailer": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.0.tgz",
-      "integrity": "sha512-tbPTid7d/p9jAA8CRZ3iomvrMaST0o6NYuY7v6JQZHpPRZ61mLFSPKYd7342NtOFuej9/+L48SOIxwfu2uDvtw==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "server/node_modules/raw-body": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,11 @@
     "form-data": "4.0.6",
     "@web/dev-server-core": {
       "ws": "^7.5.11"
-    }
+    },
+    "jsdom": {
+      "undici": "7.28.0"
+    },
+    "nodemailer": "9.0.1"
   },
   "prettier": {
     "singleQuote": true,

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "helmet": "^8.2.0",
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.22.5",
-    "nodemailer": "^9.0.0",
+    "nodemailer": "^9.0.1",
     "uuid": "^14.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Pourquoi

Depuis le **16 juin**, deux advisories **HIGH** ont été publiées et font échouer `npm audit --audit-level=high` — donc **toutes les branches** (PR Dependabot, features, et `main` lui-même si re-testé). La gate lit la base d'advisories **en direct** : le même code passe de vert à rouge sans qu'on ait rien changé.

- **undici** `7.0.0–7.27.2` (HIGH) — TLS bypass, cache poisoning, header injection, etc.
- **nodemailer** `<=9.0.0` (HIGH, [GHSA-p6gq-j5cr-w38f](https://github.com/advisories/GHSA-p6gq-j5cr-w38f)) — option `raw` → arbitrary file read / SSRF.

C'est ce qui rend rouge la CI de #342 (KPI) et de toute autre PR — **rien à voir avec leur code**.

## Correctifs

Même pattern que #336 (force les versions patchées via `overrides`), **plages semver respectées, zéro bump majeur** :

| Dép | Avant | Après | Mécanisme |
|---|---|---|---|
| undici (jsdom, devDep test) | 7.27.0 | 7.28.0 | override `jsdom › undici` |
| undici (mcp-server) | 7.26.0 | 7.28.0 | déjà dans `^7.25.0` |
| nodemailer (server) | 9.0.0 | 9.0.1 | override + range `^9.0.1` |

- Le `undici@8.5.0` **direct** (scripts) n'est pas dans la plage vulnérable → non touché (override scopé sous jsdom).
- L'override `nodemailer` est nécessaire : le résolveur npm local résout `9.0.1 → 9.0.0` sans (le lockfile committé porte bien 9.0.1).

## Vérifications

- `npm audit --audit-level=high` = **0** au root **et** mcp-server.
- Suite de tests **3438/3438** verte (les deps de test jsdom→undici ne régressent pas).
- Aucune API touchée.

> Une fois mergée, je rebase `feat/kpi-trend` (#342) sur `main` → sa CI repasse au vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)