### PR TITLE
docs(chart): exemple reference-lines 

### DIFF
--- a/.changeset/chart-reference-lines.md
+++ b/.changeset/chart-reference-lines.md
@@ -1,0 +1,20 @@
+---
+'dsfr-data': minor
+---
+
+dsfr-data-chart : lignes de référence (verticale/horizontale) avec libellé (#341).
+
+- Nouvel attribut `reference-lines` (JSON) : superpose des repères sur les
+  graphiques **cartésiens** (line, bar, bar-line, scatter). Chaque item :
+  `{ axis: "x"|"y", value, label?, color?, dash?, position? }`. `axis:"x"` trace
+  une ligne **verticale** à une catégorie/date ; `axis:"y"` une ligne
+  **horizontale** à un seuil. Couleur par défaut rouge DSFR, pointillé par
+  défaut, libellé en pastille.
+- Rendu via un **overlay SVG** dans le wrapper du chart (`pointer-events:none`,
+  `aria-hidden`), positionné depuis l'instance Chart.js de `@gouvfr/dsfr-chart`
+  (récupérée en interne, sans fork de la lib tierce). Repositionnement au resize
+  (`ResizeObserver`), nettoyage au démontage.
+- Accessibilité : les repères sont relayés dans l'`aria-label` du graphique.
+- Types non cartésiens (pie, gauge, radar, map…) ou JSON invalide : signalés via
+  `data-dsfr-config-error`, le rendu du graphique reste intact (dégradation
+  gracieuse si l'instance Chart.js est introuvable).

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -1133,6 +1133,7 @@ ce tableau en format DSFR Chart (tableaux imbriques x/y).
 | gauge-value | Number | \`null\` | type gauge | Valeur de la jauge (0-100) |
 | code-field | String | \`""\` | type map/map-reg | Champ contenant le code departement ou region (prioritaire sur label-field) |
 | map-highlight | String | \`""\` | non | Departements/regions a surligner |
+| reference-lines | String | \`""\` | non | Lignes de reference (overlay) en JSON. Cartesiens uniquement (line, bar, bar-line, scatter). Chaque item : \`{ axis: "x" ou "y", value (string ou number), label?, color?, dash?, position? }\`. \`axis:"x"\` → ligne verticale a une categorie/date ; \`axis:"y"\` → ligne horizontale a un seuil. Ex : \`reference-lines='[{"axis":"x","value":"2026-02","label":"Lancement","color":"#c9191e","dash":true},{"axis":"y","value":3000,"label":"Objectif"}]'\`. |
 
 ### Attributs par type de graphique
 | Type | Attributs essentiels | Attributs optionnels |

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -47,6 +47,7 @@
         <option value="direct-line-databox">Ligne + DataBox — Fiscalite locale</option>
         <option value="direct-kpi">KPI — Industrie du futur</option>
         <option value="kpi-barometre">KPI baromètre — titre + évolution (Plan Électrification)</option>
+        <option value="chart-reference-lines">Ligne + repères — Immatriculations VE</option>
         <option value="direct-datalist">Tableau — Maires de France (server-side)</option>
       </optgroup>
       <optgroup label="Pagination serveur">

--- a/apps/playground/src/examples/examples-data.ts
+++ b/apps/playground/src/examples/examples-data.ts
@@ -221,6 +221,39 @@ export const examples: Record<string, string> = {
   </div>
 </div>`,
 
+  'chart-reference-lines': `<!--
+  Lignes de référence — repère vertical (lancement) + seuil horizontal (objectif)
+  Mode direct : dsfr-data-source (data inline) → dsfr-data-chart (type line)
+  Démontre l'attribut reference-lines :
+    - axis "x" : ligne verticale pointillée à une catégorie (mois) + pastille
+    - axis "y" : ligne horizontale à un seuil (objectif), libellé ancré à gauche
+  Les repères sont aussi annoncés dans l'aria-label du graphique.
+-->
+
+<div class="fr-container fr-my-4w">
+  <h2>Immatriculations VE — repères de référence</h2>
+
+  <dsfr-data-source id="immat" data='[
+    {"mois":"2025-11","ventes":21000},
+    {"mois":"2025-12","ventes":23500},
+    {"mois":"2026-01","ventes":22800},
+    {"mois":"2026-02","ventes":28900},
+    {"mois":"2026-03","ventes":33200},
+    {"mois":"2026-04","ventes":35800},
+    {"mois":"2026-05","ventes":37849}
+  ]'></dsfr-data-source>
+
+  <dsfr-data-chart source="immat" type="line"
+    label-field="mois" value-field="ventes"
+    name='["Immatriculations VE"]'
+    unit-tooltip=" VE"
+    reference-lines='[
+      {"axis":"x","value":"2026-02","label":"Lancement du plan","color":"#c9191e","dash":true},
+      {"axis":"y","value":30000,"label":"Objectif","position":"start"}
+    ]'>
+  </dsfr-data-chart>
+</div>`,
+
   'direct-datalist': `<!--
   Tableau — Maires de France (pagination serveur)
   Mode : dsfr-data-source (api-type="tabular", server-side) → dsfr-data-list

--- a/guide/guide-exemples-chart-a11y.html
+++ b/guide/guide-exemples-chart-a11y.html
@@ -112,6 +112,36 @@
           </div>
         </section>
 
+        <!-- Lignes de référence -->
+        <h2>Lignes de référence</h2>
+        <p>L'attribut <code>reference-lines</code> superpose des repères sur les graphiques
+          cartésiens (line, bar, bar-line, scatter) : ligne verticale à une catégorie/date
+          (<code>axis:"x"</code>) ou horizontale à un seuil (<code>axis:"y"</code>), avec un
+          libellé en pastille. Les repères sont aussi annoncés dans l'<code>aria-label</code>
+          du graphique pour les lecteurs d'écran.</p>
+
+        <div class="example-container">
+          <dsfr-data-source id="immat-guide" data='[{"mois":"2025-11","ventes":21000},{"mois":"2025-12","ventes":23500},{"mois":"2026-01","ventes":22800},{"mois":"2026-02","ventes":28900},{"mois":"2026-03","ventes":33200},{"mois":"2026-04","ventes":35800},{"mois":"2026-05","ventes":37849}]'></dsfr-data-source>
+          <dsfr-data-chart id="guide-reflines" source="immat-guide" type="line"
+            label-field="mois" value-field="ventes"
+            name='["Immatriculations VE"]'
+            reference-lines='[{"axis":"x","value":"2026-02","label":"Lancement du plan","color":"#c9191e"},{"axis":"y","value":30000,"label":"Objectif","position":"start"}]'>
+          </dsfr-data-chart>
+        </div>
+
+        <section class="fr-accordion fr-mt-1w">
+          <h3 class="fr-accordion__title"><button class="fr-accordion__btn" aria-expanded="false" aria-controls="code-reflines">Code source</button></h3>
+          <div class="fr-collapse" id="code-reflines">
+<pre>&lt;dsfr-data-chart id="mon-graph" source="data" type="line"
+  label-field="mois" value-field="ventes"
+  reference-lines='[
+    {"axis":"x","value":"2026-02","label":"Lancement du plan","color":"#c9191e"},
+    {"axis":"y","value":30000,"label":"Objectif","position":"start"}
+  ]'&gt;
+&lt;/dsfr-data-chart&gt;</pre>
+          </div>
+        </section>
+
         <!-- Avec description -->
         <h2>Avec description textuelle</h2>
         <p>Ajoutez <code>description</code> pour fournir une transcription du graphique :</p>

--- a/packages/core/src/components/dsfr-data-chart.ts
+++ b/packages/core/src/components/dsfr-data-chart.ts
@@ -4,6 +4,16 @@ import { SourceSubscriberMixin } from '../utils/source-subscriber.js';
 import { getByPath } from '../utils/json-path.js';
 import { sendWidgetBeacon } from '../utils/beacon.js';
 import { renderSourceLoading, renderSourceError } from '../utils/status-templates.js';
+import { reportConfigError, clearConfigError } from '../utils/config-error.js';
+import {
+  parseReferenceLines,
+  isCartesianChartType,
+  resolveChartInstance,
+  computeReferenceGeometries,
+  buildReferenceOverlaySvg,
+  referenceLinesAriaSummary,
+  type ReferenceLine,
+} from '../utils/chart-reference-lines.js';
 import { escapeHtml, toNumber, isValidDeptCode } from '@dsfr-data/shared/lib';
 
 type DSFRChartType =
@@ -194,11 +204,29 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
   @property({ type: String, attribute: 'databox-actions' })
   databoxActions = '';
 
+  /**
+   * Lignes de reference (overlay) au format JSON. Graphiques cartesiens
+   * uniquement (line, bar, bar-line, scatter). Chaque item :
+   * `{ axis: "x"|"y", value: string|number, label?, color?, dash?, position? }`.
+   * `axis:"x"` → ligne verticale a une categorie/date ; `axis:"y"` → ligne
+   * horizontale a un seuil. Ex : `reference-lines='[{"axis":"x","value":"2026-02",
+   * "label":"Lancement","color":"#c9191e","dash":true}]'`.
+   */
+  @property({ type: String, attribute: 'reference-lines' })
+  referenceLines = '';
+
   @state()
   private _data: unknown[] = [];
 
   /** Timers differes en vol — annules au disconnect (#305) */
   private _pendingTimers = new Set<number>();
