### PR TITLE
chore(ci): étend check:accents (specs/guide + .ts) + ré-accentue les specs

### DIFF
--- a/scripts/check-french-accents.sh
+++ b/scripts/check-french-accents.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env bash
 # Warn (NON-BLOCKING) about French UI labels written without accents.
 #
-# Scope volontairement réduit (cf. décision 2026-05-30) : UNIQUEMENT le contenu
-# textuel des balises HTML (apps/**/*.html, packages/**/*.html). Sont ignorés :
-#  - les fichiers .ts / .css / .md (commentaires de code, prompts, styles…),
-#  - les attributs HTML (placeholder=…, title=…) et les commentaires <!-- … -->.
-# Avant, le script grepait tout le contenu de tous les fichiers et bloquait la CI
-# sur des commentaires de code — friction inutile. Il ne vise désormais que le
-# texte réellement visible dans le HTML statique, et n'échoue JAMAIS (exit 0).
+# Principe (cf. décision 2026-05-30, élargie 2026-06-19) : on ne regarde QUE le
+# CONTENU TEXTUEL DES BALISES HTML, c.-à-d. ce qui est strictement entre un
+# « > » et un « < ». Ce filtre exclut mécaniquement tout le reste :
+#  - le code (corps de fonctions, identifiants, imports…),
+#  - les ATTRIBUTS HTML (entre « < » et « > » : placeholder=…, label=…, href=…),
+#  - les URLs (dans des attributs, ou sans « >…< » autour),
+#  - les commentaires <!-- … --> (commencent par « < »).
+# Grâce à ce filtre, on peut élargir le périmètre AUX FICHIERS .ts qui embarquent
+# des templates HTML (skills, exemples, générateurs, composants Lit) sans jamais
+# toucher au code : seul le texte des balises est inspecté.
+#
+# Périmètre des fichiers scannés :
+#  - HTML : apps/, packages/, specs/, guide/  (**/*.html)
+#  - TS   : apps/, packages/                  (**/*.ts — templates HTML embarqués)
+#  Exclus : dist/, node_modules/, *.min.*, et tests/ (hors apps|packages).
+#
+# Le script n'échoue JAMAIS (exit 0) : c'est un avertissement, pas une barrière.
 #
 # Each pattern is a French word that has NO valid English / identifier meaning
 # without its accent.
@@ -65,28 +75,29 @@ PATTERNS=(
   verifie verifier Verifier verifiez Verifiez
 )
 
-PATHS=(apps packages)
-
-# Build a single ERE alternation: \b(word1|word2|…)\b
+# Build a single ERE alternation: (word1|word2|…) — word boundaries via -w.
 # IFS is scoped to the subshell, no leak to the parent shell.
 # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering
 joined=$(IFS='|'; echo "${PATTERNS[*]}")
 
-# 1. git grep (honore .gitignore) sur les SEULS fichiers HTML.
+# 1. Pré-filtre git grep (honore .gitignore) : HTML (apps/packages/specs/guide)
+#    + TS (apps/packages), qui embarquent des templates HTML.
 raw=$(git grep -nwE "(${joined})" -- \
-      "apps/**/*.html" "packages/**/*.html" \
+      "apps/**/*.html" "packages/**/*.html" "specs/**/*.html" "guide/**/*.html" \
+      "apps/**/*.ts" "packages/**/*.ts" \
       ':!**/dist/**' ':!**/node_modules/**' ':!**/*.min.*' 2>/dev/null || true)
 
-# 2. Ne garder que les hits dont le mot survit au retrait des balises <…> et des
-#    commentaires <!-- … --> : ce qui reste est le TEXTE entre balises (le
-#    "contenu"). Les attributs et commentaires sont donc exclus.
+# 2. Ne garder que les hits où le mot apparaît dans le CONTENU D'UNE BALISE,
+#    c.-à-d. dans un segment « >…< ». Tout le reste — code, attributs (entre
+#    « < » et « > »), URLs, commentaires (« <!-- ») — n'a pas cette forme et est
+#    donc exclu. Robuste pour le HTML pur ET le HTML embarqué dans du .ts.
 matches=""
 if [ -n "$raw" ]; then
   while IFS= read -r line; do
     [ -z "$line" ] && continue
     content=${line#*:*:}                                  # file:line:CONTENU
-    stripped=$(printf '%s' "$content" | sed -E 's/<!--.*-->//g; s/<[^>]*>//g')
-    if printf '%s' "$stripped" | grep -qwE "(${joined})"; then
+    tagtext=$(printf '%s' "$content" | grep -oE '>[^<>]+<' || true)
+    if [ -n "$tagtext" ] && printf '%s' "$tagtext" | grep -qwE "(${joined})"; then
       matches="${matches}${line}"$'\n'
     fi
   done <<EOF

--- a/specs/apis/generic.html
+++ b/specs/apis/generic.html
@@ -32,9 +32,9 @@
         <div class="fr-callout fr-callout--orange-terre-battue">
           <h4 class="fr-callout__title">Tout cote client</h4>
           <p class="fr-callout__text">
-            Le mode generique ne connait pas la structure de l'API cible. Il recupere les donnees
+            Le mode generique ne connait pas la structure de l'API cible. Il recupere les données
             via <code>dsfr-data-source</code> et <strong>toutes les transformations</strong> (tri, filtrage,
-            agregation, facettes, recherche) sont effectuees cote client par <code>dsfr-data-query</code>.
+            agrégation, facettes, recherche) sont effectuees cote client par <code>dsfr-data-query</code>.
           </p>
         </div>
 
@@ -77,9 +77,9 @@
                   <td>Tri effectue cote client</td>
                 </tr>
                 <tr>
-                  <td>Agregation serveur</td>
+                  <td>Agrégation serveur</td>
                   <td class="capability-no">Non</td>
-                  <td>Agregation effectuee cote client</td>
+                  <td>Agrégation effectuee cote client</td>
                 </tr>
               </tbody>
             </table>
@@ -91,7 +91,7 @@
           <h2>Pagination</h2>
           <p>
             <strong>Aucune pagination automatique.</strong> dsfr-data recupere l'URL telle quelle et
-            traite la reponse JSON comme un tableau de donnees. Si votre API utilise de la pagination,
+            traite la reponse JSON comme un tableau de données. Si votre API utilise de la pagination,
             vous devez la gerer manuellement dans l'URL ou utiliser un des fournisseurs specialises.
           </p>
         </section>
@@ -105,9 +105,9 @@
                 <tr><th>Parametre</th><th>Valeur</th></tr>
               </thead>
               <tbody>
-                <tr><td>Chemin des donnees</td><td>(racine du JSON)</td></tr>
+                <tr><td>Chemin des données</td><td>(racine du JSON)</td></tr>
                 <tr><td>Chemin du total</td><td>Non disponible</td></tr>
-                <tr><td>Donnees imbriquees</td><td>Non</td></tr>
+                <tr><td>Données imbriquees</td><td>Non</td></tr>
                 <tr><td>Necessite flatten</td><td>Non</td></tr>
               </tbody>
             </table>
@@ -116,16 +116,16 @@
             <p>
               La reponse JSON doit etre un tableau d'objets a la racine, ou vous pouvez utiliser
               l'attribut <code>data-path</code> sur <code>dsfr-data-source</code> pour specifier le
-              chemin vers le tableau de donnees dans la reponse.
+              chemin vers le tableau de données dans la reponse.
             </p>
           </div>
         </section>
 
         <!-- Syntaxe de requete -->
         <section class="fr-mt-4w">
-          <h2>Syntaxe de requete</h2>
+          <h2>Syntaxe de requête</h2>
           <p>
-            Le mode generique n'envoie aucun parametre de requete a l'API. Toutes les
+            Le mode generique n'envoie aucun parametre de requête a l'API. Toutes les
             transformations sont effectuees <strong>cote client</strong> par <code>dsfr-data-query</code>
             avec la syntaxe colon generique (<code>field:operator:value</code>).
           </p>
@@ -140,7 +140,7 @@
                 <tr><th>Parametre</th><th>Valeur</th></tr>
               </thead>
               <tbody>
-                <tr><td>Mode par defaut</td><td><strong>client</strong></td></tr>
+                <tr><td>Mode par défaut</td><td><strong>client</strong></td></tr>
                 <tr><td>Endpoint serveur</td><td>Non disponible</td></tr>
               </tbody>
             </table>
@@ -152,7 +152,7 @@
           <h2>Authentification</h2>
           <p>
             Type : <strong>aucune</strong>. Le mode generique ne gere pas l'authentification
-            automatiquement. Si votre API necessite une cle, passez-la directement dans l'URL
+            automatiquement. Si votre API necessite une clé, passez-la directement dans l'URL
             ou configurez un proxy.
           </p>
         </section>
@@ -161,7 +161,7 @@
         <section class="fr-mt-4w">
           <h2>Detection automatique</h2>
           <p>
-            Le mode generique est le <strong>fallback</strong> : il est selectionne automatiquement
+            Le mode generique est le <strong>fallback</strong> : il est sélectionne automatiquement
             quand l'URL ne correspond a aucun des autres fournisseurs (OpenDataSoft, Tabular, Grist).
           </p>
         </section>
@@ -179,11 +179,11 @@
 &lt;dsfr-data-chart
   source="src"
   type="bar"
-  name-field="categorie"
+  name-field="catégorie"
   value-field="valeur"&gt;
 &lt;/dsfr-data-chart&gt;</code></pre>
 
-          <h3 class="fr-mt-2w">API avec chemin de donnees</h3>
+          <h3 class="fr-mt-2w">API avec chemin de données</h3>
           <pre><code>&lt;!-- Si la reponse JSON est { "results": { "items": [...] } } --&gt;
 &lt;dsfr-data-source
   id="src"
@@ -204,7 +204,7 @@
   value-field="montant"&gt;
 &lt;/dsfr-data-chart&gt;</code></pre>
 
-          <h3 class="fr-mt-2w">Avec normalize pour des donnees imbriquees</h3>
+          <h3 class="fr-mt-2w">Avec normalize pour des données imbriquees</h3>
           <pre><code>&lt;dsfr-data-source
   id="src"
   url="https://mon-api.example.com/nested-data.json"&gt;

--- a/specs/apis/grist.html
+++ b/specs/apis/grist.html
@@ -26,7 +26,7 @@
     <div slot="content">
         <p class="fr-text--lead">
           API <strong>Grist</strong>, tableur collaboratif open source. Supporte
-          <a href="https://grist.numerique.gouv.fr" target="_blank" rel="noopener">grist.numerique.gouv.fr</a>
+          <a href="https://grist.numerique.gouv.fr" target="_blank" rel="noopener">grist.numérique.gouv.fr</a>
           (instance souveraine) et <a href="https://docs.getgrist.com" target="_blank" rel="noopener">docs.getgrist.com</a>.
         </p>
 
@@ -35,7 +35,7 @@
           <p class="fr-callout__text">
             L'adapter Grist choisit automatiquement entre deux modes :
             <strong>mode Records</strong> (GET /records) pour le filtrage par egalite, le tri et la pagination,
-            et <strong>mode SQL</strong> (POST /sql) pour le group-by, l'agregation, les facettes et
+            et <strong>mode SQL</strong> (POST /sql) pour le group-by, l'agrégation, les facettes et
             les operateurs avances (LIKE, comparaisons). Le fallback vers le mode Records + client-side
             est automatique si le endpoint SQL n'est pas disponible.
           </p>
@@ -68,7 +68,7 @@
                   <td>Fetch serveur</td>
                   <td class="capability-yes">Oui</td>
                   <td>Records</td>
-                  <td>Recuperation paginee des donnees</td>
+                  <td>Recuperation paginee des données</td>
                 </tr>
                 <tr>
                   <td>Tri serveur</td>
@@ -86,7 +86,7 @@
                   <td>Filtrage avance (gt, lt, LIKE...)</td>
                   <td class="capability-yes">Oui</td>
                   <td>SQL</td>
-                  <td>Requete SQL parametree avec placeholders <code>?</code></td>
+                  <td>Requête SQL parametree avec placeholders <code>?</code></td>
                 </tr>
                 <tr>
                   <td>Facettes serveur</td>
@@ -101,7 +101,7 @@
                   <td>Clause <code>GROUP BY</code> SQLite</td>
                 </tr>
                 <tr>
-                  <td>Agregation serveur</td>
+                  <td>Agrégation serveur</td>
                   <td class="capability-yes">Oui</td>
                   <td>SQL</td>
                   <td>Fonctions <code>SUM</code>, <code>AVG</code>, <code>COUNT</code>, <code>MIN</code>, <code>MAX</code></td>
@@ -127,7 +127,7 @@
               </thead>
               <tbody>
                 <tr><td>Type</td><td><code>offset</code></td></tr>
-                <tr><td>Taille de page</td><td>100 enregistrements (par defaut)</td></tr>
+                <tr><td>Taille de page</td><td>100 enregistrements (par défaut)</td></tr>
                 <tr><td>Parametres URL</td><td><code>limit</code>, <code>offset</code></td></tr>
               </tbody>
             </table>
@@ -158,7 +158,7 @@
           <h3 class="fr-mt-2w">Mode SQL (POST /sql)</h3>
           <p>
             Active automatiquement quand les capacites de l'endpoint Records sont insuffisantes
