### PR TITLE
feat(core): proxy CORS déclaratif par source (attribut proxy-url, #340)

### DIFF
--- a/.changeset/proxy-url-declaratif.md
+++ b/.changeset/proxy-url-declaratif.md
@@ -1,0 +1,25 @@
+---
+'dsfr-data': minor
+---
+
+Proxy CORS déclaratif par source via le nouvel attribut `proxy-url` sur
+`dsfr-data-source` (#340).
+
+- Nouvel attribut **`proxy-url`** : domaine du proxy CORS pour CETTE source,
+  prioritaire sur `window.DSFR_DATA_PROXY` et la config build-time (le plus
+  spécifique gagne). Sert à la fois la réécriture d'hôte connu (Grist
+  gouv/SaaS, Tabular, INSEE) et le `use-proxy` générique. Vide = résolution
+  proxy globale habituelle (rétrocompatible). Ex : `proxy-url="https://mon-proxy.fr"`.
+- L'override est threadé jusqu'aux adapters (ODS, Grist, Tabular, INSEE) et aux
+  facettes serveur ; `getProxyConfig()`, `getProxiedUrl()`,
+  `buildProxiedRequest()`, `buildCorsProxyRequest()` et `getProxyUrl()`
+  acceptent désormais un override optionnel (paramètres rétrocompatibles).
+- Beacon : nouvel override runtime `window.DSFR_DATA_BEACON_URL` (string),
+  prioritaire sur l'URL bakée au build et résolu à l'appel — un site hôte peut
+  rediriger la collecte de télémétrie vers son propre domaine sans rebuild.
+- La résolution proxy build-time (`VITE_PROXY_URL_EMBED`) est marquée
+  `@deprecated` (conservée en fallback temporaire) au profit de `proxy-url` +
+  `window.DSFR_DATA_PROXY`.
+- Clarification : `use-proxy` n'a d'effet que si une base de proxy est
+  configurée (`proxy-url`, `window.DSFR_DATA_PROXY` ou build) — no-op en embed
+  nu sur un site tiers.

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -223,7 +223,8 @@ tableau de données depuis la reponse. Le resultat DOIT etre un tableau d'objets
 | limit | Number | \`0\` | non | Limite du nombre de resultats (0 = pas de limite). |
 | max-records | Number | \`0\` | non | Plafond du fetchAll en mode adapter (#233). 0 = plafond par defaut de l'adapter (ODS : 1000). A relever explicitement pour les dashboards « un fetch, N agregations client » — attention au volume (requetes en boucle, memoire). |
 | data | String | \`""\` | non | Données JSON inline (pas de fetch). Ex: \`data='[{"x":1},{"x":2}]'\` |
-| use-proxy | Boolean | \`false\` | non | Force le passage par le proxy CORS generique. Utile pour les APIs externes sans CORS. |
+| use-proxy | Boolean | \`false\` | non | Force le passage par le proxy CORS generique. N'a d'effet QUE si une base de proxy est configuree (\`proxy-url\`, \`window.DSFR_DATA_PROXY\`, ou build) : en embed nu sur un site tiers sans aucune de ces sources, c'est un no-op (URL renvoyee inchangee). |
+| proxy-url | String | \`""\` | non | Domaine du proxy CORS pour CETTE source, prioritaire sur \`window.DSFR_DATA_PROXY\` et la config build. Sert la reecriture d'hote connu (Grist gouv/SaaS, Tabular, INSEE) ET le \`use-proxy\` generique. Ex: \`proxy-url="https://mon-proxy.fr"\`. Vide = resolution proxy globale habituelle. |
 | api-key-ref | String | \`""\` | non | Reference vers une clé API dans window.DSFR_DATA_KEYS. Injecte la valeur comme header Authorization. |
 
 ### Événements emis
@@ -2099,11 +2100,25 @@ L'adapter INSEE aplatit automatiquement les observations (dimensions + measures 
 | Generique | Variable | Via \`headers\` sur dsfr-data-source |
 
 ### Proxy CORS
-Certaines APIs externes necessitent un proxy CORS en production.
-Les URLs connues sont automatiquement proxifiees :
-- \`grist.numerique.gouv.fr\` -> \`${PROXY_BASE_URL_EMBED}/grist-gouv-proxy\`
-- \`docs.getgrist.com\` -> \`${PROXY_BASE_URL_EMBED}/grist-proxy\`
-- \`tabular-api.data.gouv.fr\` -> \`${PROXY_BASE_URL_EMBED}/tabular-proxy\`
+Certaines APIs externes (Grist gouv/SaaS, Tabular) ne supportent pas le CORS
+navigateur : il faut un proxy CORS. La voie recommandee est l'attribut
+**\`proxy-url\` par source** : on declare l'URL reelle de l'API + le domaine du
+proxy, l'integrateur peut remplacer ce domaine par le sien.
+
+\`\`\`html
+<!-- Grist gouv via proxy declaratif : URL reelle + proxy-url -->
+<dsfr-data-source id="src"
+  url="https://grist.numerique.gouv.fr/api/docs/DOC_ID/tables/TABLE/records"
+  proxy-url="https://mon-proxy.fr"
+  transform="records">
+</dsfr-data-source>
+\`\`\`
+
+\`proxy-url\` reecrit automatiquement les hotes connus vers leur endpoint dedie
+(\`/grist-gouv-proxy\`, \`/grist-proxy\`, \`/tabular-proxy\`, \`/insee-proxy\`). Il est
+prioritaire sur le global \`window.DSFR_DATA_PROXY\` et la config build. Sans
+\`proxy-url\` ni global, l'URL est fetchee en direct (echec CORS attendu sur les
+instances gouv).
 
 APIs avec CORS natif (pas de proxy necessaire) :
 - OpenDataSoft (\`*.opendatasoft.com\` et portails publics)

--- a/apps/builder/src/ui/code-generator.ts
+++ b/apps/builder/src/ui/code-generator.ts
@@ -1325,18 +1325,30 @@ export function generateDynamicCode(): void {
   const source = state.savedSource;
   if (!source || source.type !== 'grist') return;
 
-  // Build full proxy URL via ProviderConfig knownHosts
+  // URL Grist reelle + proxy-url declaratif (#340) : on n'inline plus l'URL
+  // proxifiee complete (domaine opaque). L'integrateur voit l'URL Grist source
+  // et un proxy-url qu'il peut remplacer par son propre domaine de proxy.
   const gristProvider = getProvider('grist');
-  let proxyUrl = source.apiUrl || '';
+  let realUrl = source.apiUrl || '';
   let gristHost = 'Grist';
+  let knownHost = false;
 
   for (const host of gristProvider.knownHosts) {
     if (source.apiUrl?.includes(host.hostname)) {
-      proxyUrl = `${PROXY_BASE_URL_EMBED}${host.proxyEndpoint}/api/docs/${source.documentId}/tables/${source.tableId}/records`;
+      realUrl = `https://${host.hostname}/api/docs/${source.documentId}/tables/${source.tableId}/records`;
       gristHost = host.hostname;
+      knownHost = true;
       break;
     }
   }