+
+  /** Lignes de reference : poll rAF en cours (annule au disconnect, #341) */
+  private _refOverlayRaf: number | null = null;
+  /** Lignes de reference : observer de resize du canvas (#341) */
+  private _refOverlayResize: ResizeObserver | null = null;
+  /** Lignes de reference : warn-once si l'instance Chart.js reste introuvable */
+  private _refOverlayWarned = false;
 
   /** Attributs poses par la mise a jour incrementale (#305) */
   private _managedChartAttrs = new Set<string>();
@@ -209,6 +237,15 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
     // onSourceData et survivaient au composant
     for (const t of this._pendingTimers) clearTimeout(t);
     this._pendingTimers.clear();
+    this._cleanupReferenceOverlay();
+  }
+
+  updated(changed: Map<string, unknown>) {
+    super.updated(changed);
+    // Redessine l'overlay de lignes de reference apres chaque rendu (#341).
+    // Chart.js rend de maniere asynchrone → le draw poll en rAF jusqu'a ce que
+    // l'instance soit prete.
+    this._refreshReferenceOverlay();
   }
 
   // Light DOM pour les styles DSFR
@@ -545,7 +582,145 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
     };
     const typeName = typeLabels[this.type] || this.type;
     const count = this._data.length;
-    return `Graphique ${typeName}, ${count} valeurs`;
+    let label = `Graphique ${typeName}, ${count} valeurs`;
+    // Repères de référence relayés a l'aria-label (overlay SVG aria-hidden, #341)
+    if (this.referenceLines && isCartesianChartType(this.type)) {
+      const { lines } = parseReferenceLines(this.referenceLines);
+      if (lines.length) label += `. ${referenceLinesAriaSummary(lines)}`;
+    }
+    return label;
+  }
+
+  // --- Lignes de reference (overlay SVG, #341) -------------------------------
+
+  /** Valide la config et (re)programme le dessin de l'overlay. */
+  private _refreshReferenceOverlay() {
+    if (this._refOverlayRaf !== null) {
+      cancelAnimationFrame(this._refOverlayRaf);
+      this._refOverlayRaf = null;
+    }
+
+    if (!this.referenceLines.trim()) {
+      this._cleanupReferenceOverlay();
+      clearConfigError(this);
+      return;
+    }
+
+    const { lines, error } = parseReferenceLines(this.referenceLines);
+    if (error) {
+      reportConfigError(this, 'dsfr-data-chart', error);
+      this._removeReferenceOverlay();
+      return;
+    }
+    if (!isCartesianChartType(this.type)) {
+      reportConfigError(
+        this,
+        'dsfr-data-chart',
+        `reference-lines : type "${this.type}" non supporté (cartésiens uniquement : line, bar, bar-line, scatter)`
+      );
+      this._removeReferenceOverlay();
+      return;
+    }
+
+    clearConfigError(this);
+    this._scheduleReferenceDraw(lines, 120);
+  }
+
+  /** Poll rAF jusqu'a ce que l'instance Chart.js soit prete (chartArea > 0). */
+  private _scheduleReferenceDraw(lines: ReferenceLine[], framesLeft: number) {
+    if (typeof requestAnimationFrame === 'undefined') return;
+    this._refOverlayRaf = requestAnimationFrame(() => {
+      this._refOverlayRaf = null;
+      if (!this.isConnected) return;
+      if (this._paintReferenceOverlay(lines)) {
+        this._observeReferenceResize(lines);
+        return;
+      }
+      if (framesLeft > 0) {
+        this._scheduleReferenceDraw(lines, framesLeft - 1);
+      } else if (!this._refOverlayWarned) {
+        this._refOverlayWarned = true;
+        console.warn(
+          `dsfr-data-chart[${this.id}]: instance Chart.js introuvable, lignes de référence non dessinées`
+        );
+      }
+    });
+  }
+
+  /** Localise le chart rendu + son canvas + le conteneur positionne. */
+  private _resolveOverlayTargets(): {
+    container: HTMLElement;
+    canvas: HTMLCanvasElement;
+    chartEl: HTMLElement;
+  } | null {
+    const tag = CHART_TAG_MAP[this.type];
+    if (!tag) return null;
+    const container = (this.querySelector('.dsfr-data-chart__wrapper') ||
+      this.querySelector('.dsfr-data-chart__databox-wrapper')) as HTMLElement | null;
+    const chartEl = this.querySelector(tag) as HTMLElement | null;
+    const canvas = (chartEl?.querySelector('canvas') ||
+      this.querySelector('canvas')) as HTMLCanvasElement | null;
+    if (!container || !chartEl || !canvas) return null;
+    return { container, canvas, chartEl };
+  }
+
+  /** Dessine l'overlay. Retourne false si l'instance Chart.js n'est pas prete. */
+  private _paintReferenceOverlay(lines: ReferenceLine[]): boolean {
+    const targets = this._resolveOverlayTargets();
+    if (!targets) return false;
+    const { container, canvas, chartEl } = targets;
+    const chart = resolveChartInstance(chartEl, canvas);
+    if (!chart || !chart.chartArea || chart.chartArea.width <= 0) return false;
+
+    const geometries = computeReferenceGeometries(chart, lines);
+    this._removeReferenceOverlay();
+
+    const w = canvas.clientWidth || canvas.width || 0;
+    const h = canvas.clientHeight || canvas.height || 0;
+    const svg = buildReferenceOverlaySvg(geometries, w, h);
+
+    // Aligner l'overlay sur le canvas dans le conteneur positionne
+    const cRect = canvas.getBoundingClientRect();
+    const wRect = container.getBoundingClientRect();
+    svg.style.left = `${Math.round(cRect.left - wRect.left)}px`;
+    svg.style.top = `${Math.round(cRect.top - wRect.top)}px`;
+    if (getComputedStyle(container).position === 'static') {
+      container.style.position = 'relative';
+    }
+    container.appendChild(svg);
+    return true;
+  }
+
+  /** Observe le resize du canvas pour recalculer l'overlay (debounce rAF). */
+  private _observeReferenceResize(lines: ReferenceLine[]) {
+    if (typeof ResizeObserver === 'undefined') return;
+    const targets = this._resolveOverlayTargets();
+    if (!targets) return;
+    this._refOverlayResize?.disconnect();
+    let pending = false;
+    this._refOverlayResize = new ResizeObserver(() => {
+      if (pending) return;
+      pending = true;
+      requestAnimationFrame(() => {
+        pending = false;
+        if (this.isConnected) this._paintReferenceOverlay(lines);
+      });
+    });
+    this._refOverlayResize.observe(targets.canvas);
+  }
+
+  private _removeReferenceOverlay() {
+    this.querySelector('.dsfr-data-chart__reflines')?.remove();
+  }
+
+  private _cleanupReferenceOverlay() {
+    if (this._refOverlayRaf !== null) {
+      cancelAnimationFrame(this._refOverlayRaf);
+      this._refOverlayRaf = null;
+    }
+    this._refOverlayResize?.disconnect();
+    this._refOverlayResize = null;
+    this._removeReferenceOverlay();
   }
 
   private _createRawChartElement(

--- a/packages/core/src/utils/chart-reference-lines.ts
+++ b/packages/core/src/utils/chart-reference-lines.ts
@@ -1,0 +1,369 @@
+/**
+ * Lignes de référence pour dsfr-data-chart (#341) — logique PURE et testable.
+ *
+ * Trace une ligne verticale (à une catégorie/date) ou horizontale (à un seuil)
+ * sur un graphique cartésien, avec un libellé en pastille. `@gouvfr/dsfr-chart`
+ * rend dans un `<canvas>` (Chart.js) et n'expose aucune prop d'annotation : on
+ * dessine un overlay SVG par-dessus, positionné depuis l'instance Chart.js.
+ *
+ * Aucune dépendance Lit / DOM-bridge : réutilisable et testable hors composant.
+ */
+
+/** Rouge DSFR par défaut (error-active-red-marianne). */
+export const DEFAULT_REF_COLOR = '#c9191e';
+
+/** Une ligne de référence déclarée dans l'attribut `reference-lines` (JSON). */
+export interface ReferenceLine {
+  /** `"x"` → ligne verticale ; `"y"` → ligne horizontale. */
+  axis: 'x' | 'y';
+  /** Valeur ciblée : libellé de catégorie / date (x) ou seuil numérique (y). */
+  value: string | number;
+  /** Libellé affiché en pastille (optionnel). */
+  label?: string;
+  /** Couleur CSS de la ligne et de la pastille. Défaut : rouge DSFR. */
+  color?: string;
+  /** Ligne pointillée. Défaut : true. */
+  dash?: boolean;
+  /** Ancrage du libellé le long de la ligne. Défaut : `"start"`. */
+  position?: 'start' | 'end';
+}
+
+// --- Sous-ensemble structurel (duck-typing) d'une instance Chart.js -----------
+
+export interface ChartScaleLike {
+  getPixelForValue?: (value: unknown, index?: number) => number;
+}
+export interface ChartAreaLike {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  width: number;
+  height: number;
+}
+export interface ChartLike {
+  canvas?: HTMLCanvasElement | null;
+  chartArea?: ChartAreaLike;
+  scales?: Record<string, ChartScaleLike | undefined>;
+  data?: { labels?: unknown[] };
+}
+
+// --- Types de graphiques supportés -------------------------------------------
+
+const CARTESIAN_TYPES = new Set(['line', 'bar', 'bar-line', 'scatter']);
+
+/** Les lignes de référence ne valent que pour les graphiques cartésiens. */
+export function isCartesianChartType(type: string): boolean {
+  return CARTESIAN_TYPES.has(type);
+}
+
+// --- Parsing / validation ----------------------------------------------------
+
+export interface ParseResult {
+  lines: ReferenceLine[];
+  error: string | null;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Parse et valide l'attribut JSON `reference-lines`.
+ * - vide → `{ lines: [], error: null }`
+ * - JSON invalide / pas un tableau → `error` renseigné, `lines: []`
+ * - items invalides → ignorés ; si AUCUN item valide dans un tableau non vide,
+ *   `error` renseigné.
+ */
+export function parseReferenceLines(json: string): ParseResult {
+  const raw = (json || '').trim();
+  if (!raw) return { lines: [], error: null };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { lines: [], error: 'reference-lines : JSON invalide' };
+  }
+  if (!Array.isArray(parsed)) {
+    return { lines: [], error: 'reference-lines : un tableau JSON est attendu' };
+  }
+
+  const lines: ReferenceLine[] = [];
+  for (const item of parsed) {
+    if (!isPlainObject(item)) continue;
+    const axis = item.axis;
+    if (axis !== 'x' && axis !== 'y') continue;
+    const value = item.value;
+    const validValue =
+      (typeof value === 'number' && Number.isFinite(value)) ||
+      (typeof value === 'string' && value.length > 0);
+    if (!validValue) continue;
+
+    const line: ReferenceLine = { axis, value: value as string | number };
+    if (typeof item.label === 'string') line.label = item.label;
+    if (typeof item.color === 'string' && item.color.trim()) line.color = item.color.trim();
+    if (typeof item.dash === 'boolean') line.dash = item.dash;
+    if (item.position === 'start' || item.position === 'end') line.position = item.position;
+    lines.push(line);
+  }
+
+  if (lines.length === 0) {
+    return {
+      lines: [],
+      error: 'reference-lines : aucune ligne valide (axis "x"/"y" + value requis)',
+    };
+  }
+  return { lines, error: null };
+}
+
+// --- Récupération de l'instance Chart.js -------------------------------------
+
+function looksLikeChart(v: unknown, canvas: HTMLCanvasElement | null): v is ChartLike {
+  if (!v || typeof v !== 'object') return false;
+  const c = v as ChartLike;
+  return c.canvas === canvas && !!c.scales && !!c.chartArea;
+}
+
+function deref(v: unknown): unknown {
+  return v && typeof v === 'object' && (v as { __v_isRef?: boolean }).__v_isRef
+    ? (v as { value: unknown }).value
+    : v;
+}
+
+/**
+ * Récupère l'instance Chart.js d'un custom element `@gouvfr/dsfr-chart`.
+ *
+ * La lib bundle sa propre copie de Chart.js (donc `window.Chart.getChart` ne la
+ * connaît pas) et n'expose aucune API publique. Le GATE de faisabilité (#341) a
+ * montré que l'instance vit dans les internes Vue, accessible en ACCÈS DIRECT
+ * via `el._instance.proxy.chart` (et `ctx.chart`) — l'énumération des clés est
+ * vide en build Vue production, donc on cible des noms candidats validés par
+ * duck-typing plutôt que de scanner. Dégradation gracieuse → `null`.
+ */
+export function resolveChartInstance(
+  chartEl: Element | null | undefined,
+  canvas: HTMLCanvasElement | null
+): ChartLike | null {
+  if (!chartEl || !canvas) return null;
+
+  // 1. window.Chart.getChart (inoffensif ; KO car Chart.js est bundlé)
+  const win =
+    typeof window !== 'undefined'
+      ? (window as { Chart?: { getChart?: (c: HTMLCanvasElement) => unknown } })
+      : undefined;
+  try {
+    const viaGlobal = win?.Chart?.getChart?.(canvas);
+    if (looksLikeChart(viaGlobal, canvas)) return viaGlobal;
+  } catch {
+    /* ignore */
+  }
+
+  // 2. Internes Vue — accès DIRECT aux noms candidats (pas d'énumération)
+  const inst = (chartEl as { _instance?: Record<string, Record<string, unknown> | undefined> })
+    ._instance;
+  if (inst) {
+    const candidates: unknown[] = [
+      inst.proxy?.chart,
+      inst.ctx?.chart,
+      inst.setupState?.chart,
+      inst.exposed?.chart,
+      inst.proxy?.myChart,
+      inst.proxy?.chartInstance,
+    ];
+    for (const c of candidates) {
+      const resolved = deref(c);
+      if (looksLikeChart(resolved, canvas)) return resolved;
+    }
+  }
+
+  return null;
+}
+
+// --- Calcul des coordonnées --------------------------------------------------
+
+export interface LineGeometry {
+  axis: 'x' | 'y';
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  color: string;
+  dash: boolean;
+  label?: string;
+  labelX: number;
+  labelY: number;
+  textAnchor: 'start' | 'middle' | 'end';
+}
+
+function pixelForX(chart: ChartLike, value: string | number): number {
+  const scale = chart.scales?.x;
+  if (!scale?.getPixelForValue) return NaN;
+  // Échelle catégorielle : Chart.js attend l'INDEX de la catégorie. On le
+  // retrouve dans data.labels puis on passe (value, index).
+  if (typeof value === 'string' && Array.isArray(chart.data?.labels)) {
+    const idx = chart.data!.labels!.findIndex((l) => String(l) === value);
+    return idx >= 0 ? scale.getPixelForValue(value, idx) : NaN;
+  }
+  return scale.getPixelForValue(value);
+}
+
+/**
+ * Calcule la géométrie (en pixels canvas) de chaque ligne de référence.
+ * Les lignes hors zone traçable ou non résolubles (NaN) sont ignorées.
+ */
+export function computeReferenceGeometries(
+  chart: ChartLike,
+  lines: ReferenceLine[]
+): LineGeometry[] {
+  const area = chart.chartArea;
+  if (!area) return [];
+  const out: LineGeometry[] = [];
+
+  for (const line of lines) {
+    const color = line.color || DEFAULT_REF_COLOR;
+    const dash = line.dash !== false;
+
+    if (line.axis === 'x') {
+      const px = pixelForX(chart, line.value);
+      if (!Number.isFinite(px) || px < area.left - 0.5 || px > area.right + 0.5) continue;
+      const atEnd = line.position === 'end';
+      out.push({
+        axis: 'x',
+        x1: px,
+        y1: area.top,
+        x2: px,
+        y2: area.bottom,
+        color,
+        dash,
+        label: line.label,
+        labelX: px,
+        labelY: atEnd ? area.bottom : area.top,
+        textAnchor: 'middle',
+      });
+    } else {
+      const scale = chart.scales?.y;
+      if (!scale?.getPixelForValue) continue;
+      const py = scale.getPixelForValue(line.value);
+      if (!Number.isFinite(py) || py < area.top - 0.5 || py > area.bottom + 0.5) continue;
+      const atStart = line.position === 'start';
+      out.push({
+        axis: 'y',
+        x1: area.left,
+        y1: py,
+        x2: area.right,
+        y2: py,
+        color,
+        dash,
+        label: line.label,
+        labelX: atStart ? area.left : area.right,
+        labelY: py,
+        textAnchor: atStart ? 'start' : 'end',
+      });
+    }
+  }
+
+  return out;
+}
+
+// --- Génération de l'overlay SVG ---------------------------------------------
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const LABEL_HEIGHT = 18;
+const LABEL_PAD_X = 6;
+const CHAR_WIDTH = 7; // estimation (pas de mesure de texte en logique pure)
+
+/** Largeur estimée d'une pastille pour `label`. */
+function pastilleWidth(label: string): number {
+  return label.length * CHAR_WIDTH + LABEL_PAD_X * 2;
+}
+
+/**
+ * Construit l'overlay SVG (lignes + pastilles) à superposer au canvas.
+ * `aria-hidden` + `pointer-events:none` : purement décoratif, l'info est
+ * relayée dans l'aria-label du wrapper via {@link referenceLinesAriaSummary}.
+ */
+export function buildReferenceOverlaySvg(
+  geometries: LineGeometry[],
+  width: number,
+  height: number
+): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('class', 'dsfr-data-chart__reflines');
+  svg.setAttribute('width', String(width));
+  svg.setAttribute('height', String(height));
+  svg.setAttribute('aria-hidden', 'true');
+  svg.style.position = 'absolute';
+  svg.style.pointerEvents = 'none';
+  svg.style.overflow = 'visible';
+
+  for (const g of geometries) {
+    const line = document.createElementNS(SVG_NS, 'line');
+    line.setAttribute('x1', String(g.x1));
+    line.setAttribute('y1', String(g.y1));
+    line.setAttribute('x2', String(g.x2));
+    line.setAttribute('y2', String(g.y2));
+    line.setAttribute('stroke', g.color);
+    line.setAttribute('stroke-width', '2');
+    if (g.dash) line.setAttribute('stroke-dasharray', '5,4');
+    svg.appendChild(line);
+
+    if (!g.label) continue;
+
+    const w = pastilleWidth(g.label);
+    // Position de la pastille : décalée pour ne pas chevaucher la ligne.
+    let rectX: number;
+    let rectY: number;
+    let textX: number;
+    if (g.axis === 'x') {
+      rectX = Math.max(0, Math.min(g.labelX - w / 2, width - w));
+      // au-dessus (start) ou en dessous (end) de la zone
+      rectY =
+        g.textAnchor === 'middle' && g.labelY === g.y1 ? g.labelY - LABEL_HEIGHT - 2 : g.labelY + 2;
+      textX = rectX + w / 2;
+    } else {
+      // y : ancré à droite (end) ou à gauche (start)
+      rectX = g.textAnchor === 'start' ? g.labelX + 2 : Math.max(0, g.labelX - w - 2);
+      rectY = g.labelY - LABEL_HEIGHT / 2;
+      textX = rectX + w / 2;
+    }
+
+    const group = document.createElementNS(SVG_NS, 'g');
+    group.setAttribute('class', 'dsfr-data-chart__refline-label');
+
+    const rect = document.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('x', String(rectX));
+    rect.setAttribute('y', String(rectY));
+    rect.setAttribute('width', String(w));
+    rect.setAttribute('height', String(LABEL_HEIGHT));
+    rect.setAttribute('rx', '2');
+    rect.setAttribute('fill', g.color);
+    group.appendChild(rect);
+
+    const text = document.createElementNS(SVG_NS, 'text');
+    text.setAttribute('x', String(textX));
+    text.setAttribute('y', String(rectY + LABEL_HEIGHT / 2));
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('dominant-baseline', 'central');
+    text.setAttribute('fill', '#ffffff');
+    text.setAttribute('font-size', '12');
+    text.textContent = g.label;
+    group.appendChild(text);
+
+    svg.appendChild(group);
+  }
+
+  return svg;
+}
+
+/**
+ * Résumé textuel des repères, injecté dans l'aria-label du wrapper pour que les
+ * lecteurs d'écran connaissent les lignes de référence (overlay SVG aria-hidden).
+ */
+export function referenceLinesAriaSummary(lines: ReferenceLine[]): string {
+  const parts = lines.map((l) => {
+    const what = l.label ? `${l.label} ` : '';
+    return `Repere : ${what}a ${l.value}`.replace('  ', ' ');
+  });
+  return parts.join('. ');
+}