-            (group-by, agregation, operateurs avances comme <code>contains</code>, <code>gt</code>, <code>lt</code>).
+            (group-by, agrégation, operateurs avances comme <code>contains</code>, <code>gt</code>, <code>lt</code>).
           </p>
           <pre><code>POST /api/docs/{docId}/sql
 {
@@ -174,7 +174,7 @@
 
           <div class="fr-highlight fr-mt-2w">
             <p>
-              <strong>Securite :</strong> toutes les valeurs sont passees via des placeholders <code>?</code> (requetes parametrees).
+              <strong>Securite :</strong> toutes les valeurs sont passees via des placeholders <code>?</code> (requêtes parametrees).
               Les noms de colonnes et tables sont echappes avec des guillemets doubles (standard SQLite).
             </p>
           </div>
@@ -183,7 +183,7 @@
           <p>
             Si le endpoint SQL n'est pas disponible (ancienne version de Grist, restrictions admin),
             l'adapter retombe en mode Records + traitement client-side. La disponibilite est cachee
-            par hostname pour eviter des requetes inutiles.
+            par hostname pour eviter des requêtes inutiles.
           </p>
         </section>
 
@@ -196,9 +196,9 @@
                 <tr><th>Parametre</th><th>Valeur</th></tr>
               </thead>
               <tbody>
-                <tr><td>Chemin des donnees</td><td><code>records</code></td></tr>
+                <tr><td>Chemin des données</td><td><code>records</code></td></tr>
                 <tr><td>Chemin du total</td><td>Non disponible</td></tr>
-                <tr><td>Donnees imbriquees</td><td>Oui (<code>fields</code>)</td></tr>
+                <tr><td>Données imbriquees</td><td>Oui (<code>fields</code>)</td></tr>
                 <tr><td>Aplatissement</td><td><strong>Automatique</strong> (par l'adapter, sans dsfr-data-normalize)</td></tr>
               </tbody>
             </table>
@@ -237,7 +237,7 @@
 
         <!-- Syntaxe de requete -->
         <section class="fr-mt-4w">
-          <h2>Syntaxe de requete</h2>
+          <h2>Syntaxe de requête</h2>
           <p>
             L'adapter Grist utilise la syntaxe colon generique (<code>champ:operateur:valeur</code>)
             et la convertit automatiquement :
@@ -266,7 +266,7 @@
           </div>
           <p class="fr-mt-1w">
             Separateur WHERE : <code>, </code> (virgule + espace).
-            Agregation : syntaxe <code>sql</code> (traduite en SQLite natif).
+            Agrégation : syntaxe <code>sql</code> (traduite en SQLite natif).
           </p>
         </section>
 
@@ -279,14 +279,14 @@
                 <tr><th>Parametre</th><th>Valeur</th></tr>
               </thead>
               <tbody>
-                <tr><td>Mode par defaut</td><td><strong>server</strong></td></tr>
-                <tr><td>Methode</td><td>SQL <code>GROUP BY</code> + <code>COUNT(*)</code></td></tr>
+                <tr><td>Mode par défaut</td><td><strong>server</strong></td></tr>
+                <tr><td>Méthode</td><td>SQL <code>GROUP BY</code> + <code>COUNT(*)</code></td></tr>
                 <tr><td>Limite par champ</td><td>200 valeurs distinctes</td></tr>
               </tbody>
             </table>
           </div>
           <p class="fr-mt-1w">
-            Les facettes sont calculees cote serveur via des requetes SQL.
+            Les facettes sont calculees cote serveur via des requêtes SQL.
             Si le endpoint SQL n'est pas disponible, les facettes sont calculees cote client.
           </p>
         </section>
@@ -295,12 +295,12 @@
         <section class="fr-mt-4w">
           <h2>Introspection</h2>
           <p>
-            L'adapter expose des methodes d'introspection du schema Grist :
+            L'adapter expose des méthodes d'introspection du schema Grist :
           </p>
           <div class="fr-table">
             <table>
               <thead>
-                <tr><th>Methode</th><th>Endpoint</th><th>Description</th></tr>
+                <tr><th>Méthode</th><th>Endpoint</th><th>Description</th></tr>
               </thead>
               <tbody>
                 <tr>
@@ -333,7 +333,7 @@
         <section class="fr-mt-4w">
           <h2>Detection automatique</h2>
           <p>
-            dsfr-data detecte automatiquement une source Grist si l'URL contient :
+            dsfr-data détecté automatiquement une source Grist si l'URL contient :
           </p>
           <ul>
             <li><code>/api/docs/{documentId}/tables/{tableId}</code></li>
@@ -346,7 +346,7 @@
                 <tr><th>Hostname</th><th>Endpoint proxy</th></tr>
               </thead>
               <tbody>
-                <tr><td><code>grist.numerique.gouv.fr</code></td><td><code>/grist-gouv-proxy</code></td></tr>
+                <tr><td><code>grist.numérique.gouv.fr</code></td><td><code>/grist-gouv-proxy</code></td></tr>
                 <tr><td><code>docs.getgrist.com</code></td><td><code>/grist-proxy</code></td></tr>
               </tbody>
             </table>
@@ -357,7 +357,7 @@
         <section class="fr-mt-4w">
           <h2>Exemples d'utilisation</h2>
 
-          <h3>Graphique avec agregation serveur (SQL)</h3>
+          <h3>Graphique avec agrégation serveur (SQL)</h3>
           <pre><code>&lt;dsfr-data-source id="src" api-type="grist"
   base-url="https://&lt;votre-proxy&gt;/grist-gouv-proxy/api/docs/DOC_ID/tables/Table1/records"
   headers='{"Authorization":"Bearer API_KEY"}'&gt;
@@ -391,8 +391,8 @@
 &lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-facets source="src"
-  fields="categorie,region"
-  labels="categorie:Categorie | region:Region"
+  fields="catégorie,region"
+  labels="catégorie:Catégorie | region:Region"
   server-facets&gt;
 &lt;/dsfr-data-facets&gt;
 
@@ -402,7 +402,7 @@
 &lt;/dsfr-data-search&gt;
 
 &lt;dsfr-data-list source="src"
-  colonnes="nom,categorie,region"
+  colonnes="nom,catégorie,region"
   pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</code></pre>
         </section>

--- a/specs/apis/insee.html
+++ b/specs/apis/insee.html
@@ -26,16 +26,16 @@
     <div slot="content">
         <p class="fr-text--lead">
           API <strong>Melodi</strong> de l'<a href="https://www.insee.fr" target="_blank" rel="noopener">INSEE</a>,
-          donnant acces a plus de 95 jeux de donnees statistiques (population, PIB, emploi, etc.)
-          du <a href="https://catalogue-donnees.insee.fr" target="_blank" rel="noopener">catalogue de donnees de l'INSEE</a>.
+          donnant acces a plus de 95 jeux de données statistiques (population, PIB, emploi, etc.)
+          du <a href="https://catalogue-donnees.insee.fr" target="_blank" rel="noopener">catalogue de données de l'INSEE</a>.
         </p>
 
         <div class="fr-callout fr-callout--brown-caramel">
-          <h4 class="fr-callout__title">Donnees statistiques dimensionnelles</h4>
+          <h4 class="fr-callout__title">Données statistiques dimensionnelles</h4>
           <p class="fr-callout__text">
             L'API Melodi utilise un modele <strong>dimensionnel</strong> : chaque observation est decrite par
             des dimensions (GEO, TIME_PERIOD, FREQ...), une mesure (OBS_VALUE) et des attributs optionnels.
-            Le filtrage se fait par <strong>egalite sur les dimensions</strong> via des parametres de requete.
+            Le filtrage se fait par <strong>egalite sur les dimensions</strong> via des parametres de requête.
             L'adapter aplatit automatiquement les observations en objets plats exploitables par les composants dsfr-data.
           </p>
         </div>
@@ -44,7 +44,7 @@
           <h4 class="fr-callout__title">CORS actif, pas de proxy</h4>
           <p class="fr-callout__text">
             L'API INSEE supporte nativement CORS. Aucun proxy n'est necessaire.
-            Acces anonyme, limite a <strong>30 requetes par minute</strong>.
+            Acces anonyme, limite a <strong>30 requêtes par minute</strong>.
           </p>
         </div>
 
@@ -79,7 +79,7 @@
                 <tr>
                   <td>Group-by serveur</td>
                   <td class="capability-no">Non</td>
-                  <td>Agregation effectuee cote client via dsfr-data-query</td>
+                  <td>Agrégation effectuee cote client via dsfr-data-query</td>
                 </tr>
                 <tr>
                   <td>Tri serveur</td>
@@ -87,9 +87,9 @@
                   <td>Tri effectue cote client via dsfr-data-query</td>
                 </tr>
                 <tr>
-                  <td>Agregation serveur</td>
+                  <td>Agrégation serveur</td>
                   <td class="capability-no">Non</td>
-                  <td>Agregation effectuee cote client via dsfr-data-query</td>
+                  <td>Agrégation effectuee cote client via dsfr-data-query</td>
                 </tr>
               </tbody>
             </table>
@@ -121,8 +121,8 @@
         <section class="fr-mt-4w">
           <h2>Filtrage par dimensions</h2>
           <p>
-            L'API Melodi filtre par <strong>egalite sur les dimensions</strong> via des parametres de requete.
-            Chaque jeu de donnees a ses propres dimensions (GEO, TIME_PERIOD, FREQ, etc.).
+            L'API Melodi filtre par <strong>egalite sur les dimensions</strong> via des parametres de requête.
+            Chaque jeu de données a ses propres dimensions (GEO, TIME_PERIOD, FREQ, etc.).
           </p>
 
           <h3 class="fr-mt-2w">Syntaxe API native</h3>
@@ -138,7 +138,7 @@
           <div class="fr-table">
             <table>
               <thead>
-                <tr><th>Attribut <code>where</code></th><th>Parametre URL genere</th></tr>
+                <tr><th>Attribut <code>where</code></th><th>Paramètre URL généré</th></tr>
               </thead>
               <tbody>
                 <tr><td><code>TIME_PERIOD:eq:2023</code></td><td><code>?TIME_PERIOD=2023</code></td></tr>
@@ -169,9 +169,9 @@
                 <tr><th>Parametre</th><th>Valeur</th></tr>
               </thead>
               <tbody>
-                <tr><td>Chemin des donnees</td><td><code>observations</code></td></tr>
+                <tr><td>Chemin des données</td><td><code>observations</code></td></tr>
                 <tr><td>Chemin du total</td><td><code>paging.count</code></td></tr>
-                <tr><td>Donnees imbriquees</td><td>Oui : <code>dimensions</code>, <code>measures</code>, <code>attributes</code></td></tr>
+                <tr><td>Données imbriquees</td><td>Oui : <code>dimensions</code>, <code>measures</code>, <code>attributes</code></td></tr>
                 <tr><td>Aplatissement auto</td><td>Oui (par l'adapter, pas besoin de <code>dsfr-data-normalize</code>)</td></tr>
               </tbody>
             </table>
@@ -198,20 +198,20 @@
           <div class="fr-highlight fr-mt-2w">
             <p>
               La mesure <code>OBS_VALUE_NIVEAU</code> est renommee <code>OBS_VALUE</code>
-              (le suffixe <code>_NIVEAU</code> est supprime). D'autres mesures suivent le meme pattern.
+              (le suffixe <code>_NIVEAU</code> est supprime). D'autres mesures suivent le même pattern.
             </p>
           </div>
         </section>
 
         <!-- Catalogue -->
         <section class="fr-mt-4w">
-          <h2>Catalogue des jeux de donnees</h2>
+          <h2>Catalogue des jeux de données</h2>
           <p>
-            L'endpoint <code>/catalog/all</code> liste les 95+ jeux de donnees disponibles.
+            L'endpoint <code>/catalog/all</code> liste les 95+ jeux de données disponibles.
             Chaque entree contient l'identifiant, le titre, la description, le nombre d'observations
             et la liste des dimensions (<code>ordreComposants</code>).
           </p>
-          <h3 class="fr-mt-2w">Jeux de donnees courants</h3>
+          <h3 class="fr-mt-2w">Jeux de données courants</h3>
           <div class="fr-table">
             <table>
               <thead>
@@ -226,7 +226,7 @@
             </table>
           </div>
           <p class="fr-mt-1w">
-            Liste complete : <a href="https://catalogue-donnees.insee.fr" target="_blank" rel="noopener">catalogue-donnees.insee.fr</a>
+            Liste complete : <a href="https://catalogue-donnees.insee.fr" target="_blank" rel="noopener">catalogue-données.insee.fr</a>
           </p>
         </section>
 
@@ -235,7 +235,7 @@
           <h2>Authentification</h2>
           <p>
             Type : <strong>aucune</strong>. L'API Melodi est publique et ne necessite pas d'authentification.
-            Le debit est limite a 30 requetes par minute en mode anonyme.
+            Le debit est limite a 30 requêtes par minute en mode anonyme.
           </p>
         </section>
 
@@ -243,7 +243,7 @@
         <section class="fr-mt-4w">
           <h2>Detection automatique</h2>
           <p>
-            dsfr-data detecte automatiquement une source INSEE si l'URL contient :
+            dsfr-data détecté automatiquement une source INSEE si l'URL contient :
           </p>
           <ul>
             <li><code>melodi/data/{datasetId}</code></li>
@@ -301,7 +301,7 @@
             Les dimensions INSEE utilisent des codes (<code>AGE: "Y30T39"</code>, <code>PCS: "3"</code>).
             L'attribut <code>replace-fields</code> de <code>&lt;dsfr-data-normalize&gt;</code> permet de les
             remplacer par des libelles lisibles, <strong>sans affecter</strong> les autres champs
-            qui pourraient contenir les memes valeurs.
+            qui pourraient contenir les mêmes valeurs.
           </p>
           <pre><code>&lt;dsfr-data-source
   id="raw"

--- a/specs/apis/opendatasoft.html
+++ b/specs/apis/opendatasoft.html
@@ -34,7 +34,7 @@
           <h4 class="fr-callout__title">API la plus riche</h4>
           <p class="fr-callout__text">
             OpenDataSoft supporte <strong>toutes les fonctionnalites serveur</strong> : pagination, facettes,
-            recherche full-text, group-by, tri et agregation. Les requetes utilisent la syntaxe
+            recherche full-text, group-by, tri et agrégation. Les requêtes utilisent la syntaxe
             <strong>ODSQL</strong>, un dialecte SQL simplifie.
           </p>
         </div>
@@ -55,7 +55,7 @@
                 <tr>
                   <td>Fetch serveur</td>
                   <td class="capability-yes">Oui</td>
-                  <td>Recuperation paginee des donnees</td>
+                  <td>Recuperation paginee des données</td>
                 </tr>
                 <tr>
                   <td>Facettes serveur</td>
@@ -78,7 +78,7 @@
                   <td>Clause <code>order_by</code> ODSQL</td>
                 </tr>
                 <tr>
-                  <td>Agregation serveur</td>
+                  <td>Agrégation serveur</td>
                   <td class="capability-yes">Oui</td>
                   <td>Fonctions <code>sum</code>, <code>avg</code>, <code>count</code>, <code>min</code>, <code>max</code> dans <code>select</code></td>
                 </tr>
@@ -107,7 +107,7 @@
           <div class="fr-highlight fr-mt-2w">
             <p>
               La limite de 1 000 enregistrements s'applique a la recuperation client-side via
-              <code>dsfr-data-source</code>. Pour les agregations et group-by, utilisez <code>dsfr-data-query</code>
+              <code>dsfr-data-source</code>. Pour les agrégations et group-by, utilisez <code>dsfr-data-query</code>
               qui delegue le calcul au serveur ODS.
             </p>
           </div>
@@ -115,7 +115,7 @@
 
         <!-- Syntaxe de requete -->
         <section class="fr-mt-4w">
-          <h2>Syntaxe de requete (ODSQL)</h2>
+          <h2>Syntaxe de requête (ODSQL)</h2>
           <p>
             OpenDataSoft utilise <strong>ODSQL</strong>, un dialecte SQL simplifie, pour les clauses
             <code>select</code>, <code>where</code>, <code>group_by</code> et <code>order_by</code>.
@@ -149,13 +149,13 @@
                 <tr><th>Parametre</th><th>Valeur</th></tr>
               </thead>
               <tbody>
-                <tr><td>Mode par defaut</td><td><strong>server</strong></td></tr>
+                <tr><td>Mode par défaut</td><td><strong>server</strong></td></tr>
                 <tr><td>Endpoint</td><td><code>/facets</code> (dedie)</td></tr>
               </tbody>
             </table>
           </div>
           <p class="fr-mt-1w">
-            Les facettes sont calculees cote serveur, ce qui est tres performant meme sur de gros jeux de donnees.
+            Les facettes sont calculees cote serveur, ce qui est tres performant même sur de gros jeux de données.
             Utilisez <code>&lt;dsfr-data-facets server-facets&gt;</code> pour activer ce mode.
           </p>
         </section>
@@ -166,7 +166,7 @@
           <p>
             Type : <strong>API key en header</strong> (<code>apikey-header</code>).<br>
             La plupart des portails ODS publics ne necessitent pas d'authentification.
-            Pour les datasets prives, ajoutez la cle API via le header <code>Authorization</code>.
+            Pour les datasets prives, ajoutez la clé API via le header <code>Authorization</code>.
           </p>
         </section>
 
@@ -179,9 +179,9 @@
                 <tr><th>Parametre</th><th>Valeur</th></tr>
               </thead>
               <tbody>
-                <tr><td>Chemin des donnees</td><td><code>results</code></td></tr>
+                <tr><td>Chemin des données</td><td><code>results</code></td></tr>
                 <tr><td>Chemin du total</td><td><code>total_count</code></td></tr>
-                <tr><td>Donnees imbriquees</td><td>Non (champs a plat)</td></tr>
+                <tr><td>Données imbriquees</td><td>Non (champs a plat)</td></tr>
                 <tr><td>Necessite flatten</td><td>Non</td></tr>
               </tbody>
             </table>
@@ -192,7 +192,7 @@
         <section class="fr-mt-4w">
           <h2>Detection automatique</h2>
           <p>
-            dsfr-data detecte automatiquement une source OpenDataSoft si l'URL contient :
+            dsfr-data détecté automatiquement une source OpenDataSoft si l'URL contient :
           </p>
           <ul>
             <li><code>/api/explore/v2.1/catalog/datasets/{datasetId}</code></li>

--- a/specs/apis/tabular.html
+++ b/specs/apis/tabular.html
@@ -30,10 +30,10 @@
         </p>
 
         <div class="fr-callout fr-callout--green-emeraude">
-          <h4 class="fr-callout__title">Agregation et group-by serveur</h4>
+          <h4 class="fr-callout__title">Agrégation et group-by serveur</h4>
           <p class="fr-callout__text">
             Tabular supporte la <strong>pagination par page</strong> (500 pages de 50, soit 25 000 enregistrements),
-            le <strong>tri serveur</strong>, et surtout le <strong>group-by et l'agregation cote serveur</strong>
+            le <strong>tri serveur</strong>, et surtout le <strong>group-by et l'agrégation cote serveur</strong>
             (<code>sum</code>, <code>avg</code>, <code>count</code>, <code>min</code>, <code>max</code>).
             La recherche full-text et les facettes restent cote client.
           </p>
@@ -55,7 +55,7 @@
                 <tr>
                   <td>Fetch serveur</td>
                   <td class="capability-yes">Oui</td>
-                  <td>Recuperation paginee des donnees</td>
+                  <td>Recuperation paginee des données</td>
                 </tr>
                 <tr>
                   <td>Facettes serveur</td>
@@ -78,7 +78,7 @@
                   <td>Parametre <code>column__sort=asc|desc</code></td>
                 </tr>
                 <tr>
-                  <td>Agregation serveur</td>
+                  <td>Agrégation serveur</td>
                   <td class="capability-yes">Oui</td>
                   <td>Parametres <code>column__sum</code>, <code>__avg</code>, <code>__count</code>, <code>__min</code>, <code>__max</code></td>
                 </tr>
@@ -116,7 +116,7 @@
 
         <!-- Syntaxe de requete -->
         <section class="fr-mt-4w">
-          <h2>Syntaxe de requete</h2>
+          <h2>Syntaxe de requête</h2>
           <p>
             Tabular utilise une syntaxe <strong>colon</strong> (deux-points) pour les filtres :
             <code>field:operator:value</code>.
@@ -148,9 +148,9 @@
           <h3 class="fr-mt-2w">Separateur WHERE</h3>
           <p>Les clauses WHERE multiples sont jointes par <code>, </code> (virgule + espace).</p>
 
-          <h3 class="fr-mt-2w">Agregation serveur</h3>
+          <h3 class="fr-mt-2w">Agrégation serveur</h3>
           <p>
-            L'API supporte l'agregation cote serveur via des parametres URL :
+            L'API supporte l'agrégation cote serveur via des parametres URL :
           </p>
           <div class="fr-table">
             <table>
@@ -170,7 +170,7 @@
           <div class="fr-highlight fr-mt-2w">
             <p>
               Les colonnes de resultat sont nommees <code>column__operator</code> (ex : <code>population__sum</code>).
-              Les filtres sont appliques <strong>avant</strong> l'agregation.
+              Les filtres sont appliques <strong>avant</strong> l'agrégation.
             </p>
           </div>
         </section>
@@ -179,7 +179,7 @@
         <section class="fr-mt-4w">
           <h2>Selection de colonnes</h2>
           <p>
-            L'API supporte la selection de colonnes specifiques via le parametre <code>columns</code> :
+            L'API supporte la selection de colonnes spécifiques via le parametre <code>columns</code> :
           </p>
           <pre><code>?columns=nom,prenom,commune</code></pre>
           <p class="fr-mt-1w">
@@ -196,15 +196,15 @@
                 <tr><th>Parametre</th><th>Valeur</th></tr>
               </thead>
               <tbody>
-                <tr><td>Mode par defaut</td><td><strong>static</strong> (client-side)</td></tr>
+                <tr><td>Mode par défaut</td><td><strong>static</strong> (client-side)</td></tr>
                 <tr><td>Endpoint serveur</td><td>Non disponible</td></tr>
               </tbody>
             </table>
           </div>
           <p class="fr-mt-1w">
-            Les facettes sont calculees sur les donnees deja recuperees cote client.
-            Si le jeu de donnees est volumineux, pensez a utiliser <code>auto-pagination</code>
-            pour charger plus de donnees avant le calcul des facettes.
+            Les facettes sont calculees sur les données deja recuperees cote client.
+            Si le jeu de données est volumineux, pensez a utiliser <code>auto-pagination</code>
+            pour charger plus de données avant le calcul des facettes.
           </p>
         </section>
 
@@ -226,9 +226,9 @@
                 <tr><th>Parametre</th><th>Valeur</th></tr>
               </thead>
               <tbody>
-                <tr><td>Chemin des donnees</td><td><code>data</code></td></tr>
+                <tr><td>Chemin des données</td><td><code>data</code></td></tr>
                 <tr><td>Chemin du total</td><td><code>meta.total</code></td></tr>
-                <tr><td>Donnees imbriquees</td><td>Non (champs a plat)</td></tr>
+                <tr><td>Données imbriquees</td><td>Non (champs a plat)</td></tr>
                 <tr><td>Necessite flatten</td><td>Non</td></tr>
               </tbody>
             </table>
@@ -239,7 +239,7 @@
         <section class="fr-mt-4w">
           <h2>Detection automatique</h2>
           <p>
-            dsfr-data detecte automatiquement une source Tabular si l'URL contient :
+            dsfr-data détecté automatiquement une source Tabular si l'URL contient :
           </p>
           <ul>
             <li><code>tabular-api.data.gouv.fr/api/resources/{resourceId}</code></li>
@@ -253,7 +253,7 @@
         <section class="fr-mt-4w">
           <h2>Exemple d'utilisation</h2>
 
-          <h3>Graphique avec agregation</h3>
+          <h3>Graphique avec agrégation</h3>
           <pre><code>&lt;dsfr-data-source
   id="src"
   api-type="tabular"

--- a/specs/charts/bar-chart.html
+++ b/specs/charts/bar-chart.html
@@ -20,7 +20,7 @@
 
   <app-layout-demo title="Graphique en barres" icon="ri-bar-chart-horizontal-line" active-path="charts/bar-chart" base-path="../">
     <div slot="content">
-      <p class="fr-text--lead">Le composant <code>&lt;bar-chart&gt;</code> permet de comparer des valeurs entre categories.</p>
+      <p class="fr-text--lead">Le composant <code>&lt;bar-chart&gt;</code> permet de comparer des valeurs entre catégories.</p>
 
       <h2>Attributs</h2>
       <table class="attr-table">
@@ -28,7 +28,7 @@
         <tbody>
           <tr><td><code>x</code></td><td>String</td><td>Labels en JSON : <code>'[["A", "B", "C"]]'</code></td></tr>
           <tr><td><code>y</code></td><td>String</td><td>Valeurs en JSON : <code>'[[10, 20, 30]]'</code></td></tr>
-          <tr><td><code>name</code></td><td>String</td><td>Noms des series : <code>'["Serie 1"]'</code></td></tr>
+          <tr><td><code>name</code></td><td>String</td><td>Noms des series : <code>'["Série 1"]'</code></td></tr>
           <tr><td><code>selected-palette</code></td><td>String</td><td>Palette de couleurs</td></tr>
           <tr><td><code>unit-tooltip</code></td><td>String</td><td>Unite dans les tooltips</td></tr>
           <tr><td><code>horizontal</code></td><td>Boolean</td><td>Barres horizontales</td></tr>

--- a/specs/charts/index.html
+++ b/specs/charts/index.html
@@ -26,13 +26,13 @@
       <p class="fr-text--lead">
         Ces graphiques proviennent de la bibliotheque officielle
         <a href="https://gouvernementfr.github.io/dsfr-chart/" target="_blank">DSFR Chart</a>
-        et sont conformes au Design System de l'Etat.
+        et sont conformes au Design System de l'État.
       </p>
 
       <div class="fr-callout fr-my-3w">
         <p class="fr-callout__text">
-          Utilisez ces composants directement avec des donnees statiques, ou via notre wrapper
-          <code>&lt;dsfr-data-chart&gt;</code> pour des donnees dynamiques connectees a une API.
+          Utilisez ces composants directement avec des données statiques, ou via notre wrapper
+          <code>&lt;dsfr-data-chart&gt;</code> pour des données dynamiques connectees a une API.
         </p>
       </div>
 
@@ -48,7 +48,7 @@
 
         <div class="chart-card">
           <h3><span class="ri-bar-chart-horizontal-line" aria-hidden="true"></span> Graphique en barres</h3>
-          <p>Parfait pour comparer des valeurs entre categories.</p>
+          <p>Parfait pour comparer des valeurs entre catégories.</p>
           <bar-chart x='[["Economie", "Education", "Culture", "Sante"]]' y="[[87, 91, 95, 68]]" selected-palette="categorical" unit-tooltip="%"></bar-chart>
           <a class="fr-btn fr-btn--secondary fr-btn--sm fr-mt-2w" href="bar-chart.html">Documentation</a>
         </div>
@@ -83,10 +83,10 @@
       </div>
 
       <h2 class="fr-mt-4w">Palettes de couleurs</h2>
-      <p>DSFR Chart propose plusieurs palettes conformes aux recommandations d'accessibilite :</p>
+      <p>DSFR Chart propose plusieurs palettes conformes aux recommandations d'accessibilité :</p>
       <ul>
-        <li><strong>default</strong> : Bleu France par defaut</li>
-        <li><strong>categorical</strong> : Palette categorielle pour comparer des groupes</li>
+        <li><strong>default</strong> : Bleu France par défaut</li>
+        <li><strong>categorical</strong> : Palette catégorielle pour comparer des groupes</li>
         <li><strong>sequentialAscending / sequentialDescending</strong> : Gradient de couleurs</li>
         <li><strong>divergentAscending / divergentDescending</strong> : Palette divergente</li>
         <li><strong>neutral</strong> : Palette neutre avec mise en avant possible</li>
@@ -96,7 +96,7 @@
       <ul>
         <li><a href="https://gouvernementfr.github.io/dsfr-chart/" target="_blank">Documentation officielle DSFR Chart</a></li>
         <li><a href="https://github.com/GouvernementFR/dsfr-chart" target="_blank">Repository GitHub</a></li>
-        <li><a href="https://www.systeme-de-design.gouv.fr/" target="_blank">Design System de l'Etat</a></li>
+        <li><a href="https://www.systeme-de-design.gouv.fr/" target="_blank">Design System de l'État</a></li>
       </ul>
     </div>
   </app-layout-demo>

--- a/specs/charts/map-chart.html
+++ b/specs/charts/map-chart.html
@@ -20,11 +20,11 @@
 
   <app-layout-demo title="Carte de France" icon="ri-map-line" active-path="charts/map-chart" base-path="../">
     <div slot="content">
-      <p class="fr-text--lead">Les composants <code>&lt;map-chart&gt;</code> et <code>&lt;map-chart-reg&gt;</code> visualisent des donnees geographiques.</p>
+      <p class="fr-text--lead">Les composants <code>&lt;map-chart&gt;</code> et <code>&lt;map-chart-reg&gt;</code> visualisent des données geographiques.</p>
 
       <section class="demo-section">
         <h3>Carte departementale</h3>
-        <p>Le composant <code>&lt;map-chart&gt;</code> affiche une carte de France avec donnees par departement.</p>
+        <p>Le composant <code>&lt;map-chart&gt;</code> affiche une carte de France avec données par departement.</p>
         <map-chart
           data='{"75": 95, "13": 82, "69": 78, "33": 71, "31": 68, "59": 88, "67": 75, "44": 80, "34": 72, "06": 91}'
           date="2024-01-15"
@@ -73,12 +73,12 @@
           <tr>
             <td><code>data</code></td>
             <td>String (JSON)</td>
-            <td>Dictionnaire JSON avec codes departement/region comme cles et valeurs numeriques</td>
+            <td>Dictionnaire JSON avec codes departement/region comme clés et valeurs numériques</td>
           </tr>
           <tr>
             <td><code>date</code></td>
             <td>String</td>
-            <td>Date des donnees au format YYYY-MM-DD</td>
+            <td>Date des données au format YYYY-MM-DD</td>
           </tr>
           <tr>
             <td><code>highlight-index</code></td>

--- a/specs/charts/pie-chart.html
+++ b/specs/charts/pie-chart.html
@@ -38,7 +38,7 @@
       <h2 class="fr-mt-4w">Exemples</h2>
 
       <section class="demo-section">
-        <h3>1. Donut (par defaut)</h3>
+        <h3>1. Donut (par défaut)</h3>
         <pie-chart
           x='[["Actifs", "Inactifs", "En maintenance"]]'
           y="[[75, 15, 10]]"

--- a/specs/charts/radar-chart.html
+++ b/specs/charts/radar-chart.html
@@ -30,7 +30,7 @@
           selected-palette="default">
         </radar-chart>
         <div class="code-block"><pre>&lt;radar-chart
-  x='[["RGAA", "DSFR", "Performance", "Securite", "Accessibilite"]]'
+  x='[["RGAA", "DSFR", "Performance", "Securite", "Accessibilité"]]'
   y="[[85, 90, 75, 95, 88]]"
   selected-palette="default"&gt;
 &lt;/radar-chart&gt;</pre></div>

--- a/specs/components/dsfr-data-a11y.html
+++ b/specs/components/dsfr-data-a11y.html
@@ -30,21 +30,21 @@
     base-path="../">
     <div slot="content">
         <p class="fr-text--lead">
-          Companion d'accessibilite unifie pour les visualisations. Offre trois
-          alternatives activables independamment : <strong>tableau de donnees</strong>,
-          <strong>telechargement CSV</strong> et <strong>description textuelle</strong>.
-          Le contenu est replie dans un accordeon DSFR par defaut.
+          Companion d'accessibilité unifie pour les visualisations. Offre trois
+          alternatives activables independamment : <strong>tableau de données</strong>,
+          <strong>téléchargement CSV</strong> et <strong>description textuelle</strong>.
+          Le contenu est replie dans un accordeon DSFR par défaut.
         </p>
 
         <div class="fr-callout fr-callout--green-emeraude fr-mb-4w">
           <h3 class="fr-callout__title">
             <span class="ri-accessibility-line fr-mr-1w" aria-hidden="true"></span>
-            Accessibilite
+            Accessibilité
           </h3>
           <p class="fr-callout__text">
-            Les graphiques (canvas, SVG) sont difficilement accessibles aux lecteurs d'ecran.
+            Les graphiques (canvas, SVG) sont difficilement accessibles aux lecteurs d'écran.
             <code>dsfr-data-a11y</code> offre trois alternatives complementaires :
-            un tableau HTML, un telechargement CSV et une description textuelle.
+            un tableau HTML, un téléchargement CSV et une description textuelle.
             Via l'attribut <code>for</code>, il injecte un skip link dans le graphique,
             pose <code>aria-describedby</code> et <code>aria-details</code> pour
             creer un lien semantique complet.
@@ -57,9 +57,9 @@
           <tbody>
             <tr><td><code>source</code></td><td>String</td><td>ID du <code>&lt;dsfr-data-source&gt;</code> ou <code>&lt;dsfr-data-query&gt;</code> (requis)</td></tr>
             <tr><td><code>for</code></td><td>String</td><td>ID de l'element cible pour skip link + ARIA automatique</td></tr>
-            <tr><td><code>table</code></td><td>Boolean</td><td>Active l'affichage du tableau de donnees</td></tr>
-            <tr><td><code>download</code></td><td>Boolean</td><td>Active le bouton de telechargement CSV</td></tr>
-            <tr><td><code>filename</code></td><td>String</td><td>Nom du fichier CSV (defaut : <code>donnees.csv</code>)</td></tr>
+            <tr><td><code>table</code></td><td>Boolean</td><td>Active l'affichage du tableau de données</td></tr>
+            <tr><td><code>download</code></td><td>Boolean</td><td>Active le bouton de téléchargement CSV</td></tr>
+            <tr><td><code>filename</code></td><td>String</td><td>Nom du fichier CSV (défaut : <code>données.csv</code>)</td></tr>
             <tr><td><code>description</code></td><td>String</td><td>Description textuelle du graphique</td></tr>
             <tr><td><code>label-field</code></td><td>String</td><td>Colonne pour les labels du tableau (optionnel)</td></tr>
             <tr><td><code>value-field</code></td><td>String</td><td>Colonne(s) pour les valeurs (separees par virgules, optionnel)</td></tr>
@@ -67,21 +67,21 @@
             <tr><td><code>no-auto-aria</code></td><td>Boolean</td><td>Desactive ARIA automatique et skip link</td></tr>
           </tbody>
         </table>
-        <p class="fr-text--sm fr-mt-1w">Si ni <code>table</code>, ni <code>download</code>, ni <code>description</code> ne sont definis, les trois sont actives par defaut.</p>
+        <p class="fr-text--sm fr-mt-1w">Si ni <code>table</code>, ni <code>download</code>, ni <code>description</code> ne sont définis, les trois sont actives par défaut.</p>
 
         <h2 class="fr-mt-4w">Fonctionnement ARIA</h2>
         <ol>
-          <li>Le composant genere automatiquement un <code>id</code> s'il n'en a pas</li>
+          <li>Le composant génère automatiquement un <code>id</code> s'il n'en a pas</li>
           <li>Un <strong>skip link</strong> est injecte dans le graphique cible (visible au focus clavier)</li>
           <li><code>aria-describedby</code> pointe vers un resume concis dans le composant</li>
-          <li><code>aria-details</code> pointe vers le tableau de donnees (si <code>table</code> est active)</li>
+          <li><code>aria-details</code> pointe vers le tableau de données (si <code>table</code> est active)</li>
           <li>A la deconnexion, tout est nettoye automatiquement</li>
         </ol>
 
         <h2 class="fr-mt-4w">Exemples</h2>
 
         <section class="demo-section">
-          <h3>1. Tableau + telechargement CSV</h3>
+          <h3>1. Tableau + téléchargement CSV</h3>
           <dsfr-data-query id="data-chart" source="sites"
             group-by="statut" aggregate="statut:count:total">
           </dsfr-data-query>

--- a/specs/components/dsfr-data-chart.html
+++ b/specs/components/dsfr-data-chart.html
@@ -24,14 +24,14 @@
     <div slot="content">
       <p class="fr-text--lead">
         Wrapper qui connecte les graphiques officiels DSFR Chart au systeme <code>dsfr-data-source</code>
-        pour une alimentation dynamique des donnees.
+        pour une alimentation dynamique des données.
       </p>
 
       <div class="fr-callout fr-callout--green-emeraude">
         <p class="fr-callout__text">
           Ce composant utilise la bibliotheque officielle
           <a href="https://gouvernementfr.github.io/dsfr-chart/" target="_blank">DSFR Chart</a>
-          tout en beneficiant de la connexion automatique aux sources de donnees.
+          tout en beneficiant de la connexion automatique aux sources de données.
         </p>
       </div>
 
@@ -41,8 +41,8 @@
         <tbody>
           <tr><td><code>source</code></td><td>String</td><td>ID du <code>&lt;dsfr-data-source&gt;</code> (requis)</td></tr>
           <tr><td><code>type</code></td><td>String</td><td>Type de chart : <code>bar</code>, <code>line</code>, <code>pie</code>, <code>radar</code>, <code>gauge</code>, <code>scatter</code></td></tr>
-          <tr><td><code>label-field</code></td><td>String</td><td>Chemin vers le champ label dans les donnees</td></tr>
-          <tr><td><code>value-field</code></td><td>String</td><td>Chemin vers le champ valeur dans les donnees</td></tr>
+          <tr><td><code>label-field</code></td><td>String</td><td>Chemin vers le champ label dans les données</td></tr>
+          <tr><td><code>value-field</code></td><td>String</td><td>Chemin vers le champ valeur dans les données</td></tr>
           <tr><td><code>selected-palette</code></td><td>String</td><td>Palette : <code>default</code>, <code>categorical</code>, <code>sequential*</code>, <code>divergent*</code></td></tr>
           <tr><td><code>unit-tooltip</code></td><td>String</td><td>Unite affichee dans les tooltips (%, euro, etc.)</td></tr>
           <tr><td><code>horizontal</code></td><td>Boolean</td><td>Barres horizontales (bar chart)</td></tr>
@@ -51,7 +51,7 @@
           <tr><td><code>code-field</code></td><td>String</td><td>Champ code departement/region (map, map-reg)</td></tr>
           <tr><td><code>map-highlight</code></td><td>String</td><td>Departements/regions a surligner</td></tr>
           <tr><td><code>gauge-value</code></td><td>Number</td><td>Valeur de la jauge 0-100 (type gauge)</td></tr>
-          <tr><td><code>value-field-2</code></td><td>String</td><td>2e serie de valeurs (bar-line)</td></tr>
+          <tr><td><code>value-field-2</code></td><td>String</td><td>2e série de valeurs (bar-line)</td></tr>
           <tr><td><code>value-fields</code></td><td>String</td><td>Series supplementaires separees par virgules</td></tr>
           <tr><td><code>highlight-index</code></td><td>String</td><td>Indices a mettre en avant : <code>"[0, 2]"</code></td></tr>
         </tbody>
@@ -60,17 +60,17 @@
       <h3 class="fr-mt-3w">Attributs DataBox</h3>
       <p>L'attribut <code>databox</code> active l'habillage DataBox DSFR autour du graphique :
         cadre editorial avec titre, source, date, switch chart/tableau integre, screenshot PNG,
-        telechargement CSV, plein ecran, tendance.</p>
+        téléchargement CSV, plein écran, tendance.</p>
       <table class="attr-table">
         <thead><tr><th>Attribut</th><th>Type</th><th>Description</th></tr></thead>
         <tbody>
           <tr><td><code>databox</code></td><td>Boolean</td><td>Active l'habillage DataBox DSFR</td></tr>
           <tr><td><code>databox-title</code></td><td>String</td><td>Titre affiche dans l'en-tete (ex: "Population par region")</td></tr>
-          <tr><td><code>databox-source</code></td><td>String</td><td>Source des donnees (ex: "INSEE, RP 2021")</td></tr>
-          <tr><td><code>databox-date</code></td><td>String</td><td>Date des donnees (ex: "Mars 2024")</td></tr>
-          <tr><td><code>databox-download</code></td><td>Boolean</td><td>Bouton telechargement CSV</td></tr>
+          <tr><td><code>databox-source</code></td><td>String</td><td>Source des données (ex: "INSEE, RP 2021")</td></tr>
+          <tr><td><code>databox-date</code></td><td>String</td><td>Date des données (ex: "Mars 2024")</td></tr>
+          <tr><td><code>databox-download</code></td><td>Boolean</td><td>Bouton téléchargement CSV</td></tr>
           <tr><td><code>databox-screenshot</code></td><td>Boolean</td><td>Bouton screenshot PNG</td></tr>
-          <tr><td><code>databox-fullscreen</code></td><td>Boolean</td><td>Bouton plein ecran</td></tr>
+          <tr><td><code>databox-fullscreen</code></td><td>Boolean</td><td>Bouton plein écran</td></tr>
           <tr><td><code>databox-trend</code></td><td>String</td><td>Tendance (ex: "+5.2" ou "-3.1")</td></tr>
         </tbody>
       </table>
@@ -226,7 +226,7 @@
           </thead>
           <tbody>
             <tr>
-              <td>Donnees dynamiques</td>
+              <td>Données dynamiques</td>
               <td>Oui (via dsfr-data-source)</td>
               <td>Non (statiques)</td>
             </tr>
@@ -236,7 +236,7 @@
               <td>Non</td>
             </tr>
             <tr>
-              <td>Transformation donnees</td>
+              <td>Transformation données</td>
               <td>Automatique</td>
               <td>Manuelle</td>
             </tr>

--- a/specs/components/dsfr-data-context.html
+++ b/specs/components/dsfr-data-context.html
@@ -43,13 +43,13 @@
 
         <h2 class="fr-h4">Pattern</h2>
         <pre class="fr-text--sm" style="background: var(--background-alt-grey); padding: 1rem; border-radius: 4px; overflow-x: auto;"><code>&lt;!-- UI native libre (formulaire DSFR) --&gt;
-&lt;select id="ui-categorie" multiple&gt;...&lt;/select&gt;
+&lt;select id="ui-catégorie" multiple&gt;...&lt;/select&gt;
 &lt;input id="ui-mois" type="month"&gt;
 
 &lt;!-- Le contexte orchestre --&gt;
 &lt;dsfr-data-context sources="src-a src-b src-c" url-sync&gt;
   &lt;dsfr-data-context-filter field="categorie_produit" label="Catégorie"
-    operator="in" ui="ui-categorie"&gt;&lt;/dsfr-data-context-filter&gt;
+    operator="in" ui="ui-catégorie"&gt;&lt;/dsfr-data-context-filter&gt;
   &lt;dsfr-data-context-filter field="date_rappel" label="Mois"
     operator="month-of" ui="ui-mois"&gt;&lt;/dsfr-data-context-filter&gt;
 &lt;/dsfr-data-context&gt;
@@ -65,8 +65,8 @@
             </thead>
             <tbody>
               <tr><td><code>sources</code></td><td>String</td><td>requis</td><td>Ids des sources cibles, separes par des espaces</td></tr>
-              <tr><td><code>url-sync</code></td><td>Boolean</td><td>defaut : off</td><td>Serialisation URL des filtres (lecture au chargement, ecriture replaceState). Opt-in : evite les collisions avec le routing du site hote. Les valeurs lues pre-remplissent les UI — jamais injectees directement dans un where.</td></tr>
-              <tr><td><code>url-param-map</code></td><td>String</td><td><code>"param:field | p2:f2"</code></td><td>Renommage des parametres URL (defaut : le nom du champ)</td></tr>
+              <tr><td><code>url-sync</code></td><td>Boolean</td><td>défaut : off</td><td>Serialisation URL des filtres (lecture au chargement, ecriture replaceState). Opt-in : evite les collisions avec le routing du site hote. Les valeurs lues pre-remplissent les UI — jamais injectees directement dans un where.</td></tr>
+              <tr><td><code>url-param-map</code></td><td>String</td><td><code>"param:field | p2:f2"</code></td><td>Renommage des parametres URL (défaut : le nom du champ)</td></tr>
             </tbody>
           </table>
         </div>
@@ -82,7 +82,7 @@
               <tr><td><code>ui</code></td><td>String</td><td>requis</td><td>Id de l'element d'UI ecoute — DEUX ids (min puis max) pour <code>between</code></td></tr>
               <tr><td><code>operator</code></td><td>String</td><td><code>eq</code></td><td>Voir le tableau des operateurs</td></tr>
               <tr><td><code>apply-to</code></td><td>String</td><td><code>*</code></td><td><code>*</code> = toutes les sources du contexte, ou liste d'ids cibles</td></tr>
-              <tr><td><code>label</code></td><td>String</td><td>defaut : field</td><td>Libelle naturel pour l'affichage (tags)</td></tr>
+              <tr><td><code>label</code></td><td>String</td><td>défaut : field</td><td>Libelle naturel pour l'affichage (tags)</td></tr>
             </tbody>
           </table>
         </div>
@@ -113,7 +113,7 @@
             au <code>whereFormat</code> de chaque adapter cible (ODSQL pour OpenDataSoft, colon
             pour Tabular/Grist). Les bornes dynamiques ne figent jamais de date dans le DOM, et
             l'URL serialise l'<em>intention</em> (« 30 »), pas les dates resolues : un lien
-            partage ne gele pas de vieilles donnees.
+            partage ne gele pas de vieilles données.
           </p>
         </div>
 
@@ -124,7 +124,7 @@
               <tr><th>Attribut</th><th>Type</th><th>Valeurs</th><th>Description</th></tr>
             </thead>
             <tbody>
-              <tr><td><code>for</code></td><td>String</td><td>requis</td><td>Id du dsfr-data-context observe. Rend un tag DSFR supprimable par filtre actif : la croix vide l'UI du filtre (meme chemin qu'un clic utilisateur), sources, URL et tags se mettent a jour ensemble.</td></tr>
+              <tr><td><code>for</code></td><td>String</td><td>requis</td><td>Id du dsfr-data-context observe. Rend un tag DSFR supprimable par filtre actif : la croix vide l'UI du filtre (même chemin qu'un clic utilisateur), sources, URL et tags se mettent a jour ensemble.</td></tr>
             </tbody>
           </table>
         </div>
@@ -132,7 +132,7 @@
         <h2 class="fr-h4">Voir aussi</h2>
         <ul>
           <li><a href="../../guide/guide-exemples-context.html">Guide : dashboard RappelConso filtre</a></li>
-          <li><a href="dsfr-data-facets.html">dsfr-data-facets</a> — facettes calculees depuis les donnees (mono-source)</li>
+          <li><a href="dsfr-data-facets.html">dsfr-data-facets</a> — facettes calculees depuis les données (mono-source)</li>
         </ul>
     </div>
   </app-layout-demo>

--- a/specs/components/dsfr-data-display.html
+++ b/specs/components/dsfr-data-display.html
@@ -29,9 +29,9 @@
     <div slot="content">
         <p class="fr-text--lead">
           Composant d'affichage dynamique qui genere des elements HTML repetitifs (cartes, tuiles, etc.)
-          a partir d'un template et d'une source de donnees.
+          a partir d'un template et d'une source de données.
           Se connecte a un <code>&lt;dsfr-data-source&gt;</code>, <code>&lt;dsfr-data-query&gt;</code> ou
-          <code>&lt;dsfr-data-normalize&gt;</code> pour recevoir les donnees.
+          <code>&lt;dsfr-data-normalize&gt;</code> pour recevoir les données.
         </p>
 
         <!-- Attributs -->
@@ -41,14 +41,14 @@
             <tr><th>Attribut</th><th>Type</th><th>Description</th></tr>
           </thead>
           <tbody>
-            <tr><td><code>source</code></td><td>String</td><td>ID de la source de donnees a ecouter (requis)</td></tr>
-            <tr><td><code>cols</code></td><td>Number</td><td>Nombre de colonnes dans la grille (1-6, defaut: 1)</td></tr>
+            <tr><td><code>source</code></td><td>String</td><td>ID de la source de données a ecouter (requis)</td></tr>
+            <tr><td><code>cols</code></td><td>Number</td><td>Nombre de colonnes dans la grille (1-6, défaut: 1)</td></tr>
             <tr><td><code>pagination</code></td><td>Number</td><td>Nombre d'elements par page (0 = tout afficher)</td></tr>
-            <tr><td><code>empty</code></td><td>String</td><td>Message quand aucune donnee (defaut: "Aucun resultat")</td></tr>
-            <tr><td><code>gap</code></td><td>String</td><td>Classe CSS de gap pour la grille (defaut: "fr-grid-row--gutters")</td></tr>
-            <tr><td><code>uid-field</code></td><td>String</td><td>Champ de donnees a utiliser comme identifiant unique par element (vide = index)</td></tr>
+            <tr><td><code>empty</code></td><td>String</td><td>Message quand aucune donnee (défaut: "Aucun resultat")</td></tr>
+            <tr><td><code>gap</code></td><td>String</td><td>Classe CSS de gap pour la grille (défaut: "fr-grid-row--gutters")</td></tr>
+            <tr><td><code>uid-field</code></td><td>String</td><td>Champ de données a utiliser comme identifiant unique par element (vide = index)</td></tr>
             <tr><td><code>url-sync</code></td><td>Boolean</td><td>Synchronise le numero de page dans l'URL via replaceState</td></tr>
-            <tr><td><code>url-page-param</code></td><td>String</td><td>Nom du parametre URL pour la page (defaut: "page")</td></tr>
+            <tr><td><code>url-page-param</code></td><td>String</td><td>Nom du parametre URL pour la page (défaut: "page")</td></tr>
           </tbody>
         </table>
 
@@ -61,10 +61,10 @@
           <tbody>
             <tr><td><code>{{champ}}</code></td><td>Valeur echappee (HTML-safe)</td></tr>
             <tr><td><code>{{{champ}}}</code></td><td>Valeur brute (non echappee)</td></tr>
-            <tr><td><code>{{champ|defaut}}</code></td><td>Valeur avec fallback si null/undefined</td></tr>
+            <tr><td><code>{{champ|défaut}}</code></td><td>Valeur avec fallback si null/undefined</td></tr>
             <tr><td><code>{{champ:number}}</code></td><td>Valeur avec separateurs de milliers (ex: 32073247 &rarr; 32 073 247)</td></tr>
             <tr><td><code>{{champ:number|0}}</code></td><td>Format number + fallback si null/undefined</td></tr>
-            <tr><td><code>{{champ.sous.cle}}</code></td><td>Acces aux proprietes imbriquees</td></tr>
+            <tr><td><code>{{champ.sous.clé}}</code></td><td>Acces aux proprietes imbriquees</td></tr>
             <tr><td><code>{{$index}}</code></td><td>Index de l'element (0-based)</td></tr>
             <tr><td><code>{{$uid}}</code></td><td>Identifiant unique de l'element</td></tr>
           </tbody>
@@ -75,7 +75,7 @@
 
         <section class="demo-section" id="cards">
           <h3>1. Cartes DSFR</h3>
-          <p>Affiche les donnees sous forme de cartes DSFR dans une grille a 3 colonnes.</p>
+          <p>Affiche les données sous forme de cartes DSFR dans une grille a 3 colonnes.</p>
 
           <dsfr-data-display source="sites" cols="3" pagination="6">
             <template>
@@ -117,7 +117,7 @@
         <!-- Variante 2: Tuiles -->
         <section class="demo-section" id="tiles">
           <h3>2. Tuiles DSFR</h3>
-          <p>Affiche les donnees sous forme de tuiles dans une grille a 4 colonnes.</p>
+          <p>Affiche les données sous forme de tuiles dans une grille a 4 colonnes.</p>
 
           <dsfr-data-display source="sites" cols="4">
             <template>
@@ -182,8 +182,8 @@
 
         <!-- Variante 4: Valeur par defaut -->
         <section class="demo-section" id="defaults">
-          <h3>4. Valeurs par defaut</h3>
-          <p>Utilise la syntaxe <code>{{champ|defaut}}</code> pour afficher une valeur de remplacement quand un champ est absent.</p>
+          <h3>4. Valeurs par défaut</h3>
+          <p>Utilise la syntaxe <code>{{champ|défaut}}</code> pour afficher une valeur de remplacement quand un champ est absent.</p>
 
           <dsfr-data-display source="sites" cols="2" pagination="4">
             <template>
@@ -192,7 +192,7 @@
                   <div class="fr-card__content">
                     <h3 class="fr-card__title">{{nom}}</h3>
                     <p class="fr-card__desc">
-                      Categorie : {{categorie|Non renseignee}}<br>
+                      Catégorie : {{catégorie|Non renseignee}}<br>
                       Statut : {{statut|Inconnu}}
                     </p>
                   </div>
@@ -209,7 +209,7 @@
         &lt;div class="fr-card__content"&gt;
           &lt;h3 class="fr-card__title"&gt;{{nom}}&lt;/h3&gt;
           &lt;p class="fr-card__desc"&gt;
-            Categorie : {{categorie|Non renseignee}}
+            Catégorie : {{catégorie|Non renseignee}}
           &lt;/p&gt;
         &lt;/div&gt;
       &lt;/div&gt;
@@ -223,7 +223,7 @@
         <section class="demo-section" id="server-pagination">
           <h3>5. Pagination serveur</h3>
           <p>
-            Quand la source utilise <code>paginate</code>, <code>dsfr-data-display</code> detecte automatiquement
+            Quand la source utilise <code>paginate</code>, <code>dsfr-data-display</code> détecté automatiquement
             la pagination serveur. Chaque changement de page declenche un nouvel appel API au lieu de paginer en local.
             Le nombre total de pages est calcule depuis les metadonnees de l'API (<code>meta.total</code>).
           </p>
@@ -249,9 +249,9 @@
           </div>
           <div class="fr-callout fr-callout--blue-ecume fr-mt-2w">
             <p class="fr-callout__text">
-              <strong>Comportement :</strong> en mode pagination serveur, les donnees recues sont affichees telles quelles
+              <strong>Comportement :</strong> en mode pagination serveur, les données recues sont affichees telles quelles
               (pas de slicing client). Le total affiche (ex: "1 743 pages") vient de <code>meta.total / meta.page_size</code>.
-              La recherche et le tri ne s'appliquent qu'aux donnees de la page courante.
+              La recherche et le tri ne s'appliquent qu'aux données de la page courante.
             </p>
           </div>
         </section>
@@ -260,22 +260,22 @@
         <h2 class="fr-mt-4w">Conseils d'utilisation</h2>
         <div class="fr-callout">
           <p class="fr-callout__text">
-            <strong>Template :</strong> Le contenu du <code>&lt;template&gt;</code> est clone pour chaque element de donnees.
+            <strong>Template :</strong> Le contenu du <code>&lt;template&gt;</code> est clone pour chaque element de données.
             Utilisez n'importe quelle structure HTML DSFR (cartes, tuiles, callouts, badges...).
           </p>
         </div>
 
         <div class="fr-callout fr-callout--green-emeraude">
           <p class="fr-callout__text">
-            <strong>Performance :</strong> Pour les grands ensembles de donnees, utilisez l'attribut <code>pagination</code>
+            <strong>Performance :</strong> Pour les grands ensembles de données, utilisez l'attribut <code>pagination</code>
             pour limiter le nombre d'elements rendus simultanement.
           </p>
         </div>
 
         <div class="fr-callout fr-callout--blue-ecume">
           <p class="fr-callout__text">
-            <strong>Securite :</strong> Les valeurs <code>{{champ}}</code> sont echappees par defaut (HTML-safe).
-            Utilisez <code>{{{champ}}}</code> (triple accolades) uniquement si vous faites confiance a la source de donnees.
+            <strong>Securite :</strong> Les valeurs <code>{{champ}}</code> sont echappees par défaut (HTML-safe).
+            Utilisez <code>{{{champ}}}</code> (triple accolades) uniquement si vous faites confiance a la source de données.
           </p>
         </div>
     </div>

--- a/specs/components/dsfr-data-facets.html
+++ b/specs/components/dsfr-data-facets.html
@@ -68,13 +68,13 @@
     <div slot="content">
         <p class="fr-text--lead">
           Composant visuel intermediaire qui affiche des filtres interactifs (facettes)
-          bases sur les valeurs categoriques des donnees.
+          bases sur les valeurs categoriques des données.
         </p>
 
         <div class="fr-callout fr-callout--green-emeraude">
           <p class="fr-callout__text">
             <strong>Visuel et intermediaire :</strong> Ce composant affiche des controles de filtre
-            ET redistribue les donnees filtrees aux composants en aval via le systeme d'evenements.
+            ET redistribue les données filtrees aux composants en aval via le systeme d'événements.
           </p>
         </div>
 
@@ -91,16 +91,16 @@
 
         <h2>Cas d'usage</h2>
         <ul>
-          <li><strong>Exploration de donnees</strong> : permettre a l'utilisateur de filtrer un jeu de donnees par categories</li>
+          <li><strong>Exploration de données</strong> : permettre a l'utilisateur de filtrer un jeu de données par catégories</li>
           <li><strong>Tableau de bord interactif</strong> : les graphiques et tableaux se mettent a jour en temps reel</li>
           <li><strong>Recherche a facettes</strong> : comme sur un site e-commerce (filtrer par marque, prix, couleur...)</li>
         </ul>
 
         <h2>Attributs</h2>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>id</code></td><td>String</td><td>-</td><td><strong>Requis.</strong> Identifiant de la sortie (donnees filtrees).</td></tr>
+            <tr><td><code>id</code></td><td>String</td><td>-</td><td><strong>Requis.</strong> Identifiant de la sortie (données filtrees).</td></tr>
             <tr><td><code>source</code></td><td>String</td><td><code>""</code></td><td><strong>Requis.</strong> ID de la source a ecouter.</td></tr>
             <tr><td><code>fields</code></td><td>String</td><td><code>""</code></td><td>Champs a exposer comme facettes (virgule-separes). Vide = auto-detection.</td></tr>
             <tr><td><code>labels</code></td><td>String</td><td><code>""</code></td><td>Labels custom : <code>"field:Label | field2:Label 2"</code></td></tr>
@@ -109,11 +109,11 @@
             <tr><td><code>sort</code></td><td>String</td><td><code>"count"</code></td><td>Tri des valeurs : <code>count</code>, <code>-count</code>, <code>alpha</code>, <code>-alpha</code>.</td></tr>
             <tr><td><code>searchable</code></td><td>String</td><td><code>""</code></td><td>Champs avec barre de recherche (virgule-separes).</td></tr>
             <tr><td><code>hide-empty</code></td><td>Boolean</td><td><code>false</code></td><td>Masquer les facettes avec une seule valeur.</td></tr>
-            <tr><td><code>display</code></td><td>String</td><td><code>""</code></td><td>Mode d'affichage par facette : <code>"field:select | field2:multiselect"</code>. Modes : <code>checkbox</code> (defaut), <code>select</code>, <code>multiselect</code>, <code>radio</code>.</td></tr>
+            <tr><td><code>display</code></td><td>String</td><td><code>""</code></td><td>Mode d'affichage par facette : <code>"field:select | field2:multiselect"</code>. Modes : <code>checkbox</code> (défaut), <code>select</code>, <code>multiselect</code>, <code>radio</code>.</td></tr>
             <tr><td><code>hide-counts</code></td><td>Boolean</td><td><code>false</code></td><td>Masquer les compteurs a cote de chaque valeur de facette.</td></tr>
-            <tr><td><code>cols</code></td><td>String</td><td><code>""</code></td><td>Colonnage DSFR des facettes. Global : <code>"6"</code> (2 par ligne), <code>"4"</code> (3 par ligne). Par facette : <code>"region:4 | type:6"</code> (defaut fr-col-6 pour les non-specifies).</td></tr>
+            <tr><td><code>cols</code></td><td>String</td><td><code>""</code></td><td>Colonnage DSFR des facettes. Global : <code>"6"</code> (2 par ligne), <code>"4"</code> (3 par ligne). Par facette : <code>"region:4 | type:6"</code> (défaut fr-col-6 pour les non-specifies).</td></tr>
             <tr><td><code>server-facets</code></td><td>Boolean</td><td><code>false</code></td><td>Deleguer le calcul des facettes au serveur via l'adapter (ODS, Grist). L'attribut <code>fields</code> est requis (pas d'auto-detection).</td></tr>
-            <tr><td><code>static-values</code></td><td>String</td><td><code>""</code></td><td>Valeurs de facettes pre-calculees (JSON). Affiche les valeurs sans les calculer depuis les donnees, les selections envoient des commandes WHERE a la source. Ex : <code>'{"sexe":["F","M"]}'</code>. Les compteurs sont masques automatiquement.</td></tr>
+            <tr><td><code>static-values</code></td><td>String</td><td><code>""</code></td><td>Valeurs de facettes pre-calculees (JSON). Affiche les valeurs sans les calculer depuis les données, les selections envoient des commandes WHERE a la source. Ex : <code>'{"sexe":["F","M"]}'</code>. Les compteurs sont masques automatiquement.</td></tr>
           </tbody>
         </table>
 
@@ -128,9 +128,9 @@
         <div class="fr-callout fr-callout--brown-caramel fr-mt-3w">
           <p class="fr-callout__text">
             <strong>Modes d'affichage :</strong><br>
-            <code>checkbox</code> (defaut) : checkboxes DSFR dans un fieldset ouvert.<br>
+            <code>checkbox</code> (défaut) : checkboxes DSFR dans un fieldset ouvert.<br>
             <code>select</code> : liste deroulante DSFR native, selection exclusive.<br>
-            <code>multiselect</code> : dropdown DSFR avec checkboxes, recherche, "Tout selectionner/deselectionner".<br>
+            <code>multiselect</code> : dropdown DSFR avec checkboxes, recherche, "Tout sélectionner/deselectionner".<br>
             <code>radio</code> : dropdown DSFR avec radio buttons, recherche, selection exclusive.<br>
             Le mode <code>select</code>/<code>radio</code> est automatiquement exclusif, <code>multiselect</code> automatiquement disjonctif.
           </p>
@@ -140,7 +140,7 @@
           <p class="fr-callout__text">
             <strong>Facettes server-side :</strong> Avec une source <code>api-type="opendatasoft"</code>
             et l'attribut <code>server-side</code>, les valeurs des facettes et les compteurs sont
-            calcules directement par l'API (pas de telechargement complet des donnees).
+            calcules directement par l'API (pas de téléchargement complet des données).
             Les exemples ci-dessous utilisent le dataset
             <em>Prix du controle technique</em> (~133 000 enregistrements) de data.economie.gouv.fr.
           </p>
@@ -194,7 +194,7 @@
              Exemple 2 : Facettes + Query + Barres (prix moyen par departement)
              ======================================================== -->
         <h2 class="fr-mt-6w">Exemple 2 : graphique filtre par region</h2>
-        <p>La facette Region en mode multiselect filtre les donnees, puis <code>dsfr-data-query</code> agrege
+        <p>La facette Region en mode multiselect filtre les données, puis <code>dsfr-data-query</code> agrège
         le prix moyen du controle technique par departement pour le graphique en barres.</p>
 
         <dsfr-data-facets id="ct-filtered2" source="ct-src2"
@@ -250,8 +250,8 @@
              Exemple 3 : Facettes + KPI + Carte (prix par departement)
              ======================================================== -->
         <h2 class="fr-mt-6w">Exemple 3 : KPI + carte filtres par region</h2>
-        <p>Un meme <code>dsfr-data-facets</code> alimente a la fois des <strong>KPI</strong> et une <strong>carte</strong>.
-        Selectionner des regions met a jour simultanement les indicateurs et la carte departementale.</p>
+        <p>Un même <code>dsfr-data-facets</code> alimente a la fois des <strong>KPI</strong> et une <strong>carte</strong>.
+        Sélectionner des regions met a jour simultanement les indicateurs et la carte departementale.</p>
 
         <dsfr-data-facets id="ct-filtered3" source="ct-src3"
           server-facets
@@ -301,11 +301,11 @@
   sort="alpha"&gt;
 &lt;/dsfr-data-facets&gt;
 
-&lt;!-- KPI sur les donnees filtrees --&gt;
+&lt;!-- KPI sur les données filtrees --&gt;
 &lt;dsfr-data-kpi source="filtered" valeur="count" label="Centres" format="nombre"&gt;&lt;/dsfr-data-kpi&gt;
 &lt;dsfr-data-kpi source="filtered" valeur="avg:prix_visite" label="Prix moyen" format="euros"&gt;&lt;/dsfr-data-kpi&gt;
 
-&lt;!-- Carte sur les donnees filtrees et agregees --&gt;
+&lt;!-- Carte sur les données filtrees et agregees --&gt;
 &lt;dsfr-data-query id="stats" source="filtered"
   group-by="code_departement"
   aggregate="prix_visite:avg:prix_moyen"&gt;
@@ -323,9 +323,9 @@
         <h2 class="fr-mt-6w">Exemple 4 : les 4 modes d'affichage</h2>
         <p>Quatre facettes avec des modes differents :
         <code>radio</code> pour l'Energie (dropdown avec radio buttons, selection exclusive),
-        <code>multiselect</code> pour la Region (dropdown avec checkboxes, recherche et "Tout selectionner"),
+        <code>multiselect</code> pour la Region (dropdown avec checkboxes, recherche et "Tout sélectionner"),
         <code>select</code> pour le Type de vehicule (liste deroulante native DSFR),
-        et <code>checkbox</code> (defaut) pour le Departement.</p>
+        et <code>checkbox</code> (défaut) pour le Departement.</p>
 
         <dsfr-data-facets id="ct-display-demo" source="ct-local"
           server-facets

--- a/specs/components/dsfr-data-join.html
+++ b/specs/components/dsfr-data-join.html
@@ -26,14 +26,14 @@
     <div slot="content">
         <p class="fr-text--lead">
           Composant de jointure multi-sources.
-          Joint deux jeux de donnees sur une ou plusieurs cles pivot pour produire un dataset enrichi.
+          Joint deux jeux de données sur une ou plusieurs clés pivot pour produire un dataset enrichi.
           Ne fait aucun fetch HTTP : c'est un pur transformateur.
         </p>
 
         <div class="fr-callout fr-callout--blue-france">
           <p class="fr-callout__text">
             <strong>Invisible :</strong> Ce composant ne rend rien visuellement. Il attend que ses deux sources
-            aient emis leurs donnees, les joint en memoire, puis redistribue le resultat via le systeme d'evenements.
+            aient emis leurs données, les joint en memoire, puis redistribue le resultat via le systeme d'événements.
           </p>
         </div>
 
@@ -56,32 +56,32 @@ dsfr-data-source (B)  ──────┘</pre></div>
         <table class="attr-table">
           <thead><tr><th>Attribut</th><th>Type</th><th>Format / Valeurs</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>id</code></td><td>String</td><td><code>id="enriched"</code></td><td>Identifiant unique (requis). Les composants aval l'utilisent pour s'abonner aux donnees jointes.</td></tr>
+            <tr><td><code>id</code></td><td>String</td><td><code>id="enriched"</code></td><td>Identifiant unique (requis). Les composants aval l'utilisent pour s'abonner aux données jointes.</td></tr>
             <tr><td><code>left</code></td><td>String</td><td><code>left="id-source-a"</code></td><td>ID de la source gauche — source principale (requis)</td></tr>
             <tr><td><code>right</code></td><td>String</td><td><code>right="id-source-b"</code></td><td>ID de la source droite (requis)</td></tr>
-            <tr><td><code>on</code></td><td>String</td><td>Voir formats ci-dessous</td><td>Cle(s) de jointure (requis)</td></tr>
-            <tr><td><code>type</code></td><td>String</td><td><code>inner</code> | <code>left</code> | <code>right</code> | <code>full</code></td><td>Type de jointure. Defaut : <code>left</code></td></tr>
-            <tr><td><code>prefix-left</code></td><td>String</td><td><code>prefix-left="pop_"</code></td><td>Prefixe pour les champs gauche en cas de collision. Defaut : vide</td></tr>
-            <tr><td><code>prefix-right</code></td><td>String</td><td><code>prefix-right="budget_"</code></td><td>Prefixe pour les champs droite en cas de collision. Defaut : <code>right_</code></td></tr>
+            <tr><td><code>on</code></td><td>String</td><td>Voir formats ci-dessous</td><td>Clé(s) de jointure (requis)</td></tr>
+            <tr><td><code>type</code></td><td>String</td><td><code>inner</code> | <code>left</code> | <code>right</code> | <code>full</code></td><td>Type de jointure. Défaut : <code>left</code></td></tr>
+            <tr><td><code>prefix-left</code></td><td>String</td><td><code>prefix-left="pop_"</code></td><td>Prefixe pour les champs gauche en cas de collision. Défaut : vide</td></tr>
+            <tr><td><code>prefix-right</code></td><td>String</td><td><code>prefix-right="budget_"</code></td><td>Prefixe pour les champs droite en cas de collision. Défaut : <code>right_</code></td></tr>
           </tbody>
         </table>
 
         <h3 class="fr-mt-3w">Format de l'attribut <code>on</code></h3>
 
         <section class="demo-section">
-          <h4>Cle commune</h4>
-          <p>Quand le champ porte le meme nom dans les deux sources :</p>
+          <h4>Clé commune</h4>
+          <p>Quand le champ porte le même nom dans les deux sources :</p>
           <div class="code-block"><pre>on="code_dept"</pre></div>
         </section>
 
         <section class="demo-section">
-          <h4>Cle de nommage different</h4>
+          <h4>Clé de nommage different</h4>
           <p>Quand le champ a un nom different dans chaque source (gauche=droite) :</p>
           <div class="code-block"><pre>on="dept_code=code"</pre></div>
         </section>
 
         <section class="demo-section">
-          <h4>Multi-cle</h4>
+          <h4>Multi-clé</h4>
           <p>Jointure sur plusieurs champs (separes par virgule) :</p>
           <div class="code-block"><pre>on="annee,code_region"
 on="annee, dept_code=code"</pre></div>
@@ -101,7 +101,7 @@ on="annee, dept_code=code"</pre></div>
         <h2 id="exemples" class="fr-mt-4w">Exemples</h2>
 
         <section class="demo-section">
-          <h3>Enrichir un dataset avec des donnees d'une autre source</h3>
+          <h3>Enrichir un dataset avec des données d'une autre source</h3>
           <p>
             Jointure gauche entre un dataset de population et un dataset de budgets, sur le code departement.
             <a href="../../guide/guide-exemples-join.html" class="fr-link fr-link--sm">Voir l'exemple live</a>
@@ -128,7 +128,7 @@ on="annee, dept_code=code"</pre></div>
         <section class="demo-section">
           <h3>Jointure avec transformation aval</h3>
           <p>
-            Apres la jointure, un <code>&lt;dsfr-data-query&gt;</code> peut agreger et trier les donnees fusionnees.
+            Apres la jointure, un <code>&lt;dsfr-data-query&gt;</code> peut agréger et trier les données fusionnees.
           </p>
           <div class="code-block"><pre>&lt;dsfr-data-join id="joined"
   left="src1" right="src2"
@@ -146,9 +146,9 @@ on="annee, dept_code=code"</pre></div>
         </section>
 
         <section class="demo-section">
-          <h3>Cles de nommage different</h3>
+          <h3>Clés de nommage different</h3>
           <p>
-            Quand le champ de jointure n'a pas le meme nom dans les deux sources :
+            Quand le champ de jointure n'a pas le même nom dans les deux sources :
           </p>
           <div class="code-block"><pre>&lt;dsfr-data-join id="merged"
   left="src-a" right="src-b"
@@ -156,20 +156,20 @@ on="annee, dept_code=code"</pre></div>
 &lt;/dsfr-data-join&gt;</pre></div>
         </section>
 
-        <h2 id="evenements" class="fr-mt-4w">Evenements</h2>
-        <p>Le composant emet les memes evenements que <code>&lt;dsfr-data-source&gt;</code> :</p>
+        <h2 id="evenements" class="fr-mt-4w">Événements</h2>
+        <p>Le composant emet les mêmes événements que <code>&lt;dsfr-data-source&gt;</code> :</p>
         <ul>
-          <li><code>dsfr-data-loaded</code> : Donnees jointes disponibles</li>
+          <li><code>dsfr-data-loaded</code> : Données jointes disponibles</li>
           <li><code>dsfr-data-loading</code> : En attente d'une ou plusieurs sources</li>
           <li><code>dsfr-data-error</code> : Erreur d'une source ou de la jointure</li>
         </ul>
 
         <h2 id="methodes" class="fr-mt-4w">Methodes publiques</h2>
         <table class="attr-table">
-          <thead><tr><th>Methode</th><th>Retour</th><th>Description</th></tr></thead>
+          <thead><tr><th>Méthode</th><th>Retour</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>getData()</code></td><td>Array</td><td>Retourne les donnees jointes actuelles</td></tr>
-            <tr><td><code>isLoading()</code></td><td>Boolean</td><td>Indique si le composant attend encore des donnees</td></tr>
+            <tr><td><code>getData()</code></td><td>Array</td><td>Retourne les données jointes actuelles</td></tr>
+            <tr><td><code>isLoading()</code></td><td>Boolean</td><td>Indique si le composant attend encore des données</td></tr>
             <tr><td><code>getError()</code></td><td>Error | null</td><td>Retourne l'erreur eventuelle</td></tr>
           </tbody>
         </table>
@@ -177,20 +177,20 @@ on="annee, dept_code=code"</pre></div>
         <h2 id="conseils" class="fr-mt-4w">Conseils d'utilisation</h2>
         <div class="fr-callout">
           <p class="fr-callout__text">
-            <strong>Collisions de noms :</strong> Si un champ existe dans les deux sources avec le meme nom
-            (hors cle de jointure), le <code>prefix-right</code> est applique au champ droit (defaut : <code>right_</code>).
+            <strong>Collisions de noms :</strong> Si un champ existe dans les deux sources avec le même nom
+            (hors clé de jointure), le <code>prefix-right</code> est applique au champ droit (défaut : <code>right_</code>).
             Definissez <code>prefix-left</code> pour prefixer aussi les champs gauche.
           </p>
         </div>
         <div class="fr-callout fr-mt-2w">
           <p class="fr-callout__text">
             <strong>Relations 1-N :</strong> Si plusieurs enregistrements de la source droite correspondent
-            a une cle de la source gauche, autant de lignes sont generees (comportement SQL standard).
+            a une clé de la source gauche, autant de lignes sont generees (comportement SQL standard).
           </p>
         </div>
         <div class="fr-callout fr-mt-2w">
           <p class="fr-callout__text">
-            <strong>Recalcul automatique :</strong> Si l'une des sources emet de nouvelles donnees (rechargement,
+            <strong>Recalcul automatique :</strong> Si l'une des sources emet de nouvelles données (rechargement,
             filtre, pagination), la jointure est recalculee automatiquement.
           </p>
         </div>

--- a/specs/components/dsfr-data-kpi.html
+++ b/specs/components/dsfr-data-kpi.html
@@ -30,7 +30,7 @@
     base-path="../">
     <div slot="content">
         <p class="fr-text--lead">
-          Affiche une valeur cle (KPI) avec formatage, couleurs conditionnelles basees sur des seuils, et icones optionnelles.
+          Affiche une valeur clé (KPI) avec formatage, couleurs conditionnelles basees sur des seuils, et icones optionnelles.
         </p>
 
         <h2>Attributs</h2>
@@ -43,7 +43,7 @@
             <tr><td><code>label</code></td><td>String</td><td>Libelle affiche sous la valeur (et sous les <code>lines</code>)</td></tr>
             <tr><td><code>trend</code></td><td>String</td><td>Raccourci herite : expression <code>champ:fn</code> (ex. <code>evolution:avg</code>) rendue avec une fleche en %. Preferez <code>lines</code></td></tr>
             <tr><td><code>lines</code></td><td>String (JSON)</td><td>Lignes secondaires entre la valeur et le label. Items : <code>value</code> (expression) ou <code>text</code> (statique), + <code>sign</code>, <code>suffix</code>, <code>color</code> (<code>auto</code> / token DSFR / couleur CSS), <code>na</code></td></tr>
-            <tr><td><code>format</code></td><td>String</td><td>Format d'affichage (defaut : <code>nombre</code>)</td></tr>
+            <tr><td><code>format</code></td><td>String</td><td>Format d'affichage (défaut : <code>nombre</code>)</td></tr>
             <tr><td><code>icone</code></td><td>String</td><td>Classe d'icone Remix Icon (ex: <code>ri-global-line</code>)</td></tr>
             <tr><td><code>couleur</code></td><td>String</td><td>Couleur forcee : <code>vert</code>, <code>orange</code>, <code>rouge</code>, <code>bleu</code></td></tr>
             <tr><td><code>seuil-vert</code></td><td>Number</td><td>Seuil au-dessus duquel la couleur est verte</td></tr>
@@ -56,8 +56,8 @@
         <table class="attr-table">
           <thead><tr><th>Attribut</th><th>Type</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>cols</code></td><td>Number</td><td>Nombre de colonnes par defaut (1-12, defaut: 3)</td></tr>
-            <tr><td><code>gap</code></td><td>String</td><td>Espacement : <code>sm</code> (0.5rem), <code>md</code> (1rem, defaut), <code>lg</code> (1.5rem)</td></tr>
+            <tr><td><code>cols</code></td><td>Number</td><td>Nombre de colonnes par défaut (1-12, défaut: 3)</td></tr>
+            <tr><td><code>gap</code></td><td>String</td><td>Espacement : <code>sm</code> (0.5rem), <code>md</code> (1rem, défaut), <code>lg</code> (1.5rem)</td></tr>
             <tr><td><code>aria-label</code></td><td>String</td><td>Label accessible du groupe</td></tr>
           </tbody>
         </table>

--- a/specs/components/dsfr-data-list.html
+++ b/specs/components/dsfr-data-list.html
@@ -28,8 +28,8 @@
     base-path="../">
     <div slot="content">
         <p class="fr-text--lead">
-          Composant de tableau de donnees avec fonctionnalites de recherche, filtrage, tri, pagination et export CSV.
-          Se connecte a un <code>&lt;dsfr-data-source&gt;</code> pour recevoir les donnees dynamiquement.
+          Composant de tableau de données avec fonctionnalites de recherche, filtrage, tri, pagination et export CSV.
+          Se connecte a un <code>&lt;dsfr-data-source&gt;</code> pour recevoir les données dynamiquement.
         </p>
 
         <!-- Attributs -->
@@ -43,7 +43,7 @@
             <tr><td><code>colonnes</code></td><td>String</td><td>Colonnes a afficher : <code>"key:Label, key2:Label2"</code></td></tr>
             <tr><td><code>recherche</code></td><td>Boolean</td><td>Afficher le champ de recherche</td></tr>
             <tr><td><code>filtres</code></td><td>String</td><td>Colonnes filtrables : <code>"col1,col2"</code></td></tr>
-            <tr><td><code>tri</code></td><td>String</td><td>Tri par defaut : <code>"col:asc"</code> ou <code>"col:desc"</code></td></tr>
+            <tr><td><code>tri</code></td><td>String</td><td>Tri par défaut : <code>"col:asc"</code> ou <code>"col:desc"</code></td></tr>
             <tr><td><code>pagination</code></td><td>Number</td><td>Nombre d'elements par page (0 = pas de pagination)</td></tr>
             <tr><td><code>export</code></td><td>String</td><td>Formats d'export disponibles : <code>"csv"</code></td></tr>
             <tr><td><code>server-tri</code></td><td>Boolean</td><td>Deleguer le tri des colonnes au serveur via <code>dsfr-data-source-command</code> (orderBy). Les en-tetes de colonnes envoient des commandes de tri a la source amont au lieu de trier localement.</td></tr>
@@ -55,7 +55,7 @@
 
         <section class="demo-section" id="simple">
           <h3>1. Tableau simple</h3>
-          <p>Affiche uniquement les donnees dans un tableau sans fonctionnalites supplementaires.</p>
+          <p>Affiche uniquement les données dans un tableau sans fonctionnalites supplementaires.</p>
 
           <dsfr-data-list
             source="sites"
@@ -73,7 +73,7 @@
         <!-- Variante 2: Tableau + recherche -->
         <section class="demo-section" id="search">
           <h3>2. Tableau + recherche</h3>
-          <p>Ajoute un champ de recherche pour filtrer les donnees en temps reel.</p>
+          <p>Ajoute un champ de recherche pour filtrer les données en temps reel.</p>
 
           <dsfr-data-list
             source="sites"
@@ -93,7 +93,7 @@
         <!-- Variante 3: Tableau + filtres -->
         <section class="demo-section" id="filters">
           <h3>3. Tableau + filtres</h3>
-          <p>Ajoute des menus deroulants pour filtrer par colonne specifique.</p>
+          <p>Ajoute des menus deroulants pour filtrer par colonne spécifique.</p>
 
           <dsfr-data-list
             source="sites"
@@ -113,7 +113,7 @@
         <!-- Variante 4: Tableau + tri -->
         <section class="demo-section" id="sort">
           <h3>4. Tableau + tri</h3>
-          <p>Definit un tri par defaut et permet de trier en cliquant sur les en-tetes.</p>
+          <p>Definit un tri par défaut et permet de trier en cliquant sur les en-tetes.</p>
 
           <dsfr-data-list
             source="sites"
@@ -133,7 +133,7 @@
         <!-- Variante 5: Tableau + pagination -->
         <section class="demo-section" id="pagination">
           <h3>5. Tableau + pagination</h3>
-          <p>Divise les donnees en pages pour une meilleure lisibilite.</p>
+          <p>Divise les données en pages pour une meilleure lisibilite.</p>
 
           <dsfr-data-list
             source="sites"
@@ -153,7 +153,7 @@
         <!-- Variante 6: Tableau + export -->
         <section class="demo-section" id="export">
           <h3>6. Tableau + export CSV</h3>
-          <p>Ajoute un bouton pour exporter les donnees au format CSV.</p>
+          <p>Ajoute un bouton pour exporter les données au format CSV.</p>
 
           <dsfr-data-list
             source="sites"
@@ -202,7 +202,7 @@
         <section class="demo-section" id="server-pagination">
           <h3>8. Pagination serveur</h3>
           <p>
-            Quand la source utilise <code>paginate</code>, <code>dsfr-data-list</code> detecte automatiquement
+            Quand la source utilise <code>paginate</code>, <code>dsfr-data-list</code> détecté automatiquement
             la pagination serveur. Chaque changement de page declenche un nouvel appel API. Le nombre total
             d'enregistrements et de pages vient des metadonnees de l'API.
           </p>
@@ -217,7 +217,7 @@
 &lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-list source="rappels"
-  colonnes="modeles_ou_references:Produit, categorie_produit:Categorie, marque_produit:Marque"
+  colonnes="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque"
   recherche="true"
   tri="date_publication:desc"
   pagination="20"&gt;
@@ -226,7 +226,7 @@
           <div class="fr-callout fr-callout--blue-ecume fr-mt-2w">
             <p class="fr-callout__text">
               <strong>Comportement :</strong> en mode pagination serveur, le total affiche (ex: "34 874 resultats")
-              vient de <code>meta.total</code>. La recherche, le tri et les filtres ne s'appliquent qu'aux donnees
+              vient de <code>meta.total</code>. La recherche, le tri et les filtres ne s'appliquent qu'aux données
               de la page courante. Pour filtrer sur tout le dataset, utilisez les parametres API via <code>params</code>.
             </p>
           </div>
@@ -236,7 +236,7 @@
         <h2 class="fr-mt-4w">Conseils d'utilisation</h2>
         <div class="fr-callout">
           <p class="fr-callout__text">
-            <strong>Performance :</strong> Pour les grands ensembles de donnees, utilisez toujours la pagination
+            <strong>Performance :</strong> Pour les grands ensembles de données, utilisez toujours la pagination
             pour eviter de surcharger le navigateur. Avec <code>paginate</code> sur <code>dsfr-data-source</code>,
             la pagination est geree cote serveur et seule la page courante est en memoire.
           </p>
@@ -244,8 +244,8 @@
 
         <div class="fr-callout fr-callout--green-emeraude">
           <p class="fr-callout__text">
-            <strong>Accessibilite :</strong> Le composant inclut automatiquement les attributs ARIA necessaires
-            pour les lecteurs d'ecran.
+            <strong>Accessibilité :</strong> Le composant inclut automatiquement les attributs ARIA necessaires
+            pour les lecteurs d'écran.
           </p>
         </div>
     </div>

--- a/specs/components/dsfr-data-map.html
+++ b/specs/components/dsfr-data-map.html
@@ -32,7 +32,7 @@
         <div class="fr-callout fr-callout--blue-ecume fr-mb-4w">
           <p class="fr-callout__text">
             <strong>Architecture 2 composants</strong> : <code>dsfr-data-map</code> est le conteneur carte (init Leaflet, tuiles, viewport).
-            Les donnees sont projetees par des <code>dsfr-data-map-layer</code> enfants, chacun connecte a sa propre source.
+            Les données sont projetees par des <code>dsfr-data-map-layer</code> enfants, chacun connecte a sa propre source.
             Cela permet naturellement le <strong>multi-source</strong> (ex: departements choropleth + POI pharmacies).
           </p>
         </div>
@@ -43,9 +43,9 @@
 
         <h2>dsfr-data-map — Conteneur carte</h2>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>center</code></td><td>String</td><td><code>"46.603,2.888"</code></td><td>Centre initial <code>"lat,lon"</code> (France metro par defaut)</td></tr>
+            <tr><td><code>center</code></td><td>String</td><td><code>"46.603,2.888"</code></td><td>Centre initial <code>"lat,lon"</code> (France metro par défaut)</td></tr>
             <tr><td><code>zoom</code></td><td>Number</td><td><code>6</code></td><td>Niveau de zoom initial (1-18)</td></tr>
             <tr><td><code>min-zoom</code></td><td>Number</td><td><code>2</code></td><td>Zoom minimum autorise</td></tr>
             <tr><td><code>max-zoom</code></td><td>Number</td><td><code>18</code></td><td>Zoom maximum autorise</td></tr>
@@ -53,14 +53,14 @@
             <tr><td><code>tiles</code></td><td>String</td><td><code>"ign-plan"</code></td><td>Fond de carte predefini ou URL template custom</td></tr>
             <tr><td><code>sovereign-only</code></td><td>Boolean</td><td><code>false</code></td><td>Restreint <code>tiles</code> aux presets IGN souverains. Tout autre preset (ex. <code>osm-fr</code>) ou URL custom est refuse avec un <code>console.warn</code> et remplace par <code>ign-plan</code>.</td></tr>
             <tr><td><code>no-controls</code></td><td>Boolean</td><td><code>false</code></td><td>Masque les controles de zoom Leaflet</td></tr>
-            <tr><td><code>fit-bounds</code></td><td>Boolean</td><td><code>false</code></td><td>Ajuste automatiquement le viewport aux donnees</td></tr>
+            <tr><td><code>fit-bounds</code></td><td>Boolean</td><td><code>false</code></td><td>Ajuste automatiquement le viewport aux données</td></tr>
             <tr><td><code>max-bounds</code></td><td>String</td><td><code>""</code></td><td>Limites <code>"latSW,lonSW,latNE,lonNE"</code></td></tr>
             <tr><td><code>name</code></td><td>String</td><td><code>""</code></td><td>Titre de la carte (aria-label et beacon)</td></tr>
           </tbody>
         </table>
 
         <h3>Fonds de carte predefinis</h3>
-        <p>Tuiles accessibles <strong>sans cle API</strong>. Les presets <code>ign-*</code> sont servis par la <a href="https://geoservices.ign.fr/services-geoplateforme">Geoplateforme nationale IGN</a> (infrastructure cartographique de l'Etat, hebergee en France). Le preset <code>osm-fr</code> est servi par l'<a href="https://www.openstreetmap.fr/">association OpenStreetMap France</a> (association loi 1901, infra hebergee en France, distincte de l'OSM Foundation).</p>
+        <p>Tuiles accessibles <strong>sans clé API</strong>. Les presets <code>ign-*</code> sont servis par la <a href="https://geoservices.ign.fr/services-geoplateforme">Geoplateforme nationale IGN</a> (infrastructure cartographique de l'État, hebergee en France). Le preset <code>osm-fr</code> est servi par l'<a href="https://www.openstreetmap.fr/">association OpenStreetMap France</a> (association loi 1901, infra hebergee en France, distincte de l'OSM Foundation).</p>
         <table class="attr-table">
           <thead><tr><th>Preset</th><th>Source</th><th>Souverain</th><th>Endpoint</th></tr></thead>
           <tbody>
@@ -68,7 +68,7 @@
             <tr><td><code>ign-ortho</code></td><td>Geoplateforme IGN — Orthophoto</td><td>Oui</td><td><code>data.geopf.fr/wmts</code> (layer <code>ORTHOIMAGERY.ORTHOPHOTOS</code>)</td></tr>
             <tr><td><code>ign-topo</code></td><td>Geoplateforme IGN — Carte topographique (SCAN 25/100)</td><td>Oui</td><td><code>data.geopf.fr/wmts</code> (layer <code>GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1</code>)</td></tr>
             <tr><td><code>ign-cadastre</code></td><td>Geoplateforme IGN — Cadastre</td><td>Oui</td><td><code>data.geopf.fr/wmts</code> (layer <code>CADASTRALPARCELS.PARCELLAIRE_EXPRESS</code>)</td></tr>
-            <tr><td><code>osm-fr</code></td><td>OpenStreetMap France (association)</td><td>Non (associatif hors Etat)</td><td><code>{s}.tile.openstreetmap.fr/osmfr</code></td></tr>
+            <tr><td><code>osm-fr</code></td><td>OpenStreetMap France (association)</td><td>Non (associatif hors État)</td><td><code>{s}.tile.openstreetmap.fr/osmfr</code></td></tr>
           </tbody>
         </table>
         <p class="fr-mt-2w"><strong>Mode <code>sovereign-only</code></strong> : pour les DSI qui imposent une politique "zero tiers externe non souverain", ajouter l'attribut booleen <code>sovereign-only</code> sur <code>&lt;dsfr-data-map&gt;</code> restreint les presets disponibles aux seules tuiles IGN (<code>ign-plan</code>, <code>ign-ortho</code>, <code>ign-topo</code>, <code>ign-cadastre</code>). Tout autre preset ou URL custom est refuse avec un avertissement console et remplace par <code>ign-plan</code>.</p>
@@ -78,13 +78,13 @@
         <!-- dsfr-data-map-layer -->
         <!-- ============================================================ -->
 
-        <h2 class="fr-mt-4w">dsfr-data-map-layer — Couche de donnees</h2>
+        <h2 class="fr-mt-4w">dsfr-data-map-layer — Couche de données</h2>
 
         <h3>Source et geolocalisation</h3>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>source</code></td><td>String</td><td><code>""</code></td><td>ID de la source de donnees (requis)</td></tr>
+            <tr><td><code>source</code></td><td>String</td><td><code>""</code></td><td>ID de la source de données (requis)</td></tr>
             <tr><td><code>type</code></td><td>String</td><td><code>"marker"</code></td><td>Type de couche : <code>marker</code>, <code>geoshape</code>, <code>circle</code>, <code>heatmap</code></td></tr>
             <tr><td><code>lat-field</code></td><td>String</td><td><code>""</code></td><td>Chemin vers la latitude</td></tr>
             <tr><td><code>lon-field</code></td><td>String</td><td><code>""</code></td><td>Chemin vers la longitude</td></tr>
@@ -94,17 +94,17 @@
 
         <h3>Affichage</h3>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>popup-template</code></td><td>String</td><td><code>""</code></td><td>Template HTML avec interpolation : <code>"{nom} — {puissance} kW"</code></td></tr>
             <tr><td><code>popup-fields</code></td><td>String</td><td><code>""</code></td><td>Champs separes par virgule pour un tableau auto</td></tr>
             <tr><td><code>tooltip-field</code></td><td>String</td><td><code>""</code></td><td>Champ affiche au survol</td></tr>
             <tr><td><code>color</code></td><td>String</td><td><code>"#000091"</code></td><td>Couleur contours/markers (DSFR blue-france). Sert de fallback si <code>color-map</code> ne matche pas.</td></tr>
-            <tr><td><code>color-field</code></td><td>String</td><td><code>""</code></td><td>Champ dont la valeur determine la couleur (mapping categoriel)</td></tr>
+            <tr><td><code>color-field</code></td><td>String</td><td><code>""</code></td><td>Champ dont la valeur determine la couleur (mapping catégoriel)</td></tr>
             <tr><td><code>color-map</code></td><td>String</td><td><code>""</code></td><td>Paires <code>valeur:#couleur</code> separees par virgule. Ex: <code>"1:#00A95F,2:#FF9940,3:#E1000F"</code></td></tr>
-            <tr><td><code>fill-field</code></td><td>String</td><td><code>""</code></td><td>Champ numerique pour choropleth geoshape</td></tr>
+            <tr><td><code>fill-field</code></td><td>String</td><td><code>""</code></td><td>Champ numérique pour choropleth geoshape</td></tr>
             <tr><td><code>fill-opacity</code></td><td>Number</td><td><code>0.6</code></td><td>Opacite du remplissage</td></tr>
-            <tr><td><code>selected-palette</code></td><td>String</td><td><code>""</code></td><td>Palette choropleth (memes noms que world-map)</td></tr>
+            <tr><td><code>selected-palette</code></td><td>String</td><td><code>""</code></td><td>Palette choropleth (mêmes noms que world-map)</td></tr>
             <tr><td><code>radius</code></td><td>Number</td><td><code>8</code></td><td>Rayon fixe (circle)</td></tr>
             <tr><td><code>radius-field</code></td><td>String</td><td><code>""</code></td><td>Champ pour rayon variable (cercles proportionnels)</td></tr>
             <tr><td><code>radius-unit</code></td><td>String</td><td><code>"px"</code></td><td><code>px</code> (pixels) ou <code>m</code> (metres)</td></tr>
@@ -115,17 +115,17 @@
 
         <h3>Heatmap</h3>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>heat-radius</code></td><td>Number</td><td><code>25</code></td><td>Rayon de la heatmap en pixels</td></tr>
             <tr><td><code>heat-blur</code></td><td>Number</td><td><code>15</code></td><td>Flou de la heatmap en pixels</td></tr>
-            <tr><td><code>heat-field</code></td><td>String</td><td><code>""</code></td><td>Champ numerique pour ponderer l'intensite</td></tr>
+            <tr><td><code>heat-field</code></td><td>String</td><td><code>""</code></td><td>Champ numérique pour ponderer l'intensite</td></tr>
           </tbody>
         </table>
 
         <h3>Clustering</h3>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>cluster</code></td><td>Boolean</td><td><code>false</code></td><td>Active le clustering (leaflet.markercluster)</td></tr>
             <tr><td><code>cluster-radius</code></td><td>Number</td><td><code>80</code></td><td>Rayon de clustering en pixels</td></tr>
@@ -134,19 +134,19 @@
 
         <h3>Zoom et viewport</h3>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>min-zoom</code></td><td>Number</td><td><code>0</code></td><td>Zoom minimum pour afficher cette couche</td></tr>
             <tr><td><code>max-zoom</code></td><td>Number</td><td><code>18</code></td><td>Zoom maximum pour afficher cette couche</td></tr>
             <tr><td><code>bbox</code></td><td>Boolean</td><td><code>false</code></td><td>Active le filtrage par bounding box du viewport</td></tr>
             <tr><td><code>bbox-debounce</code></td><td>Number</td><td><code>300</code></td><td>Delai ms avant re-fetch apres pan/zoom</td></tr>
-            <tr><td><code>bbox-field</code></td><td>String</td><td><code>""</code></td><td>Champ geo pour la clause bbox (auto-detecte si vide)</td></tr>
+            <tr><td><code>bbox-field</code></td><td>String</td><td><code>""</code></td><td>Champ geo pour la clause bbox (auto-détecté si vide)</td></tr>
           </tbody>
         </table>
 
         <h3>Performance</h3>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>max-items</code></td><td>Number</td><td><code>5000</code></td><td>Nombre max d'elements rendus (0 = illimite)</td></tr>
             <tr><td><code>filter</code></td><td>String</td><td><code>""</code></td><td>Filtre client-side</td></tr>
@@ -155,7 +155,7 @@
 
         <h3>Animation temporelle</h3>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>time-field</code></td><td>String</td><td><code>""</code></td><td>Champ date/heure pour le decoupage temporel</td></tr>
             <tr><td><code>time-bucket</code></td><td>String</td><td><code>"none"</code></td><td>Granularite : <code>none</code> (valeurs brutes), <code>hour</code>, <code>day</code>, <code>month</code>, <code>year</code></td></tr>
@@ -163,7 +163,7 @@
           </tbody>
         </table>
         <p>
-          Quand <code>time-field</code> est defini, les donnees sont pre-indexees par pas de temps.
+          Quand <code>time-field</code> est défini, les données sont pre-indexees par pas de temps.
           Le composant compagnon <code>dsfr-data-map-timeline</code> pilote la lecture frame par frame.
         </p>
 
@@ -179,7 +179,7 @@
         </p>
 
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>for</code></td><td>String</td><td><code>""</code></td><td>IDs des layers cibles (virgules). Vide = tous les layers avec <code>time-field</code></td></tr>
             <tr><td><code>speed</code></td><td>Number</td><td><code>1</code></td><td>Multiplicateur de vitesse (0.5, 1, 2, 4)</td></tr>
@@ -195,7 +195,7 @@
           <li>Label du pas courant avec region aria-live</li>
         </ul>
 
-        <h3>Accessibilite</h3>
+        <h3>Accessibilité</h3>
         <ul>
           <li><strong>Pas d'auto-play</strong> — l'animation demarre uniquement sur action utilisateur</li>
           <li><strong>Clavier</strong> : Espace (play/pause), fleches (pas-a-pas), Home/End (debut/fin)</li>
@@ -215,7 +215,7 @@
         </p>
 
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>mode</code></td><td>String</td><td><code>"popup"</code></td><td><code>popup</code> (infobulle Leaflet), <code>modal</code> (modale DSFR), <code>panel-right</code>, <code>panel-left</code></td></tr>
             <tr><td><code>title-field</code></td><td>String</td><td><code>""</code></td><td>Champ pour le titre du panneau/modale</td></tr>
@@ -226,8 +226,8 @@
 
         <h3>Template</h3>
         <p>
-          Le contenu est defini via un element <code>&lt;template&gt;</code> enfant avec interpolation
-          <code>{{champ}}</code>. Sans template, un tableau cle/valeur est genere automatiquement.
+          Le contenu est défini via un element <code>&lt;template&gt;</code> enfant avec interpolation
+          <code>{{champ}}</code>. Sans template, un tableau clé/valeur est genere automatiquement.
         </p>
 
         <h3>Modes</h3>
@@ -385,7 +385,7 @@
           Les styles des clusters suivent les tokens DSFR.
         </p>
 
-        <h3>Pipeline de donnees</h3>
+        <h3>Pipeline de données</h3>
         <div class="code-block"><pre>dsfr-data-source (A) ──┐
                        ├──► dsfr-data-map
 dsfr-data-source (B) ──┘     ├── dsfr-data-map-layer (source="A", type="geoshape")

--- a/specs/components/dsfr-data-normalize.html
+++ b/specs/components/dsfr-data-normalize.html
@@ -41,15 +41,15 @@
     base-path="../">
     <div slot="content">
         <p class="fr-text--lead">
-          Composant intermediaire de normalisation et nettoyage des donnees.
+          Composant intermediaire de normalisation et nettoyage des données.
           Se place entre <code>&lt;dsfr-data-source&gt;</code> et <code>&lt;dsfr-data-query&gt;</code>
-          pour nettoyer les donnees avant traitement.
+          pour nettoyer les données avant traitement.
         </p>
 
         <div class="fr-callout fr-callout--blue-france">
           <p class="fr-callout__text">
-            <strong>Invisible :</strong> Ce composant ne rend rien visuellement. Il normalise les donnees
-            et les redistribue aux composants en aval via le systeme d'evenements.
+            <strong>Invisible :</strong> Ce composant ne rend rien visuellement. Il normalise les données
+            et les redistribue aux composants en aval via le systeme d'événements.
           </p>
         </div>
 
@@ -59,46 +59,46 @@
             <code>dsfr-data-source</code> &rarr; <strong><code>dsfr-data-normalize</code></strong> &rarr; <code>dsfr-data-query</code> &rarr; <code>dsfr-data-chart</code>
           </p>
           <p>
-            Normaliser <strong>avant</strong> <code>dsfr-data-query</code> permet aux filtres et agregations de travailler
-            sur des donnees propres (evite les comparaisons string vs number).
+            Normaliser <strong>avant</strong> <code>dsfr-data-query</code> permet aux filtres et agrégations de travailler
+            sur des données propres (evite les comparaisons string vs number).
           </p>
         </div>
 
         <h2>Cas d'usage</h2>
         <ul>
-          <li><strong>Nombres en string</strong> : valeurs numeriques stockees comme texte (<code>"1234"</code> au lieu de <code>1234</code>)</li>
+          <li><strong>Nombres en string</strong> : valeurs numériques stockees comme texte (<code>"1234"</code> au lieu de <code>1234</code>)</li>
           <li><strong>Separateurs decimaux</strong> : virgule francaise vs point international (<code>"12,5"</code> vs <code>"12.5"</code>)</li>
           <li><strong>Caracteres speciaux</strong> : balises HTML, espaces superflus dans les valeurs</li>
-          <li><strong>Libelles peu clairs</strong> : cles d'API cryptiques a renommer pour la lisibilite</li>
+          <li><strong>Libelles peu clairs</strong> : clés d'API cryptiques a renommer pour la lisibilite</li>
           <li><strong>Valeurs manquantes</strong> : remplacer <code>N/A</code>, <code>n.d.</code>, <code>-</code> par des valeurs exploitables</li>
           <li><strong>Decimales parasites</strong> : arrondir <code>32073247.269999996</code> a <code>32073247</code></li>
-          <li><strong>Objets imbriques</strong> : aplatir un sous-objet pour remonter ses cles au premier niveau</li>
+          <li><strong>Objets imbriques</strong> : aplatir un sous-objet pour remonter ses clés au premier niveau</li>
         </ul>
 
         <h2>Attributs</h2>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>id</code></td><td>String</td><td>-</td><td><strong>Requis.</strong> Identifiant de la sortie.</td></tr>
             <tr><td><code>source</code></td><td>String</td><td><code>""</code></td><td><strong>Requis.</strong> ID de la source a ecouter.</td></tr>
             <tr><td><code>numeric</code></td><td>String</td><td><code>""</code></td><td>Champs a forcer en nombre (virgule-separes).</td></tr>
-            <tr><td><code>numeric-auto</code></td><td>Boolean</td><td><code>false</code></td><td>Detection et conversion automatique des champs numeriques.</td></tr>
-            <tr><td><code>rename</code></td><td>String</td><td><code>""</code></td><td>Renommage de cles : <code>"ancien:nouveau | ancien2:nouveau2"</code></td></tr>
+            <tr><td><code>numeric-auto</code></td><td>Boolean</td><td><code>false</code></td><td>Detection et conversion automatique des champs numériques.</td></tr>
+            <tr><td><code>rename</code></td><td>String</td><td><code>""</code></td><td>Renommage de clés : <code>"ancien:nouveau | ancien2:nouveau2"</code></td></tr>
             <tr><td><code>trim</code></td><td>Boolean</td><td><code>false</code></td><td>Supprime les espaces en debut/fin des valeurs string.</td></tr>
             <tr><td><code>strip-html</code></td><td>Boolean</td><td><code>false</code></td><td>Supprime les balises HTML des valeurs string.</td></tr>
             <tr><td><code>replace</code></td><td>String</td><td><code>""</code></td><td>Remplacement global de valeurs : <code>"N/A: | n.d.: | -:0"</code></td></tr>
             <tr><td><code>replace-fields</code></td><td>String</td><td><code>""</code></td><td>Remplacement cible par champ : <code>"CHAMP:ancien:nouveau | CHAMP2:a:n"</code>. Ne remplace que dans le champ specifie. Combinable avec <code>replace</code>.</td></tr>
-            <tr><td><code>flatten</code></td><td>String</td><td><code>""</code></td><td>Cle du sous-objet a aplatir au premier niveau. Supporte la dot notation (<code>"data.attributes"</code>).</td></tr>
-            <tr><td><code>round</code></td><td>String</td><td><code>""</code></td><td>Arrondit les champs numeriques. Format : <code>"champ1, champ2"</code> (0 decimales) ou <code>"champ1:2, champ2:0"</code> (N decimales).</td></tr>
-            <tr><td><code>lowercase-keys</code></td><td>Boolean</td><td><code>false</code></td><td>Met toutes les cles en minuscules.</td></tr>
-            <tr><td><code>compute</code></td><td>String</td><td><code>""</code></td><td>Colonnes calculees (ligne a ligne, en dernier). Format : <code>"cible = expression; cible2 = expr2"</code>. Supporte l'arithmetique <code>+ - * /</code>, la concatenation texte (<code>+</code> avec litteraux <code>'entre quotes'</code>) et les parentheses. Ex : <code>"pct = valeur * 100; serie = Indicateurs + ' / ' + Sous_theme"</code>. Hors perimetre : conditions, fonctions, calculs sur valeurs agregees.</td></tr>
+            <tr><td><code>flatten</code></td><td>String</td><td><code>""</code></td><td>Clé du sous-objet a aplatir au premier niveau. Supporte la dot notation (<code>"data.attributes"</code>).</td></tr>
+            <tr><td><code>round</code></td><td>String</td><td><code>""</code></td><td>Arrondit les champs numériques. Format : <code>"champ1, champ2"</code> (0 decimales) ou <code>"champ1:2, champ2:0"</code> (N decimales).</td></tr>
+            <tr><td><code>lowercase-keys</code></td><td>Boolean</td><td><code>false</code></td><td>Met toutes les clés en minuscules.</td></tr>
+            <tr><td><code>compute</code></td><td>String</td><td><code>""</code></td><td>Colonnes calculees (ligne a ligne, en dernier). Format : <code>"cible = expression; cible2 = expr2"</code>. Supporte l'arithmetique <code>+ - * /</code>, la concatenation texte (<code>+</code> avec litteraux <code>'entre quotes'</code>) et les parentheses. Ex : <code>"pct = valeur * 100; série = Indicateurs + ' / ' + Sous_theme"</code>. Hors perimetre : conditions, fonctions, calculs sur valeurs agregees.</td></tr>
           </tbody>
         </table>
 
         <div class="fr-callout fr-mt-3w">
           <p class="fr-callout__text">
             <strong>Separateurs :</strong> <code>rename</code> et <code>replace</code> utilisent le pipe <code>|</code>
-            pour separer les paires, et <code>:</code> pour separer la cle de la valeur.
+            pour separer les paires, et <code>:</code> pour separer la clé de la valeur.
             <code>replace-fields</code> utilise le format <code>CHAMP:pattern:remplacement</code> (les 2 premiers <code>:</code> sont des delimiteurs).
             <code>numeric</code> utilise la virgule.
           </p>
@@ -106,7 +106,7 @@
 
         <!-- Exemple 1 : conversion numerique + renommage -->
         <h2 class="fr-mt-4w">Exemple : trim + renommage</h2>
-        <p>Les donnees brutes RappelConso contiennent des noms de colonnes longs et techniques.
+        <p>Les données brutes RappelConso contiennent des noms de colonnes longs et techniques.
           On renomme les colonnes pour la lisibilite et on nettoie les espaces superflus.</p>
 
         <dsfr-data-normalize
@@ -118,7 +118,7 @@
 
         <div class="fr-grid-row fr-grid-row--gutters fr-mt-2w">
           <div class="fr-col-12 fr-col-md-6">
-            <h3>Donnees brutes (JSON)</h3>
+            <h3>Données brutes (JSON)</h3>
             <pre><code>{
   "modeles_ou_references": " Lot 2024-ABC ",
   "categorie_produit": "Alimentation",
@@ -131,7 +131,7 @@
             <h3>Apres normalisation</h3>
             <pre><code>{
   "Produit": "Lot 2024-ABC",       <em>// trim + rename</em>
-  "Categorie": "Alimentation",     <em>// rename</em>
+  "Catégorie": "Alimentation",     <em>// rename</em>
   "Marque": "Ma Marque",           <em>// rename</em>
   "Date": "2024-06-15",            <em>// rename</em>
   "Motif": "Presence de Listeria"  <em>// rename</em>
@@ -148,10 +148,10 @@
 
 &lt;dsfr-data-normalize id="clean" source="raw"
   trim
-  rename="modeles_ou_references:Produit | categorie_produit:Categorie | marque_produit:Marque | date_publication:Date | motif_rappel:Motif"&gt;
+  rename="modeles_ou_references:Produit | categorie_produit:Catégorie | marque_produit:Marque | date_publication:Date | motif_rappel:Motif"&gt;
 &lt;/dsfr-data-normalize&gt;
 
-&lt;!-- Les donnees normalisees sont pretes pour query/chart --&gt;
+&lt;!-- Les données normalisees sont pretes pour query/chart --&gt;
 &lt;dsfr-data-list source="clean" pagination="5"&gt;&lt;/dsfr-data-list&gt;</code></pre>
 
         <!-- Exemple 2 : pipeline complet -->
@@ -184,7 +184,7 @@
         <p>
           L'API INSEE Melodi retourne des codes de dimension (AGE: <code>"Y30T39"</code>, PCS: <code>"3"</code>).
           <code>replace-fields</code> permet de les decoder sans affecter les autres champs
-          qui pourraient contenir les memes valeurs.
+          qui pourraient contenir les mêmes valeurs.
         </p>
 
         <pre><code>&lt;dsfr-data-source id="raw" api-type="insee"

--- a/specs/components/dsfr-data-podium.html
+++ b/specs/components/dsfr-data-podium.html
@@ -30,11 +30,11 @@
 
         <h2>Attributs</h2>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>source</code></td><td>String</td><td><code>""</code></td><td>ID du <code>&lt;dsfr-data-source&gt;</code> ou <code>&lt;dsfr-data-query&gt;</code> (requis)</td></tr>
             <tr><td><code>label-field</code></td><td>String</td><td><code>""</code></td><td>Chemin vers le champ label (supporte dot notation)</td></tr>
-            <tr><td><code>value-field</code></td><td>String</td><td><code>""</code></td><td>Chemin vers le champ valeur numerique</td></tr>
+            <tr><td><code>value-field</code></td><td>String</td><td><code>""</code></td><td>Chemin vers le champ valeur numérique</td></tr>
             <tr><td><code>subtitle</code></td><td>String</td><td><code>""</code></td><td>Texte fixe affiche sous chaque label</td></tr>
             <tr><td><code>subtitle-field</code></td><td>String</td><td><code>""</code></td><td>Chemin vers un champ pour le sous-titre (prioritaire sur subtitle)</td></tr>
             <tr><td><code>value-unit</code></td><td>String</td><td><code>""</code></td><td>Unite affichee apres la valeur</td></tr>
@@ -49,7 +49,7 @@
         <table class="attr-table">
           <thead><tr><th>Palette</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>sequentialDescending</code></td><td>Bleu fonce vers bleu clair (defaut) — ideal pour les classements</td></tr>
+            <tr><td><code>sequentialDescending</code></td><td>Bleu fonce vers bleu clair (défaut) — ideal pour les classements</td></tr>
             <tr><td><code>sequentialAscending</code></td><td>Bleu clair vers bleu fonce</td></tr>
             <tr><td><code>categorical</code></td><td>Couleurs contrastees — ideal quand les items ne sont pas ordonnes</td></tr>
             <tr><td><code>neutral</code></td><td>Niveaux de gris</td></tr>
@@ -83,7 +83,7 @@
         </section>
 
         <section class="demo-section">
-          <h3>2. Top 3 avec palette categorielle</h3>
+          <h3>2. Top 3 avec palette catégorielle</h3>
           <dsfr-data-podium
             source="sites"
             label-field="nom"
@@ -153,7 +153,7 @@
         </section>
 
         <section class="demo-section">
-          <h3>5. Avec dsfr-data-query (agregation par ministere)</h3>
+          <h3>5. Avec dsfr-data-query (agrégation par ministere)</h3>
           <dsfr-data-query id="par-ministere" source="sites"
             group-by="ministere"
             aggregate="score_rgaa:avg:score_moyen"

--- a/specs/components/dsfr-data-query.html
+++ b/specs/components/dsfr-data-query.html
@@ -38,16 +38,16 @@
     base-path="../">
     <div slot="content">
         <p class="fr-text--lead">
-          Composant de transformation de donnees.
-          Filtre, groupe, agrege et trie les donnees recues d'une <code>&lt;dsfr-data-source&gt;</code>
+          Composant de transformation de données.
+          Filtre, groupe, agrège et trie les données recues d'une <code>&lt;dsfr-data-source&gt;</code>
           avant de les transmettre aux composants de visualisation.
           Ne fait aucun fetch HTTP : c'est un pur transformateur.
         </p>
 
         <div class="fr-callout fr-callout--blue-france">
           <p class="fr-callout__text">
-            <strong>Invisible :</strong> Ce composant ne rend rien visuellement. Il transforme les donnees
-            et les redistribue aux composants de visualisation via le systeme d'evenements.
+            <strong>Invisible :</strong> Ce composant ne rend rien visuellement. Il transforme les données
+            et les redistribue aux composants de visualisation via le systeme d'événements.
           </p>
         </div>
 
@@ -59,7 +59,7 @@
         </p>
 
         <h2 id="modes">Fonctionnement</h2>
-        <p><code>&lt;dsfr-data-query&gt;</code> est un pur transformateur de donnees. Il recoit les donnees
+        <p><code>&lt;dsfr-data-query&gt;</code> est un pur transformateur de données. Il recoit les données
           d'une <code>&lt;dsfr-data-source&gt;</code> (ou <code>&lt;dsfr-data-normalize&gt;</code>) via l'attribut <code>source</code>
           et applique des transformations client-side (filter, group-by, aggregate, sort, limit).</p>
 
@@ -67,22 +67,22 @@
         <table class="attr-table">
           <thead><tr><th>Attribut</th><th>Type</th><th>Format / Valeurs</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>id</code></td><td>String</td><td><code>id="mon-query"</code></td><td>Identifiant unique (requis). Les composants de visualisation l'utilisent pour s'abonner aux donnees transformees.</td></tr>
+            <tr><td><code>id</code></td><td>String</td><td><code>id="mon-query"</code></td><td>Identifiant unique (requis). Les composants de visualisation l'utilisent pour s'abonner aux données transformees.</td></tr>
             <tr><td><code>source</code></td><td>String</td><td><code>source="id-source"</code></td><td>ID de la <code>&lt;dsfr-data-source&gt;</code> ou <code>&lt;dsfr-data-normalize&gt;</code> a ecouter (requis)</td></tr>
             <tr><td><code>where</code></td><td>String</td><td><code>"champ:op:val, ..."</code></td><td>Filtres. Plusieurs filtres separes par <code>,</code> (logique ET)</td></tr>
-            <tr><td><code>filter</code></td><td>String</td><td>(meme format que <code>where</code>)</td><td>Alias pour <code>where</code></td></tr>
+            <tr><td><code>filter</code></td><td>String</td><td>(même format que <code>where</code>)</td><td>Alias pour <code>where</code></td></tr>
             <tr><td><code>group-by</code></td><td>String</td><td><code>"champ1, champ2"</code></td><td>Champs de regroupement separes par virgule</td></tr>
-            <tr><td><code>aggregate</code></td><td>String</td><td><code>"champ:fn"</code> ou <code>"champ:fn:alias"</code></td><td>Agregations. Fonctions : <code>count</code> <code>sum</code> <code>avg</code> <code>min</code> <code>max</code>. Modes <code>generic</code> / <code>tabular</code></td></tr>
-            <tr><td><code>order-by</code></td><td>String</td><td><code>"champ:asc"</code> ou <code>"champ:desc"</code></td><td>Tri des resultats. Champs agreges : <code>"champ__fn:desc"</code> ou <code>"alias:desc"</code></td></tr>
+            <tr><td><code>aggregate</code></td><td>String</td><td><code>"champ:fn"</code> ou <code>"champ:fn:alias"</code></td><td>Agrégations. Fonctions : <code>count</code> <code>sum</code> <code>avg</code> <code>min</code> <code>max</code>. Modes <code>generic</code> / <code>tabular</code></td></tr>
+            <tr><td><code>order-by</code></td><td>String</td><td><code>"champ:asc"</code> ou <code>"champ:desc"</code></td><td>Tri des resultats. Champs agrégés : <code>"champ__fn:desc"</code> ou <code>"alias:desc"</code></td></tr>
             <tr><td><code>limit</code></td><td>Number</td><td>Entier positif. <code>0</code> = illimite</td><td>Nombre maximum de resultats</td></tr>
-            <tr><td><code>transform</code></td><td>String</td><td><code>"results"</code>, <code>"data.items"</code></td><td>Chemin JSONPath pour extraire les donnees de la reponse API</td></tr>
+            <tr><td><code>transform</code></td><td>String</td><td><code>"results"</code>, <code>"data.items"</code></td><td>Chemin JSONPath pour extraire les données de la reponse API</td></tr>
             <tr><td><code>server-side</code></td><td>Boolean</td><td>Presence = <code>true</code></td><td>Active le mode server-side pilotable (une page a la fois, ecoute les commandes des composants en aval)</td></tr>
-            <tr><td><code>page-size</code></td><td>Number</td><td>Entier positif. Defaut : <code>20</code></td><td>Taille de page en mode server-side</td></tr>
+            <tr><td><code>page-size</code></td><td>Number</td><td>Entier positif. Défaut : <code>20</code></td><td>Taille de page en mode server-side</td></tr>
             <tr><td><code>refresh</code></td><td>Number</td><td>Entier en secondes. <code>0</code> = off</td><td>Intervalle de rafraichissement automatique</td></tr>
           </tbody>
         </table>
 
-        <h3 class="fr-mt-3w">Syntaxe detaillee des attributs cles</h3>
+        <h3 class="fr-mt-3w">Syntaxe detaillee des attributs clés</h3>
 
         <section class="demo-section">
           <h4><code>where</code> / <code>filter</code> (modes generic et tabular)</h4>
@@ -91,7 +91,7 @@
 where="population:gt:5000, region:in:IDF|OCC|BRE"
 where="email:isnull"                 &lt;!-- pas de valeur pour isnull/isnotnull --&gt;
 where="region:in:IDF|OCC|BRE"        &lt;!-- separateur | pour in/notin --&gt;</pre></div>
-          <p class="fr-text--sm fr-mt-1w">Les valeurs <code>"true"</code>/<code>"false"</code> sont parsees en booleen, les chaines numeriques en nombre.</p>
+          <p class="fr-text--sm fr-mt-1w">Les valeurs <code>"true"</code>/<code>"false"</code> sont parsees en booleen, les chaines numériques en nombre.</p>
         </section>
 
         <section class="demo-section">
@@ -100,17 +100,17 @@ where="region:in:IDF|OCC|BRE"        &lt;!-- separateur | pour in/notin --&gt;</
             Avec alias : <code>champ:fonction:alias</code> — le champ de sortie porte le nom de l'alias.</p>
           <div class="code-block"><pre>aggregate="population:sum"            &lt;!-- sortie : population__sum --&gt;
 aggregate="population:sum:total"      &lt;!-- sortie : total --&gt;
-aggregate="pop:sum:total, pop:count:nb"  &lt;!-- deux agregations --&gt;</pre></div>
+aggregate="pop:sum:total, pop:count:nb"  &lt;!-- deux agrégations --&gt;</pre></div>
           <p class="fr-text--sm fr-mt-1w">Fonctions : <code>count</code> (nombre de lignes), <code>sum</code>, <code>avg</code>, <code>min</code>, <code>max</code>.</p>
         </section>
 
         <section class="demo-section">
           <h4><code>order-by</code></h4>
-          <p>Format : <code>champ:direction</code> ou <code>champ</code> (defaut : <code>asc</code>).<br>
-            Pour trier des resultats agreges, utiliser le nom du champ de sortie.</p>
+          <p>Format : <code>champ:direction</code> ou <code>champ</code> (défaut : <code>asc</code>).<br>
+            Pour trier des resultats agrégés, utiliser le nom du champ de sortie.</p>
           <div class="code-block"><pre>order-by="nom:asc"
-order-by="population__sum:desc"       &lt;!-- champ agrege sans alias --&gt;
-order-by="total:desc"                 &lt;!-- champ agrege avec alias --&gt;</pre></div>
+order-by="population__sum:desc"       &lt;!-- champ agrège sans alias --&gt;
+order-by="total:desc"                 &lt;!-- champ agrège avec alias --&gt;</pre></div>
         </section>
 
         <h2 id="operateurs" class="fr-mt-4w">Operateurs de filtre</h2>
@@ -136,9 +136,9 @@ order-by="total:desc"                 &lt;!-- champ agrege avec alias --&gt;</pr
         <h2 id="exemples" class="fr-mt-4w">Exemples</h2>
 
         <section class="demo-section">
-          <h3>Mode generic : filtrer et trier des donnees existantes</h3>
+          <h3>Mode generic : filtrer et trier des données existantes</h3>
           <p>
-            Recupere les donnees d'une <code>&lt;dsfr-data-source&gt;</code> et les filtre/trie cote client.
+            Recupere les données d'une <code>&lt;dsfr-data-source&gt;</code> et les filtre/trie cote client.
             Ici on filtre les 10 premieres lignes triees par nom.
             <a href="../../guide/guide-exemples-query.html#query-datalist" class="fr-link fr-link--sm">Voir l'exemple live</a>
           </p>
@@ -165,9 +165,9 @@ order-by="total:desc"                 &lt;!-- champ agrege avec alias --&gt;</pr
         </section>
 
         <section class="demo-section">
-          <h3>Mode generic : grouper et agreger</h3>
+          <h3>Mode generic : grouper et agréger</h3>
           <p>
-            Regroupe les donnees par region et calcule la somme de la population
+            Regroupe les données par region et calcule la somme de la population
             et le nombre d'enregistrements par groupe.
             <a href="../../guide/guide-exemples-query.html#query-bar" class="fr-link fr-link--sm">Voir l'exemple live</a>
           </p>
@@ -195,7 +195,7 @@ order-by="total:desc"                 &lt;!-- champ agrege avec alias --&gt;</pr
         </section>
 
         <section class="demo-section">
-          <h3>OpenDataSoft : requete serveur via dsfr-data-source</h3>
+          <h3>OpenDataSoft : requête serveur via dsfr-data-source</h3>
           <p>
             Utilise <code>&lt;dsfr-data-source&gt;</code> pour interroger une API OpenDataSoft,
             puis <code>&lt;dsfr-data-query&gt;</code> pour le tri et la limite cote client.
@@ -227,10 +227,10 @@ order-by="total:desc"                 &lt;!-- champ agrege avec alias --&gt;</pr
         </section>
 
         <section class="demo-section">
-          <h3>OpenDataSoft : requete data.economie.gouv.fr via dsfr-data-source</h3>
+          <h3>OpenDataSoft : requête data.economie.gouv.fr via dsfr-data-source</h3>
           <p>
             Utilise <code>&lt;dsfr-data-source&gt;</code> pour interroger une API OpenDataSoft,
-            puis <code>&lt;dsfr-data-query&gt;</code> pour le groupement et l'agregation.
+            puis <code>&lt;dsfr-data-query&gt;</code> pour le groupement et l'agrégation.
             <a href="../../guide/guide-exemples-query.html#query-pie" class="fr-link fr-link--sm">Voir l'exemple live</a>
           </p>
           <div class="code-block"><pre>&lt;dsfr-data-source
@@ -286,7 +286,7 @@ order-by="total:desc"                 &lt;!-- champ agrege avec alias --&gt;</pr
   api-type="opendatasoft"
   dataset-id="mon-dataset-prive"
   base-url="https://mon-instance.opendatasoft.com"
-  headers='{"apikey":"ma-cle-api"}'
+  headers='{"apikey":"ma-clé-api"}'
 &gt;&lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-query
@@ -306,7 +306,7 @@ order-by="total:desc"                 &lt;!-- champ agrege avec alias --&gt;</pr
           <div class="fr-callout fr-mt-2w">
             <p class="fr-callout__text">
               <strong>Securite :</strong> les headers sont visibles dans le code source HTML.
-              Ne les utilisez que pour des cles a acces restreint (lecture seule)
+              Ne les utilisez que pour des clés a acces restreint (lecture seule)
               ou dans des contextes proteges (intranet, applications internes).
             </p>
           </div>
@@ -316,7 +316,7 @@ order-by="total:desc"                 &lt;!-- champ agrege avec alias --&gt;</pr
           <h3>Rafraichissement automatique</h3>
           <p>
             L'attribut <code>refresh</code> sur <code>&lt;dsfr-data-source&gt;</code> permet de re-executer
-            la requete a intervalles reguliers.
+            la requête a intervalles reguliers.
           </p>
           <div class="code-block"><pre>&lt;dsfr-data-source
   id="live-src"
@@ -333,20 +333,20 @@ order-by="total:desc"                 &lt;!-- champ agrege avec alias --&gt;</pr
 &gt;&lt;/dsfr-data-query&gt;</pre></div>
         </section>
 
-        <h2 id="evenements" class="fr-mt-4w">Evenements</h2>
-        <p>Le composant emet les memes evenements que <code>&lt;dsfr-data-source&gt;</code> :</p>
+        <h2 id="evenements" class="fr-mt-4w">Événements</h2>
+        <p>Le composant emet les mêmes événements que <code>&lt;dsfr-data-source&gt;</code> :</p>
         <ul>
-          <li><code>dsfr-data-loaded</code> : Donnees transformees disponibles</li>
+          <li><code>dsfr-data-loaded</code> : Données transformees disponibles</li>
           <li><code>dsfr-data-loading</code> : Traitement en cours</li>
-          <li><code>dsfr-data-error</code> : Erreur de traitement ou de requete</li>
+          <li><code>dsfr-data-error</code> : Erreur de traitement ou de requête</li>
         </ul>
 
         <h2 id="methodes" class="fr-mt-4w">Methodes publiques</h2>
         <table class="attr-table">
-          <thead><tr><th>Methode</th><th>Retour</th><th>Description</th></tr></thead>
+          <thead><tr><th>Méthode</th><th>Retour</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>reload()</code></td><td>void</td><td>Force le rechargement / re-traitement des donnees</td></tr>
-            <tr><td><code>getData()</code></td><td>Array</td><td>Retourne les donnees transformees actuelles</td></tr>
+            <tr><td><code>reload()</code></td><td>void</td><td>Force le rechargement / re-traitement des données</td></tr>
+            <tr><td><code>getData()</code></td><td>Array</td><td>Retourne les données transformees actuelles</td></tr>
             <tr><td><code>isLoading()</code></td><td>Boolean</td><td>Indique si un traitement est en cours</td></tr>
             <tr><td><code>getError()</code></td><td>Error | null</td><td>Retourne l'erreur eventuelle</td></tr>
           </tbody>
@@ -357,12 +357,12 @@ order-by="total:desc"                 &lt;!-- champ agrege avec alias --&gt;</pr
           <p class="fr-callout__text">
             <strong>Pipeline recommande :</strong> Utilisez <code>&lt;dsfr-data-source&gt;</code> pour le fetch HTTP
             et <code>&lt;dsfr-data-query&gt;</code> pour les transformations client-side (filter, group-by, aggregate, sort).
-            Pour les gros volumes, deleguer les agregations a la source via les attributs de <code>&lt;dsfr-data-source&gt;</code>.
+            Pour les gros volumes, deleguer les agrégations a la source via les attributs de <code>&lt;dsfr-data-source&gt;</code>.
           </p>
         </div>
         <div class="fr-callout fr-mt-2w">
           <p class="fr-callout__text">
-            <strong>Nommage des champs agreges :</strong> En mode <code>generic</code>, les champs agreges sont nommes
+            <strong>Nommage des champs agrégés :</strong> En mode <code>generic</code>, les champs agrégés sont nommes
             automatiquement <code>champ__fonction</code> (ex: <code>population__sum</code>, <code>population__count</code>).
             Vous pouvez definir un alias avec le format <code>"champ:fonction:alias"</code>.
           </p>

--- a/specs/components/dsfr-data-search.html
+++ b/specs/components/dsfr-data-search.html
@@ -60,13 +60,13 @@
     <div slot="content">
         <p class="fr-text--lead">
           Composant visuel intermediaire qui affiche un champ de recherche DSFR et filtre
-          les donnees en amont avant de les redistribuer aux composants en aval.
+          les données en amont avant de les redistribuer aux composants en aval.
         </p>
 
         <div class="fr-callout fr-callout--green-emeraude">
           <p class="fr-callout__text">
             <strong>Visuel et intermediaire :</strong> Ce composant affiche un champ de recherche
-            ET redistribue les donnees filtrees aux composants en aval via le systeme d'evenements.
+            ET redistribue les données filtrees aux composants en aval via le systeme d'événements.
             Il se combine naturellement avec <code>dsfr-data-facets</code>.
           </p>
         </div>
@@ -77,7 +77,7 @@
             <code>dsfr-data-source</code> &rarr; <code>dsfr-data-normalize</code> &rarr; <strong><code>dsfr-data-search</code></strong> &rarr; <code>dsfr-data-facets</code> &rarr; <code>dsfr-data-display</code> / <code>dsfr-data-list</code>
           </p>
           <p>
-            La recherche reduit le jeu de donnees, les facettes affinent ensuite.
+            La recherche reduit le jeu de données, les facettes affinent ensuite.
             Les compteurs de facettes se recalculent dynamiquement.
           </p>
         </div>
@@ -92,15 +92,15 @@
 
         <h2>Attributs</h2>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>id</code></td><td>String</td><td>-</td><td><strong>Requis.</strong> Identifiant de la sortie (donnees filtrees).</td></tr>
+            <tr><td><code>id</code></td><td>String</td><td>-</td><td><strong>Requis.</strong> Identifiant de la sortie (données filtrees).</td></tr>
             <tr><td><code>source</code></td><td>String</td><td><code>""</code></td><td><strong>Requis.</strong> ID de la source a ecouter.</td></tr>
             <tr><td><code>fields</code></td><td>String</td><td><code>""</code></td><td>Champs a rechercher (virgule-separes). Vide = tous les champs.</td></tr>
             <tr><td><code>placeholder</code></td><td>String</td><td><code>"Rechercher..."</code></td><td>Placeholder du champ de saisie.</td></tr>
             <tr><td><code>label</code></td><td>String</td><td><code>"Rechercher"</code></td><td>Label du champ (accessible).</td></tr>
             <tr><td><code>debounce</code></td><td>Number</td><td><code>300</code></td><td>Delai en ms avant declenchement du filtre.</td></tr>
-            <tr><td><code>min-length</code></td><td>Number</td><td><code>0</code></td><td>Nombre minimum de caracteres avant declenchement.</td></tr>
+            <tr><td><code>min-length</code></td><td>Number</td><td><code>0</code></td><td>Nombre minimum de caractères avant declenchement.</td></tr>
             <tr><td><code>highlight</code></td><td>Boolean</td><td><code>false</code></td><td>Ajoute <code>_highlight</code> avec <code>&lt;mark&gt;</code> pour dsfr-data-display.</td></tr>
             <tr><td><code>operator</code></td><td>String</td><td><code>"contains"</code></td><td>Mode : <code>contains</code>, <code>starts</code>, <code>words</code>.</td></tr>
             <tr><td><code>sr-label</code></td><td>Boolean</td><td><code>false</code></td><td>Label en sr-only (masque visuellement, accessible).</td></tr>
@@ -115,7 +115,7 @@
         <div class="fr-callout fr-mt-3w">
           <p class="fr-callout__text">
             <strong>Modes de recherche :</strong><br>
-            <code>contains</code> (defaut) : sous-chaine insensible a la casse et aux accents.<br>
+            <code>contains</code> (défaut) : sous-chaine insensible a la casse et aux accents.<br>
             <code>starts</code> : chaque mot du champ doit commencer par le terme.<br>
             <code>words</code> : tous les mots saisis doivent etre presents (dans n'importe quel champ, n'importe quel ordre). Le plus utile pour la recherche multi-criteres.
           </p>
@@ -125,7 +125,7 @@
              Exemple 1 : Recherche seule + Datalist
              ======================================================== -->
         <h2 class="fr-mt-4w">Exemple 1 : recherche simple + tableau</h2>
-        <p>Recherche textuelle sur les champs <code>Produit</code>, <code>Marque</code> et <code>Categorie</code>.
+        <p>Recherche textuelle sur les champs <code>Produit</code>, <code>Marque</code> et <code>Catégorie</code>.
         Le tableau se filtre en temps reel avec un compteur de resultats.</p>
 
         <dsfr-data-search id="elus-searched" source="elus-clean"
@@ -144,15 +144,15 @@
 
         <h3 class="fr-mt-3w">Code</h3>
         <pre><code>&lt;dsfr-data-search id="searched" source="clean"
-  fields="Produit, Marque, Categorie"
-  placeholder="Produit, marque ou categorie..."
+  fields="Produit, Marque, Catégorie"
+  placeholder="Produit, marque ou catégorie..."
   operator="words"
   min-length="2"
   count&gt;
 &lt;/dsfr-data-search&gt;
 
 &lt;dsfr-data-list source="searched"
-  colonnes="Produit, Categorie, Marque, Date"
+  colonnes="Produit, Catégorie, Marque, Date"
   tri="Date:desc"
   pagination="10"&gt;
 &lt;/dsfr-data-list&gt;</code></pre>
@@ -161,7 +161,7 @@
              Exemple 2 : Recherche + Facettes + Display
              ======================================================== -->
         <h2 class="fr-mt-6w">Exemple 2 : recherche + facettes + cartes</h2>
-        <p>La recherche et les facettes se combinent. La recherche reduit le jeu de donnees,
+        <p>La recherche et les facettes se combinent. La recherche reduit le jeu de données,
         les facettes affinent. Les cartes affichent les resultats.</p>
 
         <dsfr-data-search id="elus-search-facets" source="elus-clean"
@@ -186,7 +186,7 @@
                   <p class="fr-card__desc">{{Marque}}</p>
                 </div>
                 <div class="fr-card__footer">
-                  <p class="fr-badge fr-badge--sm fr-badge--blue-france">{{Categorie}}</p>
+                  <p class="fr-badge fr-badge--sm fr-badge--blue-france">{{Catégorie}}</p>
                 </div>
               </div>
             </div>
@@ -195,15 +195,15 @@
 
         <h3 class="fr-mt-3w">Code</h3>
         <pre><code>&lt;dsfr-data-search id="searched" source="clean"
-  fields="Produit, Marque, Categorie"
+  fields="Produit, Marque, Catégorie"
   placeholder="Rechercher un produit rappele..."
   operator="words"
   count&gt;
 &lt;/dsfr-data-search&gt;
 
 &lt;dsfr-data-facets id="filtered" source="searched"
-  fields="Categorie, Marque"
-  labels="Categorie:Categorie | Marque:Marque"
+  fields="Catégorie, Marque"
+  labels="Catégorie:Catégorie | Marque:Marque"
   max-values="6"&gt;
 &lt;/dsfr-data-facets&gt;
 
@@ -216,7 +216,7 @@
           &lt;p class="fr-card__desc"&gt;{{Marque}}&lt;/p&gt;
         &lt;/div&gt;
         &lt;div class="fr-card__footer"&gt;
-          &lt;p class="fr-badge fr-badge--sm"&gt;{{Categorie}}&lt;/p&gt;
+          &lt;p class="fr-badge fr-badge--sm"&gt;{{Catégorie}}&lt;/p&gt;
         &lt;/div&gt;
       &lt;/div&gt;
     &lt;/div&gt;

--- a/specs/components/dsfr-data-source.html
+++ b/specs/components/dsfr-data-source.html
@@ -25,9 +25,9 @@
     base-path="../">
     <div slot="content">
         <p class="fr-text--lead">
-          Composant invisible de connexion aux donnees. Recupere des donnees depuis une API REST
+          Composant invisible de connexion aux données. Recupere des données depuis une API REST
           (URL brute ou via un adapter specialise) et les distribue aux autres composants via
-          le systeme d'evenements. Supporte aussi les donnees JSON inline.
+          le systeme d'événements. Supporte aussi les données JSON inline.
         </p>
 
         <div class="fr-callout fr-callout--blue-france">
@@ -40,12 +40,12 @@
         <div class="fr-callout fr-callout--green-emeraude fr-mb-3w">
           <h4 class="fr-callout__title">dsfr-data-source vs dsfr-data-query</h4>
           <p class="fr-callout__text">
-            <strong><code>dsfr-data-source</code></strong> se connecte a une API, recupere les donnees et les
+            <strong><code>dsfr-data-source</code></strong> se connecte a une API, recupere les données et les
             redistribue. En mode adapter, il gere la pagination automatique, les filtres server-side
             et la pagination pilotable (server-side).<br><br>
             <strong><code>dsfr-data-query</code></strong> est une couche de transformation client-side : il filtre, groupe,
-            agrege et trie les donnees. Il ecoute un <code>dsfr-data-source</code> via l'attribut
-            <code>source</code> et traite les donnees cote client.<br><br>
+            agrège et trie les données. Il ecoute un <code>dsfr-data-source</code> via l'attribut
+            <code>source</code> et traite les données cote client.<br><br>
             <strong>Pattern recommande :</strong> <code>&lt;dsfr-data-source api-type="..."&gt;</code> +
             <code>&lt;dsfr-data-query source="..."&gt;</code> pour combiner fetch serveur et
             transformation client.
@@ -65,18 +65,18 @@
             <tr>
               <td><strong>Adapter</strong></td>
               <td>Active via <code>api-type</code> (sans <code>url</code>). L'adapter gere la construction d'URL,
-                la pagination automatique, les filtres et le parsing specifiques au provider
+                la pagination automatique, les filtres et le parsing spécifiques au provider
                 (OpenDataSoft, Tabular, Grist).</td>
             </tr>
             <tr>
               <td><strong>Inline data</strong></td>
-              <td>Donnees JSON passees directement via l'attribut <code>data</code>. Pas de fetch HTTP.</td>
+              <td>Données JSON passees directement via l'attribut <code>data</code>. Pas de fetch HTTP.</td>
             </tr>
           </tbody>
         </table>
 
         <h3 class="fr-mt-3w">Types d'adapter</h3>
-        <p>En mode adapter, l'attribut <code>api-type</code> selectionne le provider :</p>
+        <p>En mode adapter, l'attribut <code>api-type</code> sélectionne le provider :</p>
         <table class="attr-table">
           <thead><tr><th>api-type</th><th>API</th><th>Identifiant requis</th><th>Pagination</th><th>Max records</th></tr></thead>
           <tbody>
@@ -96,7 +96,7 @@
             </tr>
             <tr>
               <td><code>grist</code></td>
-              <td>Grist (numerique.gouv.fr, getgrist.com)</td>
+              <td>Grist (numérique.gouv.fr, getgrist.com)</td>
               <td><code>base-url</code></td>
               <td>offset, 100/page, illimitee</td>
               <td>Illimite</td>
@@ -110,13 +110,13 @@
         <table class="attr-table">
           <thead><tr><th>Attribut</th><th>Type</th><th>Format / Valeurs</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>id</code></td><td>String</td><td><code>id="ma-source"</code></td><td>Identifiant unique (requis). Les composants en aval l'utilisent pour s'abonner aux donnees.</td></tr>
+            <tr><td><code>id</code></td><td>String</td><td><code>id="ma-source"</code></td><td>Identifiant unique (requis). Les composants en aval l'utilisent pour s'abonner aux données.</td></tr>
             <tr><td><code>refresh</code></td><td>Number</td><td>Entier en secondes. <code>0</code> = off</td><td>Intervalle de rafraichissement automatique</td></tr>
-            <tr><td><code>transform</code></td><td>String</td><td><code>"results"</code>, <code>"data.items"</code></td><td>Chemin JSON pour extraire les donnees de la reponse API</td></tr>
+            <tr><td><code>transform</code></td><td>String</td><td><code>"results"</code>, <code>"data.items"</code></td><td>Chemin JSON pour extraire les données de la reponse API</td></tr>
             <tr><td><code>headers</code></td><td>String</td><td><code>'{"apikey":"abc123"}'</code></td><td>Headers HTTP en JSON (API key, Bearer token, etc.)</td></tr>
-            <tr><td><code>api-key-ref</code></td><td>String</td><td><code>"tmdb"</code></td><td>Reference vers une cle API declaree dans <code>window.DSFR_DATA_KEYS</code>.
+            <tr><td><code>api-key-ref</code></td><td>String</td><td><code>"tmdb"</code></td><td>Reference vers une clé API declaree dans <code>window.DSFR_DATA_KEYS</code>.
               La valeur est injectee comme header <code>Authorization</code>. Prioritaire sur un header Authorization explicite.</td></tr>
-            <tr><td><code>cache-ttl</code></td><td>Number</td><td>Entier en secondes. Defaut : <code>3600</code></td><td>Duree de cache serveur en mode DB (0 = pas de cache)</td></tr>
+            <tr><td><code>cache-ttl</code></td><td>Number</td><td>Entier en secondes. Défaut : <code>3600</code></td><td>Duree de cache serveur en mode DB (0 = pas de cache)</td></tr>
           </tbody>
         </table>
 
@@ -125,13 +125,13 @@
           <thead><tr><th>Attribut</th><th>Type</th><th>Format / Valeurs</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>url</code></td><td>String</td><td>URL relative ou absolue</td><td>URL de l'API REST a appeler</td></tr>
-            <tr><td><code>method</code></td><td>String</td><td><code>GET</code> | <code>POST</code></td><td>Methode HTTP. Defaut : <code>GET</code></td></tr>
+            <tr><td><code>method</code></td><td>String</td><td><code>GET</code> | <code>POST</code></td><td>Méthode HTTP. Défaut : <code>GET</code></td></tr>
             <tr><td><code>params</code></td><td>String</td><td><code>'{"limit": 100}'</code></td><td>GET : ajoutes a l'URL comme query params. POST : envoyes comme body JSON.</td></tr>
             <tr><td><code>paginate</code></td><td>Boolean</td><td>Presence = <code>true</code></td><td>Active la pagination manuelle. Injecte <code>page</code> et <code>page_size</code> dans l'URL.
-              Auto-extrait <code>json.data</code> si aucun <code>transform</code> n'est defini.</td></tr>
-            <tr><td><code>page-size</code></td><td>Number</td><td>Entier positif. Defaut : <code>20</code></td><td>Taille de page pour la pagination manuelle</td></tr>
+              Auto-extrait <code>json.data</code> si aucun <code>transform</code> n'est défini.</td></tr>
+            <tr><td><code>page-size</code></td><td>Number</td><td>Entier positif. Défaut : <code>20</code></td><td>Taille de page pour la pagination manuelle</td></tr>
             <tr><td><code>use-proxy</code></td><td>Boolean</td><td>Presence = <code>true</code></td><td>Force le passage par le proxy CORS generique (<code>/cors-proxy</code>).
-              Utile pour les APIs externes qui ne gerent pas CORS. La requete est routee cote serveur
+              Utile pour les APIs externes qui ne gerent pas CORS. La requête est routee cote serveur
               via un header <code>X-Target-URL</code>.</td></tr>
           </tbody>
         </table>
@@ -147,10 +147,10 @@
             <tr><td><code>where</code></td><td>String</td><td>Colon : <code>"champ:op:val"</code><br>ODS : ODSQL libre</td><td>Clause WHERE statique. Format depend du provider (voir section Filtres).</td></tr>
             <tr><td><code>select</code></td><td>String</td><td><code>"sum(pop) as total, region"</code></td><td>Clause SELECT en syntaxe ODSQL. Mode <code>opendatasoft</code> uniquement.</td></tr>
             <tr><td><code>group-by</code></td><td>String</td><td><code>"champ1, champ2"</code></td><td>Champs de regroupement. Delegue au serveur si le provider le supporte.</td></tr>
-            <tr><td><code>aggregate</code></td><td>String</td><td><code>"champ:fn"</code> ou <code>"champ:fn:alias"</code></td><td>Agregations server-side. Fonctions : <code>count</code> <code>sum</code> <code>avg</code> <code>min</code> <code>max</code>.</td></tr>
+            <tr><td><code>aggregate</code></td><td>String</td><td><code>"champ:fn"</code> ou <code>"champ:fn:alias"</code></td><td>Agrégations server-side. Fonctions : <code>count</code> <code>sum</code> <code>avg</code> <code>min</code> <code>max</code>.</td></tr>
             <tr><td><code>order-by</code></td><td>String</td><td><code>"champ:asc"</code> ou <code>"champ:desc"</code></td><td>Tri des resultats. Peut etre surcharge dynamiquement par un <code>dsfr-data-list</code>.</td></tr>
             <tr><td><code>limit</code></td><td>Number</td><td>Entier positif. <code>0</code> = illimite</td><td>Nombre maximum de resultats</td></tr>
-            <tr><td><code>max-records</code></td><td>Number</td><td>Entier positif. <code>0</code> = plafond par defaut de l'adapter</td><td>Plafond du fetchAll en mode adapter (#233). Le defaut ODS (1 000) est un garde-fou, pas une limite API : le relever augmente le nombre de requetes en boucle et le poids memoire — a faire en connaissance de cause (dashboards « un fetch, N agregations client »).</td></tr>
+            <tr><td><code>max-records</code></td><td>Number</td><td>Entier positif. <code>0</code> = plafond par défaut de l'adapter</td><td>Plafond du fetchAll en mode adapter (#233). Le défaut ODS (1 000) est un garde-fou, pas une limite API : le relever augmente le nombre de requêtes en boucle et le poids memoire — a faire en connaissance de cause (dashboards « un fetch, N agrégations client »).</td></tr>
             <tr><td><code>server-side</code></td><td>Boolean</td><td>Presence = <code>true</code></td><td>Mode pagination pilotable : charge une page a la fois, ecoute les commandes
               des composants en aval (<code>dsfr-data-list</code>, <code>dsfr-data-facets</code>, <code>dsfr-data-search</code>).</td></tr>
           </tbody>
@@ -160,7 +160,7 @@
         <table class="attr-table">
           <thead><tr><th>Attribut</th><th>Type</th><th>Format / Valeurs</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>data</code></td><td>String</td><td>JSON valide (tableau ou objet)</td><td>Donnees inline. Pas de fetch HTTP, les donnees sont parsees et emises directement.</td></tr>
+            <tr><td><code>data</code></td><td>String</td><td>JSON valide (tableau ou objet)</td><td>Données inline. Pas de fetch HTTP, les données sont parsees et emises directement.</td></tr>
           </tbody>
         </table>
 
@@ -182,11 +182,11 @@ where="email:isnull"</pre></div>
           <p>
             Les composants en aval (<code>dsfr-data-facets</code>, <code>dsfr-data-search</code>) peuvent ajouter
             des filtres dynamiques via le systeme de commandes. Ces filtres sont <strong>fusionnes</strong>
-            avec le <code>where</code> statique a chaque requete.
+            avec le <code>where</code> statique a chaque requête.
           </p>
           <p>
-            Chaque composant envoie un overlay identifie par une cle unique (<code>whereKey</code>).
-            Les overlays sont combines en <strong>ET logique</strong>. La methode <code>getEffectiveWhere()</code>
+            Chaque composant envoie un overlay identifie par une clé unique (<code>whereKey</code>).
+            Les overlays sont combines en <strong>ET logique</strong>. La méthode <code>getEffectiveWhere()</code>
             retourne la clause WHERE fusionnee.
           </p>
           <div class="code-block"><pre>&lt;!-- WHERE statique + overlays dynamiques des facettes et recherche --&gt;
@@ -265,13 +265,13 @@ where="email:isnull"</pre></div>
 &gt;&lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-list source="browse"
-  colonnes="modeles_ou_references:Produit, categorie_produit:Categorie, marque_produit:Marque"
+  colonnes="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque"
   pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</pre></div>
           <div class="fr-callout fr-callout--blue-ecume fr-mt-2w">
             <p class="fr-callout__text">
               <strong>Auto-extraction :</strong> en mode <code>paginate</code>, pas besoin de <code>transform="data"</code>.
-              Les donnees sont automatiquement extraites depuis <code>json.data</code> et les metadonnees de pagination
+              Les données sont automatiquement extraites depuis <code>json.data</code> et les metadonnees de pagination
               (<code>json.meta</code>) sont stockees pour calculer le nombre total de pages.
             </p>
           </div>
@@ -290,7 +290,7 @@ where="email:isnull"</pre></div>
 &gt;&lt;/dsfr-data-source&gt;</pre></div>
           <div class="fr-callout fr-callout--blue-ecume fr-mt-2w">
             <p class="fr-callout__text">
-              <strong>Fonctionnement :</strong> en dev, la requete est routee via le middleware Vite
+              <strong>Fonctionnement :</strong> en dev, la requête est routee via le middleware Vite
               <code>/cors-proxy</code>. En production, elle passe par l'endpoint equivalent sur le serveur proxy
               (<code>&lt;votre-proxy&gt;/cors-proxy</code>).
               L'URL cible est transmise dans le header <code>X-Target-URL</code>.
@@ -302,7 +302,7 @@ where="email:isnull"</pre></div>
           <h3>Mode adapter : OpenDataSoft</h3>
           <p>
             L'adapter gere automatiquement la construction d'URL, la pagination et le parsing.
-            Pagination automatique (toutes les pages en une seule requete) jusqu'a 1 000 records.
+            Pagination automatique (toutes les pages en une seule requête) jusqu'a 1 000 records.
           </p>
           <div class="code-block"><pre>&lt;dsfr-data-source
   id="elus"
@@ -339,7 +339,7 @@ where="email:isnull"</pre></div>
 &gt;&lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-list source="src-ods"
-  colonnes="modeles_ou_references:Produit, categorie_produit:Categorie, marque_produit:Marque, date_publication:Date"
+  colonnes="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque, date_publication:Date"
   server-tri
   pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</pre></div>
@@ -348,14 +348,14 @@ where="email:isnull"</pre></div>
         <section class="demo-section">
           <h3>Mode adapter : Grist</h3>
           <p>
-            L'adapter Grist se connecte aux instances Grist (numerique.gouv.fr ou getgrist.com).
-            Il detecte automatiquement si la requete necessite le mode SQL (groupement, agregation,
+            L'adapter Grist se connecte aux instances Grist (numérique.gouv.fr ou getgrist.com).
+            Il détecté automatiquement si la requête necessite le mode SQL (groupement, agrégation,
             operateurs avances) ou le mode Records standard.
           </p>
           <div class="code-block"><pre>&lt;dsfr-data-source
   id="grist-data"
   api-type="grist"
-  base-url="https://grist.numerique.gouv.fr/api/docs/DOC_ID/tables/TABLE_ID/records"
+  base-url="https://grist.numérique.gouv.fr/api/docs/DOC_ID/tables/TABLE_ID/records"
   headers='{"Authorization": "Bearer TOKEN"}'
 &gt;&lt;/dsfr-data-source&gt;
 
@@ -368,7 +368,7 @@ where="email:isnull"</pre></div>
           <div class="fr-callout fr-callout--blue-ecume fr-mt-2w">
             <p class="fr-callout__text">
               <strong>Flatten requis :</strong> Grist retourne les champs imbriques dans un objet <code>fields</code>.
-              Utilisez <code>&lt;dsfr-data-normalize flatten&gt;</code> pour aplatir les donnees avant de les exploiter.
+              Utilisez <code>&lt;dsfr-data-normalize flatten&gt;</code> pour aplatir les données avant de les exploiter.
             </p>
           </div>
         </section>
@@ -389,7 +389,7 @@ where="email:isnull"</pre></div>
 &gt;&lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-list source="srv"
-  colonnes="modeles_ou_references:Produit, categorie_produit:Categorie, marque_produit:Marque"
+  colonnes="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque"
   server-tri
   pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</pre></div>
@@ -398,8 +398,8 @@ where="email:isnull"</pre></div>
         <section class="demo-section">
           <h3>Mode inline data</h3>
           <p>
-            L'attribut <code>data</code> permet de passer des donnees JSON directement,
-            sans aucun appel HTTP. Utile pour les exemples, prototypes ou donnees statiques.
+            L'attribut <code>data</code> permet de passer des données JSON directement,
+            sans aucun appel HTTP. Utile pour les exemples, prototypes ou données statiques.
           </p>
           <div class="code-block"><pre>&lt;dsfr-data-source
   id="inline"
@@ -412,11 +412,11 @@ where="email:isnull"</pre></div>
         </section>
 
         <section class="demo-section">
-          <h3>Registre de cles API (<code>api-key-ref</code>)</h3>
+          <h3>Registre de clés API (<code>api-key-ref</code>)</h3>
           <p>
             Au lieu d'ecrire les tokens directement dans les attributs HTML, declarez-les une seule fois
             dans un registre global <code>window.DSFR_DATA_KEYS</code>, puis referencez-les par nom
-            avec <code>api-key-ref</code>. La cle est injectee comme header <code>Authorization</code>.
+            avec <code>api-key-ref</code>. La clé est injectee comme header <code>Authorization</code>.
           </p>
           <div class="code-block"><pre>&lt;script&gt;
   window.DSFR_DATA_KEYS = {
@@ -433,18 +433,18 @@ where="email:isnull"</pre></div>
 &gt;&lt;/dsfr-data-source&gt;</pre></div>
           <div class="fr-callout fr-callout--blue-ecume fr-mt-2w">
             <p class="fr-callout__text">
-              <strong>Comportement :</strong> si <code>api-key-ref</code> est defini et que la cle existe
+              <strong>Comportement :</strong> si <code>api-key-ref</code> est défini et que la clé existe
               dans <code>window.DSFR_DATA_KEYS</code>, elle est injectee en header <code>Authorization</code>
-              a chaque requete. Si la cle n'est pas trouvee, un avertissement est emis dans la console et
-              la requete est envoyee sans authentification. Fonctionne avec les deux modes (URL brute et adapter).
+              a chaque requête. Si la clé n'est pas trouvee, un avertissement est emis dans la console et
+              la requête est envoyee sans authentification. Fonctionne avec les deux modes (URL brute et adapter).
             </p>
           </div>
           <div class="fr-callout fr-callout--orange-terre-battue fr-mt-2w">
             <p class="fr-callout__text">
-              <strong>Securite :</strong> les cles restent lisibles par tout script sur la page
-              (meme modele de securite que l'attribut <code>headers</code>). Cette fonctionnalite est une
-              commodite pour separer la declaration des cles du markup, pas un mecanisme de protection.
-              Pour les cles sensibles, utilisez un proxy serveur.
+              <strong>Securite :</strong> les clés restent lisibles par tout script sur la page
+              (même modele de securite que l'attribut <code>headers</code>). Cette fonctionnalite est une
+              commodite pour separer la declaration des clés du markup, pas un mecanisme de protection.
+              Pour les clés sensibles, utilisez un proxy serveur.
             </p>
           </div>
         </section>
@@ -452,7 +452,7 @@ where="email:isnull"</pre></div>
         <section class="demo-section">
           <h3>Rafraichissement automatique</h3>
           <p>
-            L'attribut <code>refresh</code> re-execute la requete a intervalles reguliers (en secondes).
+            L'attribut <code>refresh</code> re-execute la requête a intervalles reguliers (en secondes).
             Fonctionne dans les deux modes (URL brute et adapter).
           </p>
           <div class="code-block"><pre>&lt;dsfr-data-source
@@ -464,26 +464,26 @@ where="email:isnull"</pre></div>
 &gt;&lt;/dsfr-data-source&gt;</pre></div>
         </section>
 
-        <h2 id="evenements" class="fr-mt-4w">Evenements</h2>
-        <p>Le composant emet des evenements personnalises via le systeme data-bridge :</p>
+        <h2 id="evenements" class="fr-mt-4w">Événements</h2>
+        <p>Le composant emet des événements personnalises via le systeme data-bridge :</p>
         <ul>
-          <li><code>dsfr-data-loaded</code> : Donnees chargees avec succes (detail : tableau de records)</li>
+          <li><code>dsfr-data-loaded</code> : Données chargees avec succes (detail : tableau de records)</li>
           <li><code>dsfr-data-loading</code> : Chargement en cours</li>
           <li><code>dsfr-data-error</code> : Erreur de chargement (detail : objet Error)</li>
-          <li><code>cache-fallback</code> : Les donnees proviennent du cache serveur suite a une erreur API (mode DB uniquement)</li>
+          <li><code>cache-fallback</code> : Les données proviennent du cache serveur suite a une erreur API (mode DB uniquement)</li>
         </ul>
 
         <h2 id="methodes" class="fr-mt-4w">Methodes publiques</h2>
         <table class="attr-table">
-          <thead><tr><th>Methode</th><th>Retour</th><th>Description</th></tr></thead>
+          <thead><tr><th>Méthode</th><th>Retour</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>reload()</code></td><td>void</td><td>Force le rechargement des donnees</td></tr>
-            <tr><td><code>getData()</code></td><td>unknown</td><td>Retourne les donnees actuelles</td></tr>
+            <tr><td><code>reload()</code></td><td>void</td><td>Force le rechargement des données</td></tr>
+            <tr><td><code>getData()</code></td><td>unknown</td><td>Retourne les données actuelles</td></tr>
             <tr><td><code>isLoading()</code></td><td>Boolean</td><td>Indique si un chargement est en cours</td></tr>
             <tr><td><code>getError()</code></td><td>Error | null</td><td>Retourne l'erreur eventuelle</td></tr>
             <tr><td><code>getAdapter()</code></td><td>ApiAdapter | null</td><td>Retourne l'adapter actif (mode adapter uniquement, <code>null</code> en mode URL brute)</td></tr>
             <tr><td><code>getEffectiveWhere(excludeKey?)</code></td><td>String</td><td>Retourne la clause WHERE fusionnee (statique + tous les overlays dynamiques).
-              Le parametre <code>excludeKey</code> permet d'exclure un overlay specifique (utilise par les facettes).</td></tr>
+              Le parametre <code>excludeKey</code> permet d'exclure un overlay spécifique (utilise par les facettes).</td></tr>
           </tbody>
         </table>
 
@@ -498,14 +498,14 @@ where="email:isnull"</pre></div>
         <div class="fr-callout fr-mt-2w">
           <p class="fr-callout__text">
             <strong>server-side vs pagination automatique :</strong> Sans <code>server-side</code>, l'adapter
-            charge <em>toutes</em> les donnees (multi-pages) en une seule operation. Avec <code>server-side</code>,
+            charge <em>toutes</em> les données (multi-pages) en une seule operation. Avec <code>server-side</code>,
             il charge une seule page et attend les commandes des composants en aval. Utilisez
             <code>server-side</code> pour les grands datasets avec un <code>dsfr-data-list</code> pagine.
           </p>
         </div>
         <div class="fr-callout fr-mt-2w">
           <p class="fr-callout__text">
-            <strong>Pipeline de donnees :</strong> <code>dsfr-data-source</code> s'integre dans un pipeline :
+            <strong>Pipeline de données :</strong> <code>dsfr-data-source</code> s'integre dans un pipeline :
             <code>dsfr-data-source</code> &rarr; <code>dsfr-data-normalize</code> &rarr;
             <code>dsfr-data-query</code> / <code>dsfr-data-search</code> / <code>dsfr-data-facets</code> &rarr;
             composants de visualisation.
@@ -513,10 +513,10 @@ where="email:isnull"</pre></div>
         </div>
         <div class="fr-callout fr-mt-2w">
           <p class="fr-callout__text">
-            <strong>Securite :</strong> les headers, tokens et cles dans <code>window.DSFR_DATA_KEYS</code>
-            sont visibles dans le code source HTML. Ne les utilisez que pour des cles a acces restreint (lecture seule)
+            <strong>Securite :</strong> les headers, tokens et clés dans <code>window.DSFR_DATA_KEYS</code>
+            sont visibles dans le code source HTML. Ne les utilisez que pour des clés a acces restreint (lecture seule)
             ou dans des contextes proteges (intranet, applications internes).
-            Pour une separation propre entre markup et cles, utilisez <code>api-key-ref</code>.
+            Pour une separation propre entre markup et clés, utilisez <code>api-key-ref</code>.
           </p>
         </div>
     </div>

--- a/specs/components/dsfr-data-unpivot.html
+++ b/specs/components/dsfr-data-unpivot.html
@@ -34,7 +34,7 @@
         <div class="fr-callout fr-callout--blue-france">
           <p class="fr-callout__text">
             <strong>Invisible :</strong> Ce composant ne rend rien visuellement. Il ecoute une source,
-            bascule ses colonnes en lignes, puis redistribue le resultat via le systeme d'evenements.
+            bascule ses colonnes en lignes, puis redistribue le resultat via le systeme d'événements.
             La valeur reste brute : le typage est delegue a <code>&lt;dsfr-data-normalize&gt;</code> (<code>numeric-auto</code>) en aval.
           </p>
         </div>
@@ -61,9 +61,9 @@ Immatriculations VE   | Vehicule Particulier | 2023-02 | 19965</pre></div>
             <tr><td><code>id-cols</code></td><td>String</td><td><code>id-cols="Indicateurs, Sous_theme"</code></td><td>Colonnes conservees telles quelles sur chaque ligne (virgule-separees)</td></tr>
             <tr><td><code>value-cols</code></td><td>String</td><td><code>value-cols="janv, fevr, mars"</code></td><td>Liste explicite des colonnes a deplier. Exclusif avec <code>value-cols-pattern</code></td></tr>
             <tr><td><code>value-cols-pattern</code></td><td>String</td><td><code>value-cols-pattern="c{YYYY}_{MM}"</code></td><td>Motif des colonnes a deplier (voir tokens ci-dessous)</td></tr>
-            <tr><td><code>var-name</code></td><td>String</td><td><code>var-name="mois"</code></td><td>Nom de la nouvelle colonne « variable » (cle depliee). Defaut : <code>variable</code></td></tr>
-            <tr><td><code>var-format</code></td><td>String</td><td><code>var-format="{YYYY}-{MM}"</code></td><td>Reformatage de la cle via les tokens du motif (<code>c2023_01</code> → <code>2023-01</code>)</td></tr>
-            <tr><td><code>value-name</code></td><td>String</td><td><code>value-name="valeur"</code></td><td>Nom de la nouvelle colonne « valeur ». Defaut : <code>value</code></td></tr>
+            <tr><td><code>var-name</code></td><td>String</td><td><code>var-name="mois"</code></td><td>Nom de la nouvelle colonne « variable » (clé depliee). Défaut : <code>variable</code></td></tr>
+            <tr><td><code>var-format</code></td><td>String</td><td><code>var-format="{YYYY}-{MM}"</code></td><td>Reformatage de la clé via les tokens du motif (<code>c2023_01</code> → <code>2023-01</code>)</td></tr>
+            <tr><td><code>value-name</code></td><td>String</td><td><code>value-name="valeur"</code></td><td>Nom de la nouvelle colonne « valeur ». Défaut : <code>value</code></td></tr>
             <tr><td><code>drop-empty</code></td><td>Boolean</td><td><code>drop-empty</code></td><td>Ne pas emettre de ligne quand la cellule depliee est vide / null</td></tr>
           </tbody>
         </table>
@@ -89,7 +89,7 @@ Immatriculations VE   | Vehicule Particulier | 2023-02 | 19965</pre></div>
             les valeurs, et on trace une courbe — sans une ligne de JavaScript.
           </p>
           <div class="code-block"><pre>&lt;dsfr-data-source id="grist_wide" api-type="grist"
-  base-url="https://grist.numerique.gouv.fr" doc-id="..." table="Plan_Elec"&gt;
+  base-url="https://grist.numérique.gouv.fr" doc-id="..." table="Plan_Elec"&gt;
 &lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-unpivot id="tidy" source="grist_wide"
@@ -111,12 +111,12 @@ Immatriculations VE   | Vehicule Particulier | 2023-02 | 19965</pre></div>
         </section>
 
         <section class="demo-section">
-          <h3>Cle de serie composite + multi-courbes (avec <code>compute</code> et <code>series-field</code>)</h3>
+          <h3>Clé de série composite + multi-courbes (avec <code>compute</code> et <code>series-field</code>)</h3>
           <p>
-            Quand l'identite d'une serie est repartie sur plusieurs colonnes (ici <code>Indicateurs</code>
+            Quand l'identite d'une série est repartie sur plusieurs colonnes (ici <code>Indicateurs</code>
             + <code>Sous_theme</code>), l'attribut <code>compute</code> de <code>&lt;dsfr-data-normalize&gt;</code>
-            les recolle en une cle unique. Le <code>series-field</code> de <code>&lt;dsfr-data-chart&gt;</code>
-            transforme alors cette cle tidy en une courbe par serie — sans une ligne de JavaScript.
+            les recolle en une clé unique. Le <code>series-field</code> de <code>&lt;dsfr-data-chart&gt;</code>
+            transforme alors cette clé tidy en une courbe par série — sans une ligne de JavaScript.
           </p>
           <div class="code-block"><pre>&lt;dsfr-data-normalize id="prep" source="tidy"
   numeric-auto
@@ -127,7 +127,7 @@ Immatriculations VE   | Vehicule Particulier | 2023-02 | 19965</pre></div>
   label-field="mois" series-field="groupe" value-field="valeur"&gt;
 &lt;/dsfr-data-chart&gt;</pre></div>
           <p class="fr-text--sm fr-mt-1w">
-            Alternative pour une seule serie : filtrer via <code>&lt;dsfr-data-query where="groupe = '...'"&gt;</code>.
+            Alternative pour une seule série : filtrer via <code>&lt;dsfr-data-query where="groupe = '...'"&gt;</code>.
           </p>
         </section>
 
@@ -141,19 +141,19 @@ Immatriculations VE   | Vehicule Particulier | 2023-02 | 19965</pre></div>
 &lt;/dsfr-data-unpivot&gt;</pre></div>
         </section>
 
-        <h2 id="evenements" class="fr-mt-4w">Evenements</h2>
-        <p>Le composant emet les memes evenements que <code>&lt;dsfr-data-source&gt;</code> :</p>
+        <h2 id="evenements" class="fr-mt-4w">Événements</h2>
+        <p>Le composant emet les mêmes événements que <code>&lt;dsfr-data-source&gt;</code> :</p>
         <ul>
-          <li><code>dsfr-data-loaded</code> : Donnees depliees disponibles</li>
+          <li><code>dsfr-data-loaded</code> : Données depliees disponibles</li>
           <li><code>dsfr-data-loading</code> : En attente de la source</li>
           <li><code>dsfr-data-error</code> : Erreur de la source ou du depivotage</li>
         </ul>
 
         <h2 id="methodes" class="fr-mt-4w">Methodes publiques</h2>
         <table class="attr-table">
-          <thead><tr><th>Methode</th><th>Retour</th><th>Description</th></tr></thead>
+          <thead><tr><th>Méthode</th><th>Retour</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>getData()</code></td><td>Array</td><td>Retourne les donnees depliees actuelles</td></tr>
+            <tr><td><code>getData()</code></td><td>Array</td><td>Retourne les données depliees actuelles</td></tr>
           </tbody>
         </table>
 
@@ -172,7 +172,7 @@ Immatriculations VE   | Vehicule Particulier | 2023-02 | 19965</pre></div>
         </div>
         <div class="fr-callout fr-mt-2w">
           <p class="fr-callout__text">
-            <strong>Recalcul automatique :</strong> si la source emet de nouvelles donnees (rechargement,
+            <strong>Recalcul automatique :</strong> si la source emet de nouvelles données (rechargement,
             filtre, pagination), le depivotage est recalcule automatiquement.
           </p>
         </div>

--- a/specs/components/dsfr-data-world-map.html
+++ b/specs/components/dsfr-data-world-map.html
@@ -26,7 +26,7 @@
     <div slot="content">
         <p class="fr-text--lead">
           Carte du monde choropleth avec zoom interactif par continent.
-          Colorie les pays selon une valeur numerique issue d'une source de donnees.
+          Colorie les pays selon une valeur numérique issue d'une source de données.
         </p>
 
         <div class="fr-callout fr-callout--blue-ecume fr-mb-4w">
@@ -39,11 +39,11 @@
 
         <h2>Attributs</h2>
         <table class="attr-table">
-          <thead><tr><th>Attribut</th><th>Type</th><th>Defaut</th><th>Description</th></tr></thead>
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
           <tbody>
-            <tr><td><code>source</code></td><td>String</td><td>-</td><td>ID du <code>&lt;dsfr-data-source&gt;</code> ou <code>&lt;dsfr-data-query&gt;</code> fournissant les donnees (requis)</td></tr>
+            <tr><td><code>source</code></td><td>String</td><td>-</td><td>ID du <code>&lt;dsfr-data-source&gt;</code> ou <code>&lt;dsfr-data-query&gt;</code> fournissant les données (requis)</td></tr>
             <tr><td><code>code-field</code></td><td>String</td><td>-</td><td>Chemin vers le code pays dans chaque enregistrement (requis)</td></tr>
-            <tr><td><code>value-field</code></td><td>String</td><td>-</td><td>Chemin vers la valeur numerique a representer (requis)</td></tr>
+            <tr><td><code>value-field</code></td><td>String</td><td>-</td><td>Chemin vers la valeur numérique a representer (requis)</td></tr>
             <tr><td><code>code-format</code></td><td>String</td><td><code>iso-a2</code></td><td>Format des codes pays : <code>iso-a2</code> (FR), <code>iso-a3</code> (FRA), <code>iso-num</code> (250)</td></tr>
             <tr><td><code>name</code></td><td>String</td><td>-</td><td>Titre affiche dans la legende</td></tr>
             <tr><td><code>selected-palette</code></td><td>String</td><td><code>sequentialAscending</code></td><td>Palette de couleurs DSFR (voir ci-dessous)</td></tr>
@@ -54,11 +54,11 @@
 
         <h2 class="fr-mt-4w">Palettes disponibles</h2>
         <table class="attr-table">
-          <thead><tr><th>Palette</th><th>Usage</th><th>Apercu</th></tr></thead>
+          <thead><tr><th>Palette</th><th>Usage</th><th>Aperçu</th></tr></thead>
           <tbody>
             <tr>
               <td><code>sequentialAscending</code></td>
-              <td>Donnees ordonnees croissantes (clair → fonce)</td>
+              <td>Données ordonnees croissantes (clair → fonce)</td>
               <td><span style="display:inline-flex;gap:1px;">
                 <span style="width:16px;height:12px;display:inline-block;background:#F5F5FE;border:1px solid #eee;"></span>
                 <span style="width:16px;height:12px;display:inline-block;background:#C1C1FB;"></span>
@@ -69,7 +69,7 @@
             </tr>
             <tr>
               <td><code>sequentialDescending</code></td>
-              <td>Donnees ordonnees decroissantes (fonce → clair)</td>
+              <td>Données ordonnees decroissantes (fonce → clair)</td>
               <td><span style="display:inline-flex;gap:1px;">
                 <span style="width:16px;height:12px;display:inline-block;background:#000091;"></span>
                 <span style="width:16px;height:12px;display:inline-block;background:#4747E5;"></span>
@@ -80,7 +80,7 @@
             </tr>
             <tr>
               <td><code>divergentAscending</code></td>
-              <td>Donnees bipolaires (bleu → neutre → rouge)</td>
+              <td>Données bipolaires (bleu → neutre → rouge)</td>
               <td><span style="display:inline-flex;gap:1px;">
                 <span style="width:16px;height:12px;display:inline-block;background:#000091;"></span>
                 <span style="width:16px;height:12px;display:inline-block;background:#8585F6;"></span>
@@ -91,7 +91,7 @@
             </tr>
             <tr>
               <td><code>neutral</code></td>
-              <td>Donnees neutres (nuances de gris)</td>
+              <td>Données neutres (nuances de gris)</td>
               <td><span style="display:inline-flex;gap:1px;">
                 <span style="width:16px;height:12px;display:inline-block;background:#F6F6F6;border:1px solid #eee;"></span>
                 <span style="width:16px;height:12px;display:inline-block;background:#CECECE;"></span>
@@ -109,14 +109,14 @@
           <tbody>
             <tr><td><code>iso-a2</code></td><td>FR</td><td>ISO 3166-1 alpha-2 (2 lettres)</td></tr>
             <tr><td><code>iso-a3</code></td><td>FRA</td><td>ISO 3166-1 alpha-3 (3 lettres)</td></tr>
-            <tr><td><code>iso-num</code></td><td>250</td><td>ISO 3166-1 numerique (3 chiffres)</td></tr>
+            <tr><td><code>iso-num</code></td><td>250</td><td>ISO 3166-1 numérique (3 chiffres)</td></tr>
           </tbody>
         </table>
 
         <h2 class="fr-mt-4w">Exemples</h2>
 
         <section class="demo-section">
-          <h3>1. Carte simple avec donnees embarquees</h3>
+          <h3>1. Carte simple avec données embarquees</h3>
 
           <dsfr-data-source id="demo-pib" data='[
             {"code":"US","pib":25462},{"code":"CN","pib":17963},{"code":"JP","pib":4231},
@@ -191,10 +191,10 @@
         <p>
           Les couleurs sont attribuees par <strong>quantiles</strong> : les pays sont repartis en 9 groupes
           de taille egale, chacun recevant une teinte de la palette. Cela garantit une bonne lisibilite
-          meme avec des distributions tres asymetriques (ex: PIB).
+          même avec des distributions tres asymetriques (ex: PIB).
         </p>
         <p>
-          Les pays sans donnees sont affiches en gris clair (<code>#F0F0F0</code>).
+          Les pays sans données sont affiches en gris clair (<code>#F0F0F0</code>).
         </p>
 
         <h3>Zoom continent</h3>
@@ -207,10 +207,10 @@
         <h3>Tooltip</h3>
         <p>
           Au survol d'un pays, un tooltip affiche le nom du pays (en francais) et sa valeur formatee.
-          Si <code>unit-tooltip</code> est defini, l'unite est ajoutee apres la valeur.
+          Si <code>unit-tooltip</code> est défini, l'unite est ajoutee apres la valeur.
         </p>
 
-        <h3>Pipeline de donnees</h3>
+        <h3>Pipeline de données</h3>
         <div class="code-block"><pre>dsfr-data-source (fetch / inline)
   → dsfr-data-query (optionnel : group-by, aggregate)
     → dsfr-data-world-map (affichage)</pre></div>

--- a/specs/index.html
+++ b/specs/index.html
@@ -45,7 +45,7 @@
     <div slot="content">
         <p class="fr-text--lead">
           dsfr-data est une bibliotheque de Web Components pour creer des tableaux de bord
-          et visualisations de donnees conformes au Design System de l'Etat (DSFR).
+          et visualisations de données conformes au Design System de l'État (DSFR).
         </p>
 
         <!-- Architecture et principe -->
@@ -63,10 +63,10 @@
                   Composants dsfr-data
                 </h3>
                 <p class="fr-callout__text">
-                  Composants <strong>developpes specifiquement</strong> pour ce projet. Ils gerent la <strong>connexion aux donnees</strong>,
+                  Composants <strong>developpes specifiquement</strong> pour ce projet. Ils gerent la <strong>connexion aux données</strong>,
                   les <strong>transformations</strong>, et l'<strong>affichage d'indicateurs</strong>.
                   Ils communiquent entre eux via un systeme de <em>data-bridge</em> qui permet de partager
-                  les donnees sans ecrire de JavaScript.
+                  les données sans ecrire de JavaScript.
                 </p>
               </div>
             </div>
@@ -79,7 +79,7 @@
                 <p class="fr-callout__text">
                   Graphiques provenant de la bibliotheque officielle
                   <a href="https://gouvernementfr.github.io/dsfr-chart/" target="_blank" rel="noopener">DSFR Chart</a>.
-                  Ces composants sont <strong>conformes RGAA</strong> et respectent la charte graphique de l'Etat.
+                  Ces composants sont <strong>conformes RGAA</strong> et respectent la charte graphique de l'État.
                   Ils peuvent etre utilises directement ou via notre wrapper <code>dsfr-data-chart</code>
                   pour une alimentation dynamique.
                 </p>
@@ -90,7 +90,7 @@
           <div class="fr-highlight fr-mt-3w">
             <p>
               <strong>Le pont entre les deux :</strong> Le composant <code>&lt;dsfr-data-chart&gt;</code> fait le lien
-              entre le systeme de donnees <code>dsfr-data-source</code> et les graphiques DSFR Chart,
+              entre le systeme de données <code>dsfr-data-source</code> et les graphiques DSFR Chart,
               permettant de creer des visualisations dynamiques alimentees par une API.
             </p>
           </div>
@@ -103,7 +103,7 @@
             Composants dsfr-data
           </h2>
           <p class="fr-mb-3w">
-            Ces composants gèrent la recuperation, la transformation et l'affichage des donnees.
+            Ces composants gèrent la recuperation, la transformation et l'affichage des données.
           </p>
 
           <div class="fr-grid-row fr-grid-row--gutters">
@@ -114,8 +114,8 @@
                     <h3 class="fr-tile__title">
                       <a href="components/dsfr-data-source.html">dsfr-data-source</a>
                     </h3>
-                    <p class="fr-tile__detail">Connecteur de donnees</p>
-                    <p class="fr-tile__desc">Recupere les donnees depuis une API et les distribue aux autres composants.</p>
+                    <p class="fr-tile__detail">Connecteur de données</p>
+                    <p class="fr-tile__desc">Recupere les données depuis une API et les distribue aux autres composants.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">
@@ -133,8 +133,8 @@
                     <h3 class="fr-tile__title">
                       <a href="components/dsfr-data-normalize.html">dsfr-data-normalize</a>
                     </h3>
-                    <p class="fr-tile__detail">Normalisation des donnees</p>
-                    <p class="fr-tile__desc">Nettoie et normalise les donnees : conversion numerique, renommage, trim.</p>
+                    <p class="fr-tile__detail">Normalisation des données</p>
+                    <p class="fr-tile__desc">Nettoie et normalise les données : conversion numérique, renommage, trim.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">
@@ -152,8 +152,8 @@
                     <h3 class="fr-tile__title">
                       <a href="components/dsfr-data-query.html">dsfr-data-query</a>
                     </h3>
-                    <p class="fr-tile__detail">Requetage des donnees</p>
-                    <p class="fr-tile__desc">Filtre, trie et agrege les donnees issues d'une source.</p>
+                    <p class="fr-tile__detail">Requetage des données</p>
+                    <p class="fr-tile__desc">Filtre, trie et agrège les données issues d'une source.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">
@@ -172,7 +172,7 @@
                       <a href="components/dsfr-data-join.html">dsfr-data-join</a>
                     </h3>
                     <p class="fr-tile__detail">Jointure multi-sources</p>
-                    <p class="fr-tile__desc">Joint deux sources de donnees sur une cle pivot pour enrichir un jeu de donnees.</p>
+                    <p class="fr-tile__desc">Joint deux sources de données sur une clé pivot pour enrichir un jeu de données.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">
@@ -210,7 +210,7 @@
                       <a href="components/dsfr-data-facets.html">dsfr-data-facets</a>
                     </h3>
                     <p class="fr-tile__detail">Filtres a facettes</p>
-                    <p class="fr-tile__desc">Ajoute des filtres interactifs par facettes sur les donnees d'une source.</p>
+                    <p class="fr-tile__desc">Ajoute des filtres interactifs par facettes sur les données d'une source.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">
@@ -229,7 +229,7 @@
                       <a href="components/dsfr-data-search.html">dsfr-data-search</a>
                     </h3>
                     <p class="fr-tile__detail">Recherche textuelle</p>
-                    <p class="fr-tile__desc">Champ de recherche DSFR qui filtre les donnees en amont. Se combine avec les facettes.</p>
+                    <p class="fr-tile__desc">Champ de recherche DSFR qui filtre les données en amont. Se combine avec les facettes.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">
@@ -247,7 +247,7 @@
                     <h3 class="fr-tile__title">
                       <a href="components/dsfr-data-list.html">dsfr-data-list</a>
                     </h3>
-                    <p class="fr-tile__detail">Tableau de donnees</p>
+                    <p class="fr-tile__detail">Tableau de données</p>
                     <p class="fr-tile__desc">Tableau avec recherche, filtres, tri, pagination et export CSV.</p>
                   </div>
                 </div>
@@ -267,7 +267,7 @@
                       <a href="components/dsfr-data-display.html">dsfr-data-display</a>
                     </h3>
                     <p class="fr-tile__detail">Affichage dynamique</p>
-                    <p class="fr-tile__desc">Genere des cartes, tuiles ou tout motif HTML repetitif a partir d'un template et de donnees.</p>
+                    <p class="fr-tile__desc">Genere des cartes, tuiles ou tout motif HTML repetitif a partir d'un template et de données.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">
@@ -286,7 +286,7 @@
                       <a href="components/dsfr-data-kpi.html">dsfr-data-kpi</a>
                     </h3>
                     <p class="fr-tile__detail">Indicateur chiffre</p>
-                    <p class="fr-tile__desc">Affiche une valeur cle avec formatage, couleurs conditionnelles et icones.</p>
+                    <p class="fr-tile__desc">Affiche une valeur clé avec formatage, couleurs conditionnelles et icones.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">
@@ -324,7 +324,7 @@
                       <a href="components/dsfr-data-chart.html">dsfr-data-chart</a>
                     </h3>
                     <p class="fr-tile__detail">Wrapper graphique</p>
-                    <p class="fr-tile__desc">Connecte les graphiques DSFR Chart au systeme de donnees dynamiques.</p>
+                    <p class="fr-tile__desc">Connecte les graphiques DSFR Chart au systeme de données dynamiques.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">
@@ -380,8 +380,8 @@
                     <h3 class="fr-tile__title">
                       <a href="components/dsfr-data-a11y.html">dsfr-data-a11y</a>
                     </h3>
-                    <p class="fr-tile__detail">Accessibilite graphique</p>
-                    <p class="fr-tile__desc">Companion d'accessibilite unifie : tableau des donnees, telechargement CSV et description textuelle.</p>
+                    <p class="fr-tile__detail">Accessibilité graphique</p>
+                    <p class="fr-tile__desc">Companion d'accessibilité unifie : tableau des données, téléchargement CSV et description textuelle.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">
@@ -401,7 +401,7 @@
             Graphiques DSFR Chart
           </h2>
           <p class="fr-mb-3w">
-            Graphiques officiels conformes au DSFR. Utilisez-les directement ou via <code>dsfr-data-chart</code> pour des donnees dynamiques.
+            Graphiques officiels conformes au DSFR. Utilisez-les directement ou via <code>dsfr-data-chart</code> pour des données dynamiques.
           </p>
 
           <div class="fr-grid-row fr-grid-row--gutters">
@@ -432,7 +432,7 @@
                       <a href="charts/bar-chart.html">bar-chart</a>
                     </h3>
                     <p class="fr-tile__detail">Barres et comparaisons</p>
-                    <p class="fr-tile__desc">Comparer des valeurs entre categories.</p>
+                    <p class="fr-tile__desc">Comparer des valeurs entre catégories.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">
@@ -508,7 +508,7 @@
                       <a href="charts/map-chart.html">map-chart</a>
                     </h3>
                     <p class="fr-tile__detail">Carte de France</p>
-                    <p class="fr-tile__desc">Visualiser des donnees geographiques.</p>
+                    <p class="fr-tile__desc">Visualiser des données geographiques.</p>
                   </div>
                 </div>
                 <div class="fr-tile__header">


### PR DESCRIPTION
## Contexte

La gate `check:accents` (avertissement non bloquant sur les libellés FR dé-accentués) ne scannait que `apps|packages/**/*.html`. Elle ratait donc les libellés des **specs/** et des templates HTML embarqués dans les **.ts** — d'où la subsistance de texte dé-accentué malgré la campagne #192.

## Ce que fait cette PR

**1. Étend le périmètre de la gate** (`scripts/check-french-accents.sh`)
- fichiers : + `specs/` + `guide/` (HTML) et `apps|packages` (TS) ;
- détection resserrée sur le **contenu des balises uniquement** : le texte strictement entre `>` et `<`. Ce filtre exclut **mécaniquement** le code, les attributs (entre `<` et `>`), les **URLs** et les commentaires (`<!--`) — robuste pour le HTML pur **et** le HTML embarqué dans du `.ts` ;
- reste **non bloquant** (avertissement, `exit 0`).

**2. Ré-accentue les libellés détectés** (~448 corrections, 27 fichiers `specs/`)
- `donnees → données`, `requete → requête`, `Methode → Méthode`, `Agregation → Agrégation`, etc. ;
- remplacements limités au texte entre balises (script + revue du diff) ; les 2 `genere` ambigus (généré/génère) traités à la main.

## Vérification

`check:accents` : **✓ aucun libellé HTML dé-accentué**. Aucune logique applicative touchée (specs = HTML statique).

🤖 Generated with [Claude Code](https://claude.com/claude-code)