+
+  // Hote gouv/SaaS (pas de CORS navigateur) -> emettre proxy-url si un domaine
+  // de proxy est bake. Instances self-hosted (CORS ouvert) : pas de proxy-url.
+  const proxyAttr =
+    knownHost && PROXY_BASE_URL_EMBED ? `\n    proxy-url="${PROXY_BASE_URL_EMBED}"` : '';
+  const proxyComment = proxyAttr
+    ? `  <!-- proxy-url : domaine du proxy CORS (${gristHost} ne supporte pas le CORS navigateur).\n       À REMPLACER par votre propre domaine de proxy en production. -->\n`
+    : '';
 
   // Get field info for labels
   const labelFieldInfo = state.fields.find((f) => f.name === state.labelField);
@@ -1387,9 +1399,9 @@ export function generateDynamicCode(): void {
   ${state.title ? `<h2>${escapeHtml(state.title)}</h2>` : ''}
   ${state.subtitle ? `<p class="fr-text--sm fr-text--light">${escapeHtml(state.subtitle)}</p>` : ''}
 
-  <dsfr-data-source
+${proxyComment}  <dsfr-data-source
     id="table-data"
-    url="${proxyUrl}"
+    url="${realUrl}"${proxyAttr}
     transform="records"${refreshAttr}>
   </dsfr-data-source>
 ${middlewareHtml}
@@ -1459,7 +1471,6 @@ ${middlewareHtml}
   const code = `<!-- Graphique dynamique généré avec dsfr-data Builder -->
 <!-- Doc des composants : ${PROXY_BASE_URL_EMBED}/specs/ -->
 <!-- Source : ${escapeHtml(source.name)} (chargement dynamique depuis ${gristHost}) -->
-<!-- Les données sont chargees via le proxy ${PROXY_BASE_URL_EMBED} -->
 ${state.advancedMode ? '<!-- Mode avance active : filtrage et agrégation via dsfr-data-query -->' : ''}
 
 <!-- Dependances CSS (DSFR) -->
@@ -1475,10 +1486,10 @@ ${state.advancedMode ? '<!-- Mode avance active : filtrage et agrégation via ds
   ${state.title ? `<h2>${escapeHtml(state.title)}</h2>` : ''}
   ${state.subtitle ? `<p class="fr-text--sm fr-text--light">${escapeHtml(state.subtitle)}</p>` : ''}
 
-  <!-- Source de données (via proxy CORS) -->
-  <dsfr-data-source
+  <!-- Source de données (via proxy CORS si proxy-url defini) -->
+${proxyComment}  <dsfr-data-source
     id="chart-data"
-    url="${proxyUrl}"
+    url="${realUrl}"${proxyAttr}
     transform="records"${refreshAttr}>
   </dsfr-data-source>
 ${middlewareHtml}${queryElement}

--- a/packages/core/src/adapters/api-adapter.ts
+++ b/packages/core/src/adapters/api-adapter.ts
@@ -57,6 +57,12 @@ export interface AdapterParams {
   pageSize: number;
   /** Headers HTTP custom (ex: authentification, API key) */
   headers?: Record<string, string>;
+  /**
+   * Override du proxy CORS par source (attribut `proxy-url`, #340) —
+   * prioritaire sur `window.DSFR_DATA_PROXY` et la config build-time.
+   * Vide/absent = résolution proxy globale habituelle.
+   */
+  proxyUrl?: string;
 }
 
 /**
@@ -155,7 +161,7 @@ export interface ApiAdapter {
    * Retourne null si la capacite serverFacets est false.
    */
   fetchFacets?(
-    params: Pick<AdapterParams, 'baseUrl' | 'datasetId' | 'headers'>,
+    params: Pick<AdapterParams, 'baseUrl' | 'datasetId' | 'headers' | 'proxyUrl'>,
     fields: string[],
     where: string,
     signal?: AbortSignal

--- a/packages/core/src/adapters/grist-adapter.ts
+++ b/packages/core/src/adapters/grist-adapter.ts
@@ -119,7 +119,7 @@ export class GristAdapter implements ApiAdapter {
     }
 
     // Mode Records (enrichi avec filter/sort/limit)
-    const url = getProxiedUrl(this.buildUrl(params));
+    const url = getProxiedUrl(this.buildUrl(params), params.proxyUrl);
     const response = await fetch(url, buildFetchOptions(params, signal));
     if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 
@@ -146,7 +146,7 @@ export class GristAdapter implements ApiAdapter {
     }
 
     // Mode Records pagine
-    const url = getProxiedUrl(this.buildServerSideUrl(params, overlay));
+    const url = getProxiedUrl(this.buildServerSideUrl(params, overlay), params.proxyUrl);
     const response = await fetch(url, buildFetchOptions(params, signal));
     if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 
@@ -224,7 +224,7 @@ export class GristAdapter implements ApiAdapter {
   // =========================================================================
 
   async fetchFacets(
-    params: Pick<AdapterParams, 'baseUrl' | 'datasetId' | 'headers'>,
+    params: Pick<AdapterParams, 'baseUrl' | 'datasetId' | 'headers' | 'proxyUrl'>,
     fields: string[],
     where: string,
     signal?: AbortSignal
@@ -248,7 +248,7 @@ export class GristAdapter implements ApiAdapter {
       }
       sql += ` GROUP BY ${col} ORDER BY cnt DESC LIMIT 200`;
 
-      const sqlUrl = getProxiedUrl(this._getSqlEndpointUrl(fullParams));
+      const sqlUrl = getProxiedUrl(this._getSqlEndpointUrl(fullParams), fullParams.proxyUrl);
       try {
         const response = await fetch(sqlUrl, {
           method: 'POST',
@@ -321,7 +321,7 @@ export class GristAdapter implements ApiAdapter {
    * GET /api/docs/{docId}/tables/{tableId}/columns
    */
   async fetchColumns(params: AdapterParams, signal?: AbortSignal): Promise<GristColumn[]> {
-    const url = getProxiedUrl(params.baseUrl.replace(/\/records.*$/, '/columns'));
+    const url = getProxiedUrl(params.baseUrl.replace(/\/records.*$/, '/columns'), params.proxyUrl);
     try {
       const response = await fetch(url, buildFetchOptions(params, signal));
       if (!response.ok) return [];
@@ -347,7 +347,10 @@ export class GristAdapter implements ApiAdapter {
    * GET /api/docs/{docId}/tables
    */
   async fetchTables(params: AdapterParams, signal?: AbortSignal): Promise<GristTable[]> {
-    const url = getProxiedUrl(params.baseUrl.replace(/\/tables\/[^/]+\/records.*$/, '/tables'));
+    const url = getProxiedUrl(
+      params.baseUrl.replace(/\/tables\/[^/]+\/records.*$/, '/tables'),
+      params.proxyUrl
+    );
     try {
       const response = await fetch(url, buildFetchOptions(params, signal));
       if (!response.ok) return [];
@@ -482,7 +485,7 @@ export class GristAdapter implements ApiAdapter {
       .filter(Boolean)
       .join(' ');
 
-    const sqlUrl = getProxiedUrl(this._getSqlEndpointUrl(params));
+    const sqlUrl = getProxiedUrl(this._getSqlEndpointUrl(params), params.proxyUrl);
     const response = await fetch(sqlUrl, {
       method: 'POST',
       headers: {
@@ -520,7 +523,7 @@ export class GristAdapter implements ApiAdapter {
 
   /** Fetch Records mode (internal fallback) */
   private async _fetchAllRecords(params: AdapterParams, signal: AbortSignal): Promise<FetchResult> {
-    const url = getProxiedUrl(this.buildUrl(params));
+    const url = getProxiedUrl(this.buildUrl(params), params.proxyUrl);
     const response = await fetch(url, buildFetchOptions(params, signal));
     if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 
@@ -753,7 +756,7 @@ export class GristAdapter implements ApiAdapter {
   // =========================================================================
 
   private async _checkSqlAvailability(
-    params: Pick<AdapterParams, 'baseUrl' | 'headers'>,
+    params: Pick<AdapterParams, 'baseUrl' | 'headers' | 'proxyUrl'>,
     signal?: AbortSignal
   ): Promise<boolean> {
     const endpoint = this._getSqlEndpointUrl(params);
@@ -769,7 +772,7 @@ export class GristAdapter implements ApiAdapter {
         : AbortSignal.timeout(2000);
 
     try {
-      const sqlUrl = getProxiedUrl(endpoint);
+      const sqlUrl = getProxiedUrl(endpoint, params.proxyUrl);
       const response = await fetch(sqlUrl + '?q=SELECT%201', {
         method: 'GET',
         headers: (params.headers || {}) as Record<string, string>,

--- a/packages/core/src/adapters/insee-adapter.ts
+++ b/packages/core/src/adapters/insee-adapter.ts
@@ -85,7 +85,7 @@ export class InseeAdapter implements ApiAdapter {
       if (remaining <= 0) break;
 
       const effectivePageSize = Math.min(pageSize, remaining);
-      const url = getProxiedUrl(this.buildUrl(params, effectivePageSize, page));
+      const url = getProxiedUrl(this.buildUrl(params, effectivePageSize, page), params.proxyUrl);
 
       const response = await fetch(url, buildFetchOptions(params, signal));
       if (!response.ok) {
@@ -134,7 +134,7 @@ export class InseeAdapter implements ApiAdapter {
     overlay: ServerSideOverlay,
     signal: AbortSignal
   ): Promise<FetchResult> {
-    const url = getProxiedUrl(this.buildServerSideUrl(params, overlay));
+    const url = getProxiedUrl(this.buildServerSideUrl(params, overlay), params.proxyUrl);
 
     const response = await fetch(url, buildFetchOptions(params, signal));
     if (!response.ok) {

--- a/packages/core/src/adapters/opendatasoft-adapter.ts
+++ b/packages/core/src/adapters/opendatasoft-adapter.ts
@@ -122,7 +122,10 @@ export class OpenDataSoftAdapter implements ApiAdapter {
       const remaining = requestedLimit - allResults.length;
       if (remaining <= 0) break;
 
-      const url = getProxiedUrl(this.buildUrl(params, Math.min(pageSize, remaining), offset));
+      const url = getProxiedUrl(
+        this.buildUrl(params, Math.min(pageSize, remaining), offset),
+        params.proxyUrl
+      );
 
       const response = await fetch(url, buildFetchOptions(params, signal));
       if (!response.ok) {
@@ -175,7 +178,7 @@ export class OpenDataSoftAdapter implements ApiAdapter {
     overlay: ServerSideOverlay,
     signal: AbortSignal
   ): Promise<FetchResult> {
-    const url = getProxiedUrl(this.buildServerSideUrl(params, overlay));
+    const url = getProxiedUrl(this.buildServerSideUrl(params, overlay), params.proxyUrl);
 
     const response = await fetch(url, buildFetchOptions(params, signal));
     if (!response.ok) {
@@ -278,7 +281,7 @@ export class OpenDataSoftAdapter implements ApiAdapter {
    * Fetch les valeurs de facettes depuis l'endpoint ODS /facets.
    */
   async fetchFacets(
-    params: Pick<AdapterParams, 'baseUrl' | 'datasetId' | 'headers'>,
+    params: Pick<AdapterParams, 'baseUrl' | 'datasetId' | 'headers' | 'proxyUrl'>,
     fields: string[],
     where: string,
     signal?: AbortSignal
@@ -293,7 +296,10 @@ export class OpenDataSoftAdapter implements ApiAdapter {
       url.searchParams.set('where', where);
     }
 
-    const response = await fetch(getProxiedUrl(url.toString()), buildFetchOptions(params, signal));
+    const response = await fetch(
+      getProxiedUrl(url.toString(), params.proxyUrl),
+      buildFetchOptions(params, signal)
+    );
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }

--- a/packages/core/src/adapters/tabular-adapter.ts
+++ b/packages/core/src/adapters/tabular-adapter.ts
@@ -365,7 +365,7 @@ export class TabularAdapter implements ApiAdapter {
     if (params.baseUrl) {
       return params.baseUrl;
     }
-    const config = getProxyConfig();
+    const config = getProxyConfig(params.proxyUrl);
     // Aucun proxy configuré : appel direct de l'API Tabular (CORS ouvert)
     if (config.mode === 'direct') {
       return TABULAR_CONFIG.defaultBaseUrl || 'https://tabular-api.data.gouv.fr';

--- a/packages/core/src/components/dsfr-data-facets.ts
+++ b/packages/core/src/components/dsfr-data-facets.ts
@@ -692,11 +692,13 @@ export class DsfrDataFacets extends TransformerMixin(LitElement) {
     let baseUrl: string;
     let datasetId: string;
     let headers: Record<string, string> | undefined;
+    let proxyUrl: string | undefined;
 
     if (resolvedParams) {
       baseUrl = resolvedParams.baseUrl || '';
       datasetId = resolvedParams.datasetId || '';
       headers = resolvedParams.headers;
+      proxyUrl = resolvedParams.proxyUrl;
     } else {
       // Fallback legacy : remonter le pipeline et lire les attributs DOM
       // (sources tierces n'implementant pas getAdapterParams)
@@ -752,7 +754,7 @@ export class DsfrDataFacets extends TransformerMixin(LitElement) {
     for (const [where, groupFields] of whereToFields) {
       try {
         const results = await adapter.fetchFacets(
-          { baseUrl, datasetId, headers },
+          { baseUrl, datasetId, headers, proxyUrl },
           groupFields,
           where,
           abort.signal

--- a/packages/core/src/components/dsfr-data-source.ts
+++ b/packages/core/src/components/dsfr-data-source.ts
@@ -74,6 +74,16 @@ export class DsfrDataSource extends LitElement {
   @property({ type: Boolean, attribute: 'use-proxy' })
   useProxy = false;
 
+  /**
+   * Domaine du proxy CORS pour CETTE source (#340), prioritaire sur
+   * `window.DSFR_DATA_PROXY` et la config build-time. Sert a la fois la
+   * reecriture d'hote connu (Grist gouv/SaaS, Tabular, INSEE) et le
+   * `use-proxy` generique. Vide = resolution proxy globale habituelle.
+   * Ex: `proxy-url="https://mon-proxy.fr"`.
+   */
+  @property({ type: String, attribute: 'proxy-url' })
+  proxyUrl = '';
+
   /** Reference vers une clé API declaree dans window.DSFR_DATA_KEYS */
   @property({ type: String, attribute: 'api-key-ref' })
   apiKeyRef = '';
@@ -230,7 +240,8 @@ export class DsfrDataSource extends LitElement {
     const sharedChanged =
       changedProperties.has('pageSize') ||
       changedProperties.has('serverSide') ||
-      changedProperties.has('headers');
+      changedProperties.has('headers') ||
+      changedProperties.has('proxyUrl');
 
     if (urlModeChanged || adapterModeChanged || sharedChanged) {
       if (
@@ -505,13 +516,17 @@ export class DsfrDataSource extends LitElement {
 
     try {
       const rawUrl = this._buildUrl();
-      let url = getProxiedUrl(rawUrl);
+      let url = getProxiedUrl(rawUrl, this.proxyUrl);
       const options = this._buildFetchOptions();
 
       // If use-proxy is set and URL was not already proxied by getProxiedUrl(),
       // route through the generic CORS proxy
       if (this.useProxy && url === rawUrl) {
-        const proxy = buildCorsProxyRequest(url, options.headers as Record<string, string>);
+        const proxy = buildCorsProxyRequest(
+          url,
+          options.headers as Record<string, string>,
+          this.proxyUrl
+        );
         url = proxy.url;
         options.headers = proxy.headers;
       }
@@ -735,6 +750,7 @@ export class DsfrDataSource extends LitElement {
       transform: this.transform,
       pageSize: this.pageSize,
       headers: parsedHeaders,
+      proxyUrl: this.proxyUrl || undefined,
     };
   }
 

--- a/packages/core/src/utils/beacon.ts
+++ b/packages/core/src/utils/beacon.ts
@@ -6,7 +6,24 @@
 
 import { BEACON_BASE_URL } from '@dsfr-data/shared/lib';
 
-const BEACON_URL = `${BEACON_BASE_URL}/beacon`;
+/**
+ * Resout la base de collecte du beacon **a l'appel** (#340) :
+ * `window.DSFR_DATA_BEACON_URL` (string non vide) est prioritaire sur la
+ * valeur bakee au build (`BEACON_BASE_URL`). Resolu dynamiquement et non en
+ * const au chargement pour que le site hote puisse la poser avant le 1er
+ * beacon. Vide → no-op (pas de domaine de collecte).
+ */
+function resolveBeaconBase(): string {
+  const override =
+    typeof window !== 'undefined'
+      ? (window as Window & { DSFR_DATA_BEACON_URL?: string }).DSFR_DATA_BEACON_URL
+      : undefined;
+  if (typeof override === 'string' && override.trim()) {
+    return override.trim().replace(/\/+$/, '');
+  }
+  return BEACON_BASE_URL;
+}
+
 const sent = new Set<string>();
 /** Keep references to pending beacon images to prevent GC before request completes */
 const pending: HTMLImageElement[] = [];
@@ -43,9 +60,10 @@ export function sendWidgetBeacon(component: string, subtype?: string): void {
   )
     return;
 
-  // Pas de domaine de collecte baké dans le bundle (build sans VITE_BEACON_URL
-  // ni VITE_PROXY_URL*) : aucun endroit où envoyer le beacon
-  if (!BEACON_BASE_URL) return;
+  // Aucun domaine de collecte (ni override runtime, ni bake au build) :
+  // aucun endroit où envoyer le beacon
+  const beaconBase = resolveBeaconBase();
+  if (!beaconBase) return;
 
   const key = `${component}:${subtype || ''}`;
   if (sent.has(key)) return;
@@ -59,7 +77,7 @@ export function sendWidgetBeacon(component: string, subtype?: string): void {
   // external deployments — internal pings would inflate stats with our own
   // navigation on the app/embed domain).
   const host = window.location.hostname;
-  if (host === 'localhost' || host === '127.0.0.1' || host === new URL(BEACON_BASE_URL).hostname) {
+  if (host === 'localhost' || host === '127.0.0.1' || host === new URL(beaconBase).hostname) {
     return;
   }
 
@@ -97,7 +115,7 @@ export function sendWidgetBeacon(component: string, subtype?: string): void {
     }
   }
 
-  const url = `${BEACON_URL}?${params.toString()}`;
+  const url = `${beaconBase}/beacon?${params.toString()}`;
 
   try {
     const img = new Image();

--- a/packages/shared/src/api/proxy-config.ts
+++ b/packages/shared/src/api/proxy-config.ts
@@ -174,7 +174,10 @@ function stripTrailingSlash(url: string): string {
 /**
  * Get the proxy configuration based on the current environment.
  *
- * Ordre de résolution (cf. #319) :
+ * Ordre de résolution (du plus spécifique au plus général ; cf. #319, #340) :
+ * 0. `override` (attribut `proxy-url` d'une source) → proxy explicite par
+ *    source, prioritaire sur tout le reste. String non vide → proxy distant ;
+ *    objet → merge baseUrl/endpoints ; vide/absent → ignoré (on continue).
  * 1. `window.DSFR_DATA_PROXY = false` → mode `direct`, aucun proxying.
  * 2. `window.DSFR_DATA_PROXY` (string ou objet) → proxy du site déployeur.
  * 3. Dev Vite de CE repo → chemins relatifs (routes de vite.config.ts).
@@ -188,9 +191,26 @@ function stripTrailingSlash(url: string): string {
  * cette config est consommée par les adapters de `packages/core` qui tournent
  * dans le bundle lib — chargé indifféremment dans l'app elle-même (preview)
  * ou sur un site tiers embarquant un widget. Cf. issue #180.
+ *
+ * @param override Override explicite (attribut `proxy-url`), prioritaire sur
+ *   `window.DSFR_DATA_PROXY` et la config build-time. Le plus spécifique gagne.
  */
-export function getProxyConfig(): ProxyConfig {
+export function getProxyConfig(override?: string | RuntimeProxyConfig): ProxyConfig {
   const endpoints = { ...DEFAULT_ENDPOINTS };
+
+  // 0. Override explicite par source (attribut proxy-url, #340) : le plus
+  //    spécifique gagne, prioritaire sur window.DSFR_DATA_PROXY et le build-time.
+  if (typeof override === 'string' && override.trim()) {
+    return { baseUrl: stripTrailingSlash(override.trim()), endpoints, mode: 'remote' };
+  }
+  if (override && typeof override === 'object') {
+    return {
+      baseUrl: stripTrailingSlash(override.baseUrl?.trim() ?? ''),
+      endpoints: { ...endpoints, ...override.endpoints },
+      mode: 'remote',
+    };
+  }
+
   const runtime = readRuntimeProxy();
 
   // 1. Opt-out runtime explicite : aucun proxy
@@ -215,7 +235,9 @@ export function getProxyConfig(): ProxyConfig {
     return { baseUrl: '', endpoints, mode: 'dev-relative' };
   }
 
-  // 4. Config injectée au build (app self-hosted, Tauri)
+  // 4. Config injectée au build (app self-hosted, Tauri).
+  //    @deprecated Résolution build-time conservée en fallback temporaire (#340) :
+  //    préférer l'attribut `proxy-url` par source ou `window.DSFR_DATA_PROXY`.
   if (PROXY_BASE_URL_EMBED) {
     return { baseUrl: PROXY_BASE_URL_EMBED, endpoints, mode: 'remote' };
   }

--- a/packages/shared/src/api/proxy-config.ts
+++ b/packages/shared/src/api/proxy-config.ts
@@ -168,7 +168,12 @@ function readRuntimeProxy(): string | false | RuntimeProxyConfig | undefined {
 }
 
 function stripTrailingSlash(url: string): string {
-  return url.replace(/\/+$/, '');
+  // Parcours caractere par caractere plutot qu'un regex `/\/+$/` : `override`
+  // est une entree publique (attribut proxy-url, #340) et le `+$` ancre est
+  // signale ReDoS polynomial par CodeQL. Cette version est lineaire.
+  let end = url.length;
+  while (end > 0 && url.charCodeAt(end - 1) === 47 /* '/' */) end--;
+  return url.slice(0, end);
 }
 
 /**

--- a/packages/shared/src/api/proxy.ts
+++ b/packages/shared/src/api/proxy.ts
@@ -3,17 +3,27 @@
  */
 
 import { getProxyConfig } from './proxy-config.js';
-import type { ProxyConfig } from './proxy-config.js';
+import type { ProxyConfig, RuntimeProxyConfig } from './proxy-config.js';
+
+/** Override proxy explicite (attribut `proxy-url` d'une source, #340). */
+type ProxyOverride = string | RuntimeProxyConfig | undefined;
 
 /**
  * Get proxied URL for a Grist API endpoint
  * Handles both docs.getgrist.com and grist.numerique.gouv.fr
+ *
+ * @param proxyOverride Override proxy par source (attribut `proxy-url`, #340),
+ *   prioritaire sur `window.DSFR_DATA_PROXY` et la config build-time.
  */
-export function getProxyUrl(gristUrl: string, endpoint: string): string {
+export function getProxyUrl(
+  gristUrl: string,
+  endpoint: string,
+  proxyOverride?: ProxyOverride
+): string {
   if (!gristUrl) {
     throw new Error('getProxyUrl: gristUrl is required');
   }
-  const config = getProxyConfig();
+  const config = getProxyConfig(proxyOverride);
   const url = new URL(gristUrl);
 
   // Aucun proxy configuré : acces direct a l'instance Grist
@@ -67,12 +77,15 @@ function rewriteKnownHost(parsed: URL, config: ProxyConfig): string | null {
  * Note : pour router *aussi* les hôtes inconnus via le proxy CORS générique
  * (nécessaire dès qu'on envoie un en-tête custom comme `Apikey` qui déclenche
  * un preflight), utiliser `buildProxiedRequest` qui renvoie url + en-têtes.
+ *
+ * @param proxyOverride Override proxy par source (attribut `proxy-url`, #340),
+ *   prioritaire sur `window.DSFR_DATA_PROXY` et la config build-time.
  */
-export function getProxiedUrl(url: string): string {
+export function getProxiedUrl(url: string, proxyOverride?: ProxyOverride): string {
   if (!url) {
     throw new Error('getProxiedUrl: url is required');
   }
-  const config = getProxyConfig();
+  const config = getProxyConfig(proxyOverride);
 
   let parsed: URL;
   try {
@@ -98,13 +111,14 @@ export function getProxiedUrl(url: string): string {
  */
 export function buildProxiedRequest(
   url: string,
-  extraHeaders: Record<string, string> = {}
+  extraHeaders: Record<string, string> = {},
+  proxyOverride?: ProxyOverride
 ): { url: string; headers: Record<string, string> } {
   if (!url) {
     throw new Error('buildProxiedRequest: url is required');
   }
   const headers: Record<string, string> = { ...extraHeaders };
-  const config = getProxyConfig();
+  const config = getProxyConfig(proxyOverride);
 
   let parsed: URL;
   try {
@@ -149,9 +163,10 @@ export function buildProxiedRequest(
  */
 export function buildCorsProxyRequest(
   targetUrl: string,
-  extraHeaders?: Record<string, string>
+  extraHeaders?: Record<string, string>,
+  proxyOverride?: ProxyOverride
 ): { url: string; headers: Record<string, string> } {
-  const config = getProxyConfig();
+  const config = getProxyConfig(proxyOverride);
 
   // Aucun proxy configuré : requête directe vers la cible
   if (config.mode === 'direct') {

--- a/specs/components/dsfr-data-source.html
+++ b/specs/components/dsfr-data-source.html
@@ -132,7 +132,13 @@
             <tr><td><code>page-size</code></td><td>Number</td><td>Entier positif. Défaut : <code>20</code></td><td>Taille de page pour la pagination manuelle</td></tr>
             <tr><td><code>use-proxy</code></td><td>Boolean</td><td>Presence = <code>true</code></td><td>Force le passage par le proxy CORS generique (<code>/cors-proxy</code>).
               Utile pour les APIs externes qui ne gerent pas CORS. La requête est routee cote serveur
-              via un header <code>X-Target-URL</code>.</td></tr>
+              via un header <code>X-Target-URL</code>. <strong>N'a d'effet que si une base de proxy est
+              configuree</strong> (<code>proxy-url</code>, <code>window.DSFR_DATA_PROXY</code> ou build) :
+              en embed nu sans proxy, c'est un no-op (URL renvoyee inchangee).</td></tr>
+            <tr><td><code>proxy-url</code></td><td>String</td><td><code>""</code></td><td>Domaine du proxy CORS pour
+              <strong>cette source</strong>, prioritaire sur <code>window.DSFR_DATA_PROXY</code> et la config build.
+              Sert a la fois la reecriture d'hote connu (Grist gouv/SaaS, Tabular, INSEE) et le <code>use-proxy</code>
+              generique. Ex : <code>proxy-url="https://mon-proxy.fr"</code>. Vide = resolution proxy globale habituelle.</td></tr>
           </tbody>
         </table>
 

--- a/tests/apps/builder/code-generator.test.ts
+++ b/tests/apps/builder/code-generator.test.ts
@@ -1362,12 +1362,13 @@ describe('generateDynamicCode', () => {
       'url="https://grist.numerique.gouv.fr/api/docs/doc1/tables/Table1/records"'
     );
     expect(code).not.toContain('grist-gouv-proxy');
-    // proxy-url declaratif : emis seulement si un domaine de proxy est bake
-    // (PROXY_BASE_URL_EMBED vide en CI sans .env → pas de proxy-url)
+    // Attribut proxy-url declaratif : emis seulement si un domaine de proxy est
+    // bake (PROXY_BASE_URL_EMBED vide en CI sans .env → pas d'attribut). On cible
+    // `proxy-url=` (l'attribut) et non `proxy-url` nu, present dans un commentaire.
     if (PROXY_BASE_URL_EMBED) {
       expect(code).toContain(`proxy-url="${PROXY_BASE_URL_EMBED}"`);
     } else {
-      expect(code).not.toContain('proxy-url');
+      expect(code).not.toContain('proxy-url=');
     }
   });
 

--- a/tests/apps/builder/code-generator.test.ts
+++ b/tests/apps/builder/code-generator.test.ts
@@ -13,7 +13,7 @@ import {
   computeStaticFacetValues,
 } from '../../../apps/builder/src/ui/code-generator';
 import { filterToOdsql, applyLocalFilter } from '@dsfr-data/shared';
-import { state } from '../../../apps/builder/src/state';
+import { state, PROXY_BASE_URL_EMBED } from '../../../apps/builder/src/state';
 
 vi.mock('../../../apps/builder/src/ui/chart-renderer', () => ({
   renderChart: vi.fn(),
@@ -1354,21 +1354,31 @@ describe('generateDynamicCode', () => {
     expect(code).toContain('transform="records"');
   });
 
-  it('should use proxy URL for grist.numerique.gouv.fr', () => {
+  it('emits the real grist.numerique.gouv.fr URL + proxy-url (no baked proxy endpoint, #340)', () => {
     generateDynamicCode();
     const code = document.getElementById('generated-code')!.textContent!;
-    expect(code).toContain('grist-gouv-proxy');
-    expect(code).toContain('/api/docs/doc1/tables/Table1/records');
+    // URL Grist reelle, plus l'endpoint proxy opaque pre-compose
+    expect(code).toContain(
+      'url="https://grist.numerique.gouv.fr/api/docs/doc1/tables/Table1/records"'
+    );
+    expect(code).not.toContain('grist-gouv-proxy');
+    // proxy-url declaratif : emis seulement si un domaine de proxy est bake
+    // (PROXY_BASE_URL_EMBED vide en CI sans .env → pas de proxy-url)
+    if (PROXY_BASE_URL_EMBED) {
+      expect(code).toContain(`proxy-url="${PROXY_BASE_URL_EMBED}"`);
+    } else {
+      expect(code).not.toContain('proxy-url');
+    }
   });
 
-  it('should use proxy URL for docs.getgrist.com', () => {
+  it('emits the real docs.getgrist.com URL (no baked proxy endpoint, #340)', () => {
     state.savedSource!.apiUrl = 'https://docs.getgrist.com/api/docs/doc2/tables/Table2/records';
     state.savedSource!.documentId = 'doc2';
     state.savedSource!.tableId = 'Table2';
     generateDynamicCode();
     const code = document.getElementById('generated-code')!.textContent!;
-    expect(code).toContain('grist-proxy');
-    expect(code).toContain('/api/docs/doc2/tables/Table2/records');
+    expect(code).toContain('url="https://docs.getgrist.com/api/docs/doc2/tables/Table2/records"');
+    expect(code).not.toContain('grist-proxy');
   });
 
   it('should use fields.X paths when normalize flatten is disabled', () => {

--- a/tests/beacon.test.ts
+++ b/tests/beacon.test.ts
@@ -33,6 +33,7 @@ describe('sendWidgetBeacon', () => {
     globalThis.Image = OriginalImage;
     delete (window as any).__gwDbMode;
     delete (window as any).DSFR_DATA_BEACON;
+    delete (window as any).DSFR_DATA_BEACON_URL;
     vi.restoreAllMocks();
     vi.resetModules();
     vi.unstubAllGlobals();
@@ -276,5 +277,59 @@ describe('sendWidgetBeacon', () => {
     // Without DB mode, pixel is created synchronously
     expect(imageSrcs).toHaveLength(1);
     expect(imageSrcs[0]).toContain('chartsbuilder.matge.com/beacon');
+  });
+
+  // --- Override runtime de l'URL de collecte (#340) ---
+
+  it('window.DSFR_DATA_BEACON_URL prend le pas sur l URL bakee', async () => {
+    (window as any).DSFR_DATA_BEACON = true;
+    (window as any).DSFR_DATA_BEACON_URL = 'https://collecte.ministere.fr/';
+    vi.stubGlobal('location', {
+      hostname: 'example.gouv.fr',
+      protocol: 'https:',
+      origin: 'https://example.gouv.fr',
+      href: 'https://example.gouv.fr/',
+    });
+
+    const sendWidgetBeacon = await loadBeacon('https://chartsbuilder.matge.com');
+    sendWidgetBeacon('dsfr-data-kpi');
+
+    expect(imageSrcs).toHaveLength(1);
+    const url = new URL(imageSrcs[0]);
+    expect(url.origin).toBe('https://collecte.ministere.fr');
+    expect(url.pathname).toBe('/beacon');
+  });
+
+  it('window.DSFR_DATA_BEACON_URL active la collecte meme sans URL bakee', async () => {
+    (window as any).DSFR_DATA_BEACON = true;
+    (window as any).DSFR_DATA_BEACON_URL = 'https://collecte.ministere.fr';
+    vi.stubGlobal('location', {
+      hostname: 'example.gouv.fr',
+      protocol: 'https:',
+      origin: 'https://example.gouv.fr',
+      href: 'https://example.gouv.fr/',
+    });
+
+    const sendWidgetBeacon = await loadBeacon('');
+    sendWidgetBeacon('dsfr-data-kpi');
+
+    expect(imageSrcs).toHaveLength(1);
+    expect(imageSrcs[0]).toContain('https://collecte.ministere.fr/beacon');
+  });
+
+  it('skip sur le host de collecte resolu via override (pas de self-ping)', async () => {
+    (window as any).DSFR_DATA_BEACON = true;
+    (window as any).DSFR_DATA_BEACON_URL = 'https://collecte.ministere.fr';
+    vi.stubGlobal('location', {
+      hostname: 'collecte.ministere.fr',
+      protocol: 'https:',
+      origin: 'https://collecte.ministere.fr',
+      href: 'https://collecte.ministere.fr/',
+    });
+
+    const sendWidgetBeacon = await loadBeacon('https://chartsbuilder.matge.com');
+    sendWidgetBeacon('dsfr-data-kpi');
+
+    expect(imageSrcs).toHaveLength(0);
   });
 });

--- a/tests/shared/proxy-config.test.ts
+++ b/tests/shared/proxy-config.test.ts
@@ -5,6 +5,7 @@ import {
   isTauriMode,
   getProxyConfig,
 } from '../../packages/shared/src/api/proxy-config';
+import { getProxiedUrl } from '../../packages/shared/src/api/proxy';
 
 /**
  * Recharge le module proxy-config avec des variables VITE_* contrôlées.
@@ -190,6 +191,71 @@ describe('proxy-config', () => {
           expect(getProxyConfig().mode).toBe('remote');
         });
       });
+    });
+  });
+
+  // --- Override explicite par source (attribut proxy-url, #340) ---
+  describe('getProxyConfig(override) — proxy-url par source', () => {
+    it('string override → proxy distant (trailing slash strippe)', () => {
+      const config = getProxyConfig('https://mon-proxy.fr/');
+      expect(config.mode).toBe('remote');
+      expect(config.baseUrl).toBe('https://mon-proxy.fr');
+    });
+
+    it('object override → merge baseUrl + endpoints', () => {
+      const config = getProxyConfig({ baseUrl: 'https://x.fr', endpoints: { tabular: '/t' } });
+      expect(config.mode).toBe('remote');
+      expect(config.baseUrl).toBe('https://x.fr');
+      expect(config.endpoints.tabular).toBe('/t');
+      expect(config.endpoints.grist).toBe('/grist-proxy');
+    });
+
+    it('override prend le pas sur window.DSFR_DATA_PROXY (le plus specifique gagne)', () => {
+      withRuntimeProxy('https://global-proxy.fr', () => {
+        const config = getProxyConfig('https://source-proxy.fr');
+        expect(config.baseUrl).toBe('https://source-proxy.fr');
+      });
+    });
+
+    it('override vide/whitespace → ignore, on retombe sur la resolution habituelle', () => {
+      withRuntimeProxy('https://global-proxy.fr', () => {
+        const config = getProxyConfig('   ');
+        expect(config.baseUrl).toBe('https://global-proxy.fr');
+      });
+    });
+
+    it('sans override ni global → defaut direct preserve', async () => {
+      const mod = await loadProxyConfigWithEnv({});
+      withLocation({ hostname: 'mon-site-tiers.example.fr', port: '' }, () => {
+        expect(mod.getProxyConfig().mode).toBe('direct');
+        expect(mod.getProxyConfig(undefined).mode).toBe('direct');
+      });
+    });
+  });
+
+  // --- getProxiedUrl avec override (proxy.ts, #340) ---
+  describe('getProxiedUrl(url, override)', () => {
+    it('reecrit un hote connu avec la base de l override', () => {
+      const url = getProxiedUrl(
+        'https://grist.numerique.gouv.fr/api/docs/x/tables/y/records',
+        'https://mon-proxy.fr'
+      );
+      expect(url).toBe('https://mon-proxy.fr/grist-gouv-proxy/api/docs/x/tables/y/records');
+    });
+
+    it('hote inconnu → URL inchangee meme avec override', () => {
+      const url = getProxiedUrl('https://api.example.com/data', 'https://mon-proxy.fr');
+      expect(url).toBe('https://api.example.com/data');
+    });
+
+    it('sans override ni proxy → URL directe (non-regression mode direct)', async () => {
+      // env vide → PROXY_BASE_URL_EMBED='' ; location happy-dom par defaut
+      // (localhost sans port) → isViteDevMode()=false → mode direct.
+      await loadProxyConfigWithEnv({});
+      const { getProxiedUrl: freshGetProxiedUrl } =
+        await import('../../packages/shared/src/api/proxy');
+      const url = freshGetProxiedUrl('https://grist.numerique.gouv.fr/api/docs/x/tables/y/records');
+      expect(url).toBe('https://grist.numerique.gouv.fr/api/docs/x/tables/y/records');
     });
   });
 });

--- a/tests/source-element-params.test.ts
+++ b/tests/source-element-params.test.ts
@@ -56,6 +56,21 @@ describe('SourceElement.getAdapterParams (#274)', () => {
     expect(params?.headers).toEqual({ Authorization: 'Bearer SECRET-TOKEN' });
   });
 
+  it('proxy-url remonte dans les params adapter et traverse la délégation (#340)', () => {
+    const source = makeSource();
+    source.proxyUrl = 'https://mon-proxy.fr';
+    expect(source.getAdapterParams().proxyUrl).toBe('https://mon-proxy.fr');
+
+    const query = mount(new DsfrDataQuery(), 'ses-proxy-q');
+    query.source = 'ses-src';
+    expect(query.getAdapterParams()?.proxyUrl).toBe('https://mon-proxy.fr');
+  });
+
+  it('proxy-url vide → proxyUrl undefined dans les params (résolution globale)', () => {
+    const source = makeSource();
+    expect(source.getAdapterParams().proxyUrl).toBeUndefined();
+  });
+
   it('unpivot délègue getAdapter / getEffectiveWhere / getAdapterParams', () => {
     makeSource();
     const unpivot = mount(new DsfrDataUnpivot(), 'ses-unpivot');


### PR DESCRIPTION
Closes #340.

## Quoi

Proxy CORS **déclaratif par source** via le nouvel attribut `proxy-url` sur
`dsfr-data-source`, prioritaire sur `window.DSFR_DATA_PROXY` et la config
build-time (« le plus spécifique gagne »). Sert à la fois la réécriture d'hôte
connu (Grist gouv/SaaS, Tabular, INSEE) et le `use-proxy` générique. Vide =
résolution proxy globale habituelle (100 % rétrocompatible).

## Pourquoi

Pour un intégrateur qui colle une viz sur un site tiers, le seul levier par
source était `use-proxy` (booléen) qui ne choisit pas le domaine — et qui est un
**no-op** en embed nu sans base de proxy. Le builder bakait par ailleurs une URL
proxifiée **opaque** (`https://chartsbuilder.matge.com/grist-gouv-proxy/...`) que
l'intégrateur ne pouvait pas changer sans recomposer l'URL à la main.

## Détail des changements

- **`packages/shared`** : `getProxyConfig(override?)` + threading de l'override
  dans `getProxiedUrl` / `buildProxiedRequest` / `buildCorsProxyRequest` /
  `getProxyUrl` (paramètres optionnels, rétrocompatibles). Résolution build-time
  `VITE_PROXY_URL_EMBED` marquée `@deprecated` (fallback conservé).
- **Adapters** : `proxyUrl?` ajouté à `AdapterParams`, threadé sur tous les sites
  de fetch (ODS, Grist, INSEE, Tabular) et les facettes serveur ; les `Pick<>`
  de `fetchFacets`/`_checkSqlAvailability` étendus ; `dsfr-data-facets` propage
  l'override.
- **`dsfr-data-source`** : attribut `proxy-url`, branché en mode URL **et** mode
  adapter, câblé au re-fetch.
- **Beacon** : override runtime `window.DSFR_DATA_BEACON_URL` résolu **à l'appel**
  (un site hôte peut rediriger la collecte sans rebuild).
- **Builder** : code Grist généré → **URL Grist réelle + `proxy-url` commenté**
  (« À REMPLACER par votre propre domaine ») au lieu de l'URL proxifiée opaque.
- **Doc** : skill builder-IA (ligne `proxy-url` + note no-op de `use-proxy` +
  section Proxy CORS modernisée), spec HTML. Changeset **minor**.

## Vérifications

- `npm run typecheck` (core + builder + builder-ia) ✅
- `npm run test:run` → **3477/3477** ✅ (nouveaux tests override proxy/beacon +
  non-régression mode direct ; maj des 2 tests code-generator qui figeaient
  l'ancien baking — assertion `proxy-url` rendue conditionnelle sur
  `PROXY_BASE_URL_EMBED`, vide en CI sans `.env`)
- skills alignment (46) ✅ · `check:accents` ✅ · lint ✅ · Prettier ✅ · build
  des 4 bundles ✅

## Suite

- Beacon **déclaratif** `<dsfr-data-beacon>` (pendant de `proxy-url`) → suivi en
  #345 (hors scope de cette PR, qui se limite à l'override runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