--- a/specs/components/dsfr-data-chart.html
+++ b/specs/components/dsfr-data-chart.html
@@ -54,6 +54,10 @@
           <tr><td><code>value-field-2</code></td><td>String</td><td>2e série de valeurs (bar-line)</td></tr>
           <tr><td><code>value-fields</code></td><td>String</td><td>Series supplementaires separees par virgules</td></tr>
           <tr><td><code>highlight-index</code></td><td>String</td><td>Indices a mettre en avant : <code>"[0, 2]"</code></td></tr>
+          <tr><td><code>reference-lines</code></td><td>String (JSON)</td><td>Lignes de référence (overlay) — graphiques cartésiens uniquement (line, bar, bar-line, scatter).
+            Chaque item : <code>{ axis: "x"|"y", value, label?, color?, dash?, position? }</code>.
+            <code>axis:"x"</code> = ligne verticale à une catégorie/date ; <code>axis:"y"</code> = ligne horizontale à un seuil.
+            Ex : <code>reference-lines='[{"axis":"x","value":"2026-02","label":"Lancement","color":"#c9191e","dash":true},{"axis":"y","value":3000,"label":"Objectif"}]'</code>.</td></tr>
         </tbody>
       </table>
 
@@ -140,6 +144,31 @@
   label-field="nom"
   value-field="score_dsfr"
   unit-tooltip="%"&gt;
+&lt;/dsfr-data-chart&gt;</pre></div>
+      </section>
+
+      <section class="demo-section">
+        <h3>3b. Lignes de référence (seuil / repère)</h3>
+        <p class="fr-text--sm">
+          L'attribut <code>reference-lines</code> superpose des repères : ligne horizontale à un seuil
+          (<code>axis:"y"</code>) ou verticale à une catégorie (<code>axis:"x"</code>), avec un libellé en pastille.
+          Graphiques cartésiens uniquement (line, bar, bar-line, scatter).
+        </p>
+        <dsfr-data-chart
+          source="sites"
+          type="line"
+          label-field="nom"
+          value-field="score_dsfr"
+          selected-palette="default"
+          unit-tooltip="%"
+          reference-lines='[{"axis":"y","value":80,"label":"Objectif","color":"#c9191e"}]'>
+        </dsfr-data-chart>
+        <div class="code-block"><pre>&lt;dsfr-data-chart
+  source="sites"
+  type="line"
+  label-field="nom"
+  value-field="score_dsfr"
+  reference-lines='[{"axis":"y","value":80,"label":"Objectif","color":"#c9191e"}]'&gt;
 &lt;/dsfr-data-chart&gt;</pre></div>
       </section>
 

--- a/tests/apps/playground/examples.test.ts
+++ b/tests/apps/playground/examples.test.ts
@@ -8,6 +8,7 @@ describe('playground examples', () => {
     'direct-line-databox',
     'direct-kpi',
     'kpi-barometre',
+    'chart-reference-lines',
     'direct-datalist',
     'direct-worldmap',
   ];
@@ -57,8 +58,8 @@ describe('playground examples', () => {
     }
   });
 
-  it('should have 33 examples', () => {
-    expect(Object.keys(examples)).toHaveLength(33);
+  it('should have 34 examples', () => {
+    expect(Object.keys(examples)).toHaveLength(34);
   });
 
   it('should have non-empty code for all examples', () => {

--- a/tests/dsfr-data-chart.test.ts
+++ b/tests/dsfr-data-chart.test.ts
@@ -594,4 +594,53 @@ describe('DsfrDataChart', () => {
       expect(wrapper.querySelector('data-box')).toBeTruthy();
     });
   });
+
+  // --- Lignes de reference (#341) -------------------------------------------
+  describe('reference-lines', () => {
+    let el: DsfrDataChart;
+
+    afterEach(() => {
+      el?.remove();
+    });
+
+    async function mount(props: Partial<DsfrDataChart>): Promise<DsfrDataChart> {
+      el = new DsfrDataChart();
+      Object.assign(el, props);
+      document.body.appendChild(el);
+      await el.updateComplete;
+      return el;
+    }
+
+    it('type non cartésien + reference-lines → data-dsfr-config-error', async () => {
+      await mount({ type: 'pie', referenceLines: '[{"axis":"y","value":10}]' });
+      expect(el.getAttribute('data-dsfr-config-error')).toMatch(/non supporté/);
+    });
+
+    it('JSON invalide → data-dsfr-config-error', async () => {
+      await mount({ type: 'line', referenceLines: '[{bad json}]' });
+      expect(el.getAttribute('data-dsfr-config-error')).toMatch(/JSON invalide/);
+    });
+
+    it('type cartésien + JSON valide → pas d erreur de config', async () => {
+      await mount({ type: 'line', referenceLines: '[{"axis":"y","value":10}]' });
+      expect(el.hasAttribute('data-dsfr-config-error')).toBe(false);
+    });
+
+    it('retrait de reference-lines efface l erreur', async () => {
+      await mount({ type: 'pie', referenceLines: '[{"axis":"y","value":10}]' });
+      expect(el.hasAttribute('data-dsfr-config-error')).toBe(true);
+      el.referenceLines = '';
+      await el.updateComplete;
+      expect(el.hasAttribute('data-dsfr-config-error')).toBe(false);
+    });
+
+    it('aria-label inclut le résumé des repères sur un cartésien', () => {
+      (chart as any)._data = [{ m: 'Jan', v: 1 }];
+      chart.type = 'line';
+      chart.labelField = 'm';
+      chart.valueField = 'v';
+      chart.referenceLines = '[{"axis":"x","value":"Jan","label":"Lancement"}]';
+      expect((chart as any)._getAriaLabel()).toContain('Lancement');
+    });
+  });
 });

--- a/tests/utils/chart-reference-lines.test.ts
+++ b/tests/utils/chart-reference-lines.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import {
+  parseReferenceLines,
+  isCartesianChartType,
+  resolveChartInstance,
+  computeReferenceGeometries,
+  buildReferenceOverlaySvg,
+  referenceLinesAriaSummary,
+  DEFAULT_REF_COLOR,
+  type ChartLike,
+} from '@/utils/chart-reference-lines.js';
+
+// --- Chart.js mock (duck-typed) ----------------------------------------------
+
+function mockChart(canvas: HTMLCanvasElement, overrides: Partial<ChartLike> = {}): ChartLike {
+  return {
+    canvas,
+    chartArea: { left: 50, right: 450, top: 20, bottom: 320, width: 400, height: 300 },
+    data: { labels: ['Jan', 'Fev', 'Mar', 'Avr'] },
+    scales: {
+      // catégorielle : pixel par index réparti sur [left, right]
+      x: {
+        getPixelForValue: (_v: unknown, i?: number) => {
+          if (typeof i !== 'number' || !Number.isFinite(i)) return NaN;
+          return 50 + (i / 3) * 400; // 4 labels → i ∈ 0..3
+        },
+      },
+      // linéaire : 0..40 → bottom(320)..top(20)
+      y: {
+        getPixelForValue: (v: unknown) => {
+          const n = Number(v);
+          if (!Number.isFinite(n)) return NaN;
+          return 320 - (n / 40) * 300;
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe('parseReferenceLines', () => {
+  it('vide → pas d erreur, pas de lignes', () => {
+    expect(parseReferenceLines('')).toEqual({ lines: [], error: null });
+    expect(parseReferenceLines('   ')).toEqual({ lines: [], error: null });
+  });
+
+  it('parse un tableau valide avec defaults', () => {
+    const { lines, error } = parseReferenceLines(
+      '[{"axis":"x","value":"Fev","label":"Lancement"},{"axis":"y","value":3000}]'
+    );
+    expect(error).toBeNull();
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatchObject({ axis: 'x', value: 'Fev', label: 'Lancement' });
+    expect(lines[1]).toMatchObject({ axis: 'y', value: 3000 });
+  });
+
+  it('JSON invalide → erreur', () => {
+    const r = parseReferenceLines('[{axis:x}]');
+    expect(r.lines).toEqual([]);
+    expect(r.error).toMatch(/JSON invalide/);
+  });
+
+  it('pas un tableau → erreur', () => {
+    expect(parseReferenceLines('{"axis":"x","value":1}').error).toMatch(/tableau/);
+  });
+
+  it('ignore les items invalides (axis manquant, value vide)', () => {
+    const { lines, error } = parseReferenceLines(
+      '[{"axis":"z","value":1},{"axis":"x"},{"axis":"x","value":""},{"axis":"y","value":5}]'
+    );
+    expect(error).toBeNull();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ axis: 'y', value: 5 });
+  });
+
+  it('tableau non vide mais 100% invalide → erreur', () => {
+    expect(parseReferenceLines('[{"axis":"z"}]').error).toMatch(/aucune ligne valide/);
+  });
+
+  it('conserve color/dash/position quand fournis', () => {
+    const { lines } = parseReferenceLines(
+      '[{"axis":"x","value":"Mar","color":"#000","dash":false,"position":"end"}]'
+    );
+    expect(lines[0]).toMatchObject({ color: '#000', dash: false, position: 'end' });
+  });
+
+  it('value NaN/Infinity rejetée', () => {
+    // JSON ne supporte pas NaN/Infinity littéral ; on teste null et booléen
+    const { lines } = parseReferenceLines('[{"axis":"y","value":null},{"axis":"y","value":true}]');
+    expect(lines).toHaveLength(0);
+  });
+});
+
+describe('isCartesianChartType', () => {
+  it('cartésiens supportés', () => {
+    for (const t of ['line', 'bar', 'bar-line', 'scatter']) {
+      expect(isCartesianChartType(t)).toBe(true);
+    }
+  });
+  it('non cartésiens rejetés', () => {
+    for (const t of ['pie', 'gauge', 'radar', 'map', 'map-reg']) {
+      expect(isCartesianChartType(t)).toBe(false);
+    }
+  });
+});
+
+describe('resolveChartInstance', () => {
+  afterEach(() => {
+    delete (window as Record<string, unknown>).Chart;
+    vi.restoreAllMocks();
+  });
+
+  function fakeEl(instance: unknown): Element {
+    return { _instance: instance } as unknown as Element;
+  }
+
+  it('null si element ou canvas manquant', () => {
+    const canvas = document.createElement('canvas');
+    expect(resolveChartInstance(null, canvas)).toBeNull();
+    expect(resolveChartInstance(fakeEl({}), null)).toBeNull();
+  });
+
+  it('trouve l instance via _instance.proxy.chart (accès direct)', () => {
+    const canvas = document.createElement('canvas');
+    const chart = mockChart(canvas);
+    const el = fakeEl({ proxy: { chart } });
+    expect(resolveChartInstance(el, canvas)).toBe(chart);
+  });
+
+  it('fallback _instance.ctx.chart', () => {
+    const canvas = document.createElement('canvas');
+    const chart = mockChart(canvas);
+    const el = fakeEl({ ctx: { chart } });
+    expect(resolveChartInstance(el, canvas)).toBe(chart);
+  });
+
+  it('déréférence un ref Vue ({ __v_isRef, value })', () => {
+    const canvas = document.createElement('canvas');
+    const chart = mockChart(canvas);
+    const el = fakeEl({ proxy: { chart: { __v_isRef: true, value: chart } } });
+    expect(resolveChartInstance(el, canvas)).toBe(chart);
+  });
+
+  it('rejette un objet dont le canvas ne correspond pas', () => {
+    const canvas = document.createElement('canvas');
+    const other = document.createElement('canvas');
+    const chart = mockChart(other);
+    expect(resolveChartInstance(fakeEl({ proxy: { chart } }), canvas)).toBeNull();
+  });
+
+  it('utilise window.Chart.getChart si présent et valide', () => {
+    const canvas = document.createElement('canvas');
+    const chart = mockChart(canvas);
+    (window as Record<string, unknown>).Chart = { getChart: () => chart };
+    expect(resolveChartInstance(fakeEl({}), canvas)).toBe(chart);
+  });
+
+  it('null si rien ne matche', () => {
+    const canvas = document.createElement('canvas');
+    expect(resolveChartInstance(fakeEl({ proxy: {}, ctx: {} }), canvas)).toBeNull();
+  });
+});
+
+describe('computeReferenceGeometries', () => {
+  const canvas = document.createElement('canvas');
+
+  it('ligne verticale x sur une catégorie (index résolu via data.labels)', () => {
+    const chart = mockChart(canvas);
+    const [g] = computeReferenceGeometries(chart, [{ axis: 'x', value: 'Fev', label: 'L' }]);
+    // index 1 → 50 + (1/3)*400 ≈ 183.33
+    expect(g.axis).toBe('x');
+    expect(g.x1).toBeCloseTo(183.33, 1);
+    expect(g.x1).toBe(g.x2);
+    expect(g.y1).toBe(20);
+    expect(g.y2).toBe(320);
+    expect(g.color).toBe(DEFAULT_REF_COLOR);
+    expect(g.dash).toBe(true);
+  });
+
+  it('ligne horizontale y sur un seuil', () => {
+    const chart = mockChart(canvas);
+    const [g] = computeReferenceGeometries(chart, [{ axis: 'y', value: 20 }]);
+    // 320 - (20/40)*300 = 170
+    expect(g.axis).toBe('y');
+    expect(g.y1).toBe(170);
+    expect(g.y1).toBe(g.y2);
+    expect(g.x1).toBe(50);
+    expect(g.x2).toBe(450);
+    expect(g.textAnchor).toBe('end'); // défaut côté droit
+  });
+
+  it('position start déplace l ancre du libellé y à gauche', () => {
+    const chart = mockChart(canvas);
+    const [g] = computeReferenceGeometries(chart, [{ axis: 'y', value: 20, position: 'start' }]);
+    expect(g.textAnchor).toBe('start');
+    expect(g.labelX).toBe(50);
+  });
+
+  it('catégorie inconnue → ignorée', () => {
+    const chart = mockChart(canvas);
+    expect(computeReferenceGeometries(chart, [{ axis: 'x', value: 'Inconnu' }])).toHaveLength(0);
+  });
+
+  it('valeur y hors zone → ignorée', () => {
+    const chart = mockChart(canvas);
+    // 3000 → bien au-dessus du top → skip
+    expect(computeReferenceGeometries(chart, [{ axis: 'y', value: 3000 }])).toHaveLength(0);
+  });
+
+  it('respecte color et dash=false', () => {
+    const chart = mockChart(canvas);
+    const [g] = computeReferenceGeometries(chart, [
+      { axis: 'y', value: 20, color: '#0a0', dash: false },
+    ]);
+    expect(g.color).toBe('#0a0');
+    expect(g.dash).toBe(false);
+  });
+
+  it('sans chartArea → vide', () => {
+    const chart = mockChart(canvas, { chartArea: undefined });
+    expect(computeReferenceGeometries(chart, [{ axis: 'y', value: 20 }])).toEqual([]);
+  });
+});
+
+describe('buildReferenceOverlaySvg', () => {
+  const canvas = document.createElement('canvas');
+
+  it('produit un svg aria-hidden, pointer-events none, une <line> par géométrie', () => {
+    const chart = mockChart(canvas);
+    const geos = computeReferenceGeometries(chart, [
+      { axis: 'x', value: 'Fev', label: 'Lancement' },
+      { axis: 'y', value: 20 },
+    ]);
+    const svg = buildReferenceOverlaySvg(geos, 500, 340);
+    expect(svg.getAttribute('aria-hidden')).toBe('true');
+    expect(svg.style.pointerEvents).toBe('none');
+    expect(svg.querySelectorAll('line')).toHaveLength(2);
+    // une seule pastille (seule la 1re a un label)
+    expect(svg.querySelectorAll('.dsfr-data-chart__refline-label')).toHaveLength(1);
+    const text = svg.querySelector('text');
+    expect(text?.textContent).toBe('Lancement');
+  });
+
+  it('applique stroke-dasharray seulement si dash', () => {
+    const chart = mockChart(canvas);
+    const geos = computeReferenceGeometries(chart, [
+      { axis: 'y', value: 20, dash: true },
+      { axis: 'y', value: 10, dash: false },
+    ]);
+    const svg = buildReferenceOverlaySvg(geos, 500, 340);
+    const lines = svg.querySelectorAll('line');
+    expect(lines[0].getAttribute('stroke-dasharray')).toBe('5,4');
+    expect(lines[1].getAttribute('stroke-dasharray')).toBeNull();
+  });
+});
+
+describe('referenceLinesAriaSummary', () => {
+  it('résume les repères pour les lecteurs d écran', () => {
+    const s = referenceLinesAriaSummary([
+      { axis: 'x', value: '2026-02', label: 'Lancement du plan' },
+      { axis: 'y', value: 3000, label: 'Objectif' },
+    ]);
+    expect(s).toContain('Lancement du plan');
+    expect(s).toContain('2026-02');
+    expect(s).toContain('Objectif');
+    expect(s).toContain('3000');
+  });
+});


### PR DESCRIPTION
docs(chart): exemple reference-lines dans le playground + le guide ([#341](https://github.com/bmatge/dsfr-data/issues/341))

- playground : exemple 'chart-reference-lines' (line chart + repere vertical
  lancement + seuil horizontal objectif) + option menu + cle/compteur de test (34).
- guide (guide-exemples-chart-a11y) : section « Lignes de reference » avec
  exemple vivant + code source, note sur l'annonce aria.
- spec : table + exemple vivant deja ajoutes dans le commit precedent.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>