### PR TITLE
feat(core): <dsfr-data-beacon> — cible télémétrie déclarative (#345)

### DIFF
--- a/.changeset/beacon-declaratif.md
+++ b/.changeset/beacon-declaratif.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': minor
+---
+
+Nouvel element `<dsfr-data-beacon url="...">` (#345) : cible telemetrie **declarative**, pendant cote telemetrie de `proxy-url` (#340). Rend la collecte d'usage **visible et retirable** dans le HTML au lieu d'un `window.*` opaque — un integrateur voit qu'une telemetrie part et vers ou (et peut la retirer), un operateur souverain (ministère…) la pointe vers son propre collecteur sans toucher au JS de la page. La presence d'un element avec `url` non vide vaut **opt-in** ET fournit l'URL de collecte. Precedence : element `url` > `window.DSFR_DATA_BEACON_URL` > URL bakee au build ; `window.DSFR_DATA_BEACON = false` reste un **kill switch** qui neutralise meme un element present. L'element est invisible, n'emet aucun beacon lui-meme et vit dans le bundle **core** ; consulte en lookup paresseux (+ micro-defer) au moment de l'envoi, son ordre dans le DOM est indifferent. Off par defaut : sans element ni global, rien ne change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,11 +489,12 @@ Publication npm : `npm publish` via workflow GitHub Actions sur tag `v*`.
 
 ## Beacon de tracking
 
-Les beacons sont **desactives par defaut** (opt-in). Pour les activer, le site deployeur doit definir `window.DSFR_DATA_BEACON = true` avant le chargement des composants.
+Les beacons sont **desactives par defaut** (opt-in). Pour les activer, deux voies : poser `window.DSFR_DATA_BEACON = true` avant le chargement des composants, **ou** placer un element declaratif `<dsfr-data-beacon url="...">` dans la page (#345, voir ci-dessous).
 
 Quand active, chaque composant `dsfr-data-*` envoie un beacon fire-and-forget a l'initialisation (`connectedCallback`) via `sendWidgetBeacon()` dans `packages/core/src/utils/beacon.ts`. Le beacon transmet le nom du composant, le type de graphique et l'origine de la page (`window.location.origin` via le parametre `r=`) au proxy nginx qui les enregistre dans `beacon.log`. Un script periodique (`scripts/parse-beacon-logs.sh`) transforme ces logs en `monitoring-data.json` consomme par l'app monitoring.
 
-- **Opt-in** : `window.DSFR_DATA_BEACON = true` requis pour activer l'envoi
+- **Opt-in** : `window.DSFR_DATA_BEACON = true` **ou** un `<dsfr-data-beacon url="...">` present (avec `url` non vide) requis pour activer l'envoi
+- **`<dsfr-data-beacon url="...">` (#345)** — cible telemetrie **declarative** (pendant de `proxy-url`) : rend la collecte visible et retirable dans le HTML au lieu d'un `window.*` opaque. Sa presence vaut opt-in ET fournit l'URL de collecte. **Precedence de l'URL** : element `url` > `window.DSFR_DATA_BEACON_URL` (#340) > URL bakee au build. **Kill switch** : `window.DSFR_DATA_BEACON = false` neutralise meme un element present (coherent avec `window.DSFR_DATA_PROXY = false`). L'element est invisible, n'emet aucun beacon lui-meme, et vit dans le bundle **core** ; il est consulte en **lookup paresseux** au moment de l'envoi (#156), donc son ordre dans le DOM est indifferent (micro-defer `DOMContentLoaded`/microtask pour le cas « element declare apres un composant »).
 - Le parametre `r=` envoie `window.location.origin` pour identifier le site deployeur (plus fiable que le header HTTP Referer qui depend du Referrer-Policy du site)
 - Les parsers (sh et js) preferent `$arg_r` et tombent en fallback sur `$http_referer` pour compatibilite avec les anciens logs
 - Deduplication par `Set` en memoire (1 beacon par composant+type par page)

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -3028,6 +3028,54 @@ Se connecte au pipeline dsfr-data-source / dsfr-data-query via l'attribut \`sour
 </dsfr-data-podium>
 \`\`\``,
   },
+
+  dsfrDataBeacon: {
+    id: 'dsfrDataBeacon',
+    name: 'dsfr-data-beacon',
+    description: 'Cible telemetrie declarative (opt-in visible et retirable dans le HTML)',
+    trigger: [
+      'beacon',
+      'telemetrie',
+      'télémétrie',
+      'tracking',
+      'statistiques usage',
+      'collecte',
+      'suivi usage',
+    ],
+    content: `## <dsfr-data-beacon> - Cible telemetrie declarative (#345)
+
+Pendant declaratif de \`proxy-url\` cote telemetrie. Par defaut le beacon d'usage
+est **desactive**. Cet element rend la collecte VISIBLE et RETIRABLE dans le HTML
+(au lieu d'un \`window.*\` opaque) : un integrateur voit qu'une telemetrie part,
+et vers ou, et peut la retirer.
+
+La presence d'un \`<dsfr-data-beacon url="...">\` avec un \`url\` non vide :
+- fournit l'URL de collecte (prioritaire sur \`window.DSFR_DATA_BEACON_URL\` puis
+  sur l'URL bakee au build) ;
+- vaut **opt-in** (equivaut a \`window.DSFR_DATA_BEACON = true\`).
+
+\`window.DSFR_DATA_BEACON = false\` reste un kill switch qui neutralise meme un
+element present. L'element est invisible et n'emet aucun beacon lui-meme : il est
+consulte en lookup paresseux au moment de l'envoi, donc son ordre dans le DOM ne
+compte pas (peut etre place apres les composants).
+
+### Attributs
+
+| Attribut | Type | Défaut | Requis | Description |
+|----------|------|--------|--------|-------------|
+| url | String | \`""\` | non | Domaine de collecte du beacon. Présence avec valeur non vide = opt-in + cible. Vide = no-op. |
+
+### Pattern
+
+\`\`\`html
+<!-- Telemetrie vers un collecteur souverain, visible et retirable -->
+<dsfr-data-beacon url="https://collecte.ministere.fr"></dsfr-data-beacon>
+
+<dsfr-data-chart ...></dsfr-data-chart>
+<dsfr-data-kpi ...></dsfr-data-kpi>
+\`\`\`
+`,
+  },
 };
 
 /**

--- a/packages/app-ui/src/app-layout-demo.ts
+++ b/packages/app-ui/src/app-layout-demo.ts
@@ -195,6 +195,11 @@ export class AppLayoutDemo extends LitElement {
             label: 'dsfr-data-chart',
             href: 'components/dsfr-data-chart.html',
           },
+          {
+            id: 'components/dsfr-data-beacon',
+            label: 'dsfr-data-beacon',
+            href: 'components/dsfr-data-beacon.html',
+          },
         ],
       },
       {

--- a/packages/core/src/components/dsfr-data-beacon.ts
+++ b/packages/core/src/components/dsfr-data-beacon.ts
@@ -1,0 +1,55 @@
+import { LitElement, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+/**
+ * <dsfr-data-beacon url="..."> — cible telemetrie declarative (#345).
+ *
+ * Pendant declaratif de `proxy-url` (#340) cote telemetrie : rend la collecte
+ * du beacon VISIBLE et RETIRABLE dans le HTML, au lieu d'un `window.*` opaque.
+ * L'integrateur qui colle un embed *voit* qu'une telemetrie part et vers ou,
+ * et peut la retirer en connaissance de cause (argument RGPD/souverainete).
+ *
+ * La presence d'un element avec un `url` non vide :
+ *   - fournit l'URL de collecte, **prioritaire** sur `window.DSFR_DATA_BEACON_URL`
+ *     puis sur l'URL bakee au build ;
+ *   - vaut **opt-in** (equivaut a `window.DSFR_DATA_BEACON = true`).
+ * `window.DSFR_DATA_BEACON = false` reste un **kill switch** qui neutralise meme
+ * un element present (coherent avec `window.DSFR_DATA_PROXY = false`).
+ *
+ * L'element est invisible (aucun rendu) et vit dans le bundle core. Il ne
+ * declenche AUCUN beacon lui-meme : c'est `beacon.ts` qui le consulte en
+ * **lookup paresseux** au moment de l'envoi (#156), donc l'ordre de declaration
+ * dans le DOM ne compte pas — l'element peut etre place apres les composants.
+ *
+ * ```html
+ * <dsfr-data-beacon url="https://collecte.ministere.fr"></dsfr-data-beacon>
+ * <dsfr-data-chart ...></dsfr-data-chart>
+ * ```
+ */
+@customElement('dsfr-data-beacon')
+export class DsfrDataBeacon extends LitElement {
+  /** Domaine de collecte du beacon. Vide = pas de cible declarative (no-op). */
+  @property({ type: String })
+  url = '';
+
+  /** Light DOM : element de configuration, aucun rendu visible. */
+  createRenderRoot() {
+    return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Element de config strictement invisible (pas de footprint de layout).
+    this.style.display = 'none';
+  }
+
+  render() {
+    return nothing;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'dsfr-data-beacon': DsfrDataBeacon;
+  }
+}

--- a/packages/core/src/index-core.ts
+++ b/packages/core/src/index-core.ts
@@ -23,6 +23,7 @@ export { DsfrDataDisplay } from './components/dsfr-data-display.js';
 export { DsfrDataChart } from './components/dsfr-data-chart.js';
 export { DsfrDataPodium } from './components/dsfr-data-podium.js';
 export { DsfrDataA11y } from './components/dsfr-data-a11y.js';
+export { DsfrDataBeacon } from './components/dsfr-data-beacon.js';
 
 // Utilitaires
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export { DsfrDataMapLayer } from './components/dsfr-data-map-layer.js';
 export { DsfrDataMapPopup } from './components/dsfr-data-map-popup.js';
 export { DsfrDataMapTimeline } from './components/dsfr-data-map-timeline.js';
 export { DsfrDataA11y } from './components/dsfr-data-a11y.js';
+export { DsfrDataBeacon } from './components/dsfr-data-beacon.js';
 
 // Utilitaires (pour usage avancé)
 export {

--- a/packages/core/src/utils/beacon.ts
+++ b/packages/core/src/utils/beacon.ts
@@ -6,20 +6,42 @@
 
 import { BEACON_BASE_URL } from '@dsfr-data/shared/lib';
 
+/** Retire les slashs finals sans regex (evite l'alerte CodeQL polynomial-redos #340). */
+function stripTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s[end - 1] === '/') end--;
+  return s.slice(0, end);
+}
+
 /**
- * Resout la base de collecte du beacon **a l'appel** (#340) :
- * `window.DSFR_DATA_BEACON_URL` (string non vide) est prioritaire sur la
- * valeur bakee au build (`BEACON_BASE_URL`). Resolu dynamiquement et non en
- * const au chargement pour que le site hote puisse la poser avant le 1er
- * beacon. Vide → no-op (pas de domaine de collecte).
+ * URL de collecte declaree via `<dsfr-data-beacon url="...">` (#345), lue en
+ * **lookup paresseux** au moment de l'envoi : l'element peut etre declare APRES
+ * un composant dans le DOM (le composant connecte avant), donc jamais a l'init
+ * (meme regle que #156). On cible un element ayant l'attribut `url`. Vide si
+ * absent ou hors d'un document (SSR/tests sans DOM).
  */
-function resolveBeaconBase(): string {
+function beaconElementUrl(): string {
+  if (typeof document === 'undefined') return '';
+  const el = document.querySelector('dsfr-data-beacon[url]');
+  const raw = el?.getAttribute('url');
+  return typeof raw === 'string' ? raw.trim() : '';
+}
+
+/**
+ * Resout la base de collecte du beacon **a l'appel**. Precedence, du plus
+ * specifique au plus general (#340, #345) :
+ *   `<dsfr-data-beacon url>` > `window.DSFR_DATA_BEACON_URL` > URL bakee au build.
+ * Resolu dynamiquement (pas en const au chargement) pour que le site hote puisse
+ * poser l'override ou l'element avant le 1er beacon. Vide → no-op.
+ */
+function resolveBeaconBase(elementUrl: string): string {
+  if (elementUrl) return stripTrailingSlashes(elementUrl);
   const override =
     typeof window !== 'undefined'
       ? (window as Window & { DSFR_DATA_BEACON_URL?: string }).DSFR_DATA_BEACON_URL
       : undefined;
   if (typeof override === 'string' && override.trim()) {
-    return override.trim().replace(/\/+$/, '');
+    return stripTrailingSlashes(override.trim());
   }
   return BEACON_BASE_URL;
 }
@@ -39,8 +61,27 @@ function sanitizeUrl(href: string): string {
 }
 
 /**
+ * Differe une 1re evaluation le temps que le HTML initial finisse de parser, afin
+ * qu'un `<dsfr-data-beacon>` declare APRES un composant (les composants emettent
+ * dans `connectedCallback`, synchrone) soit malgre tout pris en compte. En cours
+ * de parse → `DOMContentLoaded` (l'element peut etre n'importe ou dans le HTML
+ * initial) ; sinon → microtask (ajout dynamique dans le meme tick). Jamais bloquant.
+ */
+function deferBeacon(fn: () => void): void {
+  if (typeof document !== 'undefined' && document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', fn, { once: true });
+  } else if (typeof queueMicrotask === 'function') {
+    queueMicrotask(fn);
+  } else {
+    fn();
+  }
+}
+
+/**
  * Send a beacon to track widget usage.
- * Disabled by default. Enable with: window.DSFR_DATA_BEACON = true
+ * Disabled by default. Enable with `window.DSFR_DATA_BEACON = true` OR by placing
+ * a `<dsfr-data-beacon url="...">` element in the page (declarative opt-in, #345).
+ * `window.DSFR_DATA_BEACON = false` is a kill switch that neutralizes even the element.
  * Deduplicated: only one beacon per component+type per page load.
  * Skipped in dev mode (localhost).
  *
@@ -53,16 +94,39 @@ function sanitizeUrl(href: string): string {
  * Ne PAS envoyer de preset de tuiles, d'URL, ni d'option d'affichage.
  */
 export function sendWidgetBeacon(component: string, subtype?: string): void {
-  // Opt-in: beacons are disabled unless explicitly enabled
-  if (
-    typeof window === 'undefined' ||
-    !(window as Window & { DSFR_DATA_BEACON?: boolean }).DSFR_DATA_BEACON
-  )
-    return;
+  if (typeof window === 'undefined') return;
 
-  // Aucun domaine de collecte (ni override runtime, ni bake au build) :
-  // aucun endroit où envoyer le beacon
-  const beaconBase = resolveBeaconBase();
+  // Opt-in (off par defaut), trois sources :
+  //  - window.DSFR_DATA_BEACON === false : kill switch explicite, neutralise
+  //    meme un <dsfr-data-beacon> present (coherent avec DSFR_DATA_PROXY = false) ;
+  //  - window.DSFR_DATA_BEACON === true : opt-in global classique ;
+  //  - <dsfr-data-beacon url="..."> dans le DOM : opt-in declaratif (#345).
+  const flag = (window as Window & { DSFR_DATA_BEACON?: boolean }).DSFR_DATA_BEACON;
+  if (flag === false) return;
+
+  // Opt-in deja certain (flag global, ou element deja parse) → emission
+  // synchrone. Sinon l'element peut etre declare plus loin dans le HTML : on
+  // reverifie une fois le DOM pret, sans bloquer le composant.
+  if (flag === true || beaconElementUrl()) {
+    emitBeacon(component, subtype);
+  } else {
+    deferBeacon(() => emitBeacon(component, subtype));
+  }
+}
+
+function emitBeacon(component: string, subtype?: string): void {
+  if (typeof window === 'undefined') return;
+
+  // Reevaluation au moment de l'emission (peut etre differee) : le kill switch
+  // et l'opt-in declaratif sont relus ici car l'element a pu apparaitre depuis.
+  const flag = (window as Window & { DSFR_DATA_BEACON?: boolean }).DSFR_DATA_BEACON;
+  if (flag === false) return;
+  const elementUrl = beaconElementUrl();
+  if (flag !== true && !elementUrl) return;
+
+  // Aucun domaine de collecte (ni element, ni override runtime, ni bake au
+  // build) : aucun endroit où envoyer le beacon.
+  const beaconBase = resolveBeaconBase(elementUrl);
   if (!beaconBase) return;
 
   const key = `${component}:${subtype || ''}`;

--- a/specs/components/dsfr-data-beacon.html
+++ b/specs/components/dsfr-data-beacon.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="fr" data-fr-scheme="system">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>dsfr-data-beacon - Composants - dsfr-data</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
+  <script type="module" src="/dist/dsfr-data.esm.js"></script>
+  <script type="module" src="/dist/app-ui.esm.js"></script>
+  <style>
+    body { min-height: 100vh; display: flex; flex-direction: column; }
+  </style>
+</head>
+<body>
+  <!-- Header -->
+  <app-header current-page="composants" base-path="../../"></app-header>
+
+  <!-- Layout documentation avec sidemenu -->
+  <app-layout-demo
+    title="dsfr-data-beacon"
+    icon="ri-radar-line"
+    active-path="components/dsfr-data-beacon"
+    base-path="../">
+    <div slot="content">
+        <p class="fr-text--lead">
+          Cible de telemetrie <strong>declarative</strong>. Pendant cote telemetrie de
+          <code>proxy-url</code> : rend la collecte d'usage <strong>visible et retirable</strong>
+          dans le HTML, au lieu d'un <code>window.*</code> opaque.
+        </p>
+
+        <div class="fr-callout fr-callout--blue-france">
+          <p class="fr-callout__text">
+            <strong>Invisible et opt-in :</strong> Ce composant ne rend rien et n'envoie aucun beacon
+            lui-même. Par defaut la telemetrie est <strong>desactivee</strong>. Poser un
+            <code>&lt;dsfr-data-beacon url="..."&gt;</code> avec un <code>url</code> non vide
+            <strong>active</strong> la collecte et en designe la cible.
+          </p>
+        </div>
+
+        <h2 id="probleme">Le probleme resolu</h2>
+        <p>
+          Historiquement, la telemetrie d'usage se pilotait uniquement par des variables globales posees
+          sur <code>window</code> avant le chargement des composants (<code>window.DSFR_DATA_BEACON = true</code>,
+          <code>window.DSFR_DATA_BEACON_URL</code>). Un integrateur qui colle un embed ne <em>voit</em> pas
+          qu'une telemetrie part, ni vers ou.
+        </p>
+        <p>
+          L'element rend cette intention explicite dans le DOM : un operateur (ministère, etablissement public)
+          peut diriger la collecte vers <strong>son propre collecteur</strong> sans toucher au JavaScript de la
+          page, et un integrateur peut la <strong>retirer en connaissance de cause</strong> (argument RGPD /
+          souverainete solide, contrairement a un <code>window.*</code> invisible).
+        </p>
+
+        <h2 id="attributs" class="fr-mt-4w">Attributs</h2>
+        <table class="attr-table">
+          <thead><tr><th>Attribut</th><th>Type</th><th>Format / Valeurs</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>url</code></td><td>String</td><td><code>url="https://collecte.ministere.fr"</code></td><td>Domaine de collecte du beacon. Présence avec valeur non vide = opt-in + cible. Vide ou absent = no-op (aucune collecte declarative).</td></tr>
+          </tbody>
+        </table>
+
+        <h2 id="precedence" class="fr-mt-4w">Precedence et opt-in</h2>
+        <p>L'URL de collecte est resolue, du plus spécifique au plus général :</p>
+        <div class="code-block"><pre>&lt;dsfr-data-beacon url&gt;  &gt;  window.DSFR_DATA_BEACON_URL  &gt;  URL bakee au build</pre></div>
+        <p>L'opt-in (off par défaut) est acquis si l'une de ces conditions est vraie :</p>
+        <ul>
+          <li><code>window.DSFR_DATA_BEACON === true</code> (opt-in global classique) ;</li>
+          <li>un <code>&lt;dsfr-data-beacon url="..."&gt;</code> avec <code>url</code> non vide est present.</li>
+        </ul>
+        <div class="fr-callout fr-callout--blue-france fr-mt-2w">
+          <p class="fr-callout__text">
+            <strong>Kill switch :</strong> <code>window.DSFR_DATA_BEACON = false</code> neutralise la collecte
+            <em>même</em> si un element est present (coherent avec <code>window.DSFR_DATA_PROXY = false</code>).
+          </p>
+        </div>
+
+        <h2 id="exemples" class="fr-mt-4w">Exemples</h2>
+
+        <section class="demo-section">
+          <h3>Telemetrie vers un collecteur souverain</h3>
+          <p>L'element, visible dans la page, active et cible la collecte. Il peut etre place avant ou apres les composants.</p>
+          <div class="code-block"><pre>&lt;dsfr-data-beacon url="https://collecte.ministere.fr"&gt;&lt;/dsfr-data-beacon&gt;
+
+&lt;dsfr-data-source id="src" api-type="opendatasoft"
+  dataset-id="..." base-url="https://data.gouv.fr"&gt;
+&lt;/dsfr-data-source&gt;
+&lt;dsfr-data-chart source="src" type="bar"
+  label-field="region" value-field="total"&gt;
+&lt;/dsfr-data-chart&gt;</pre></div>
+        </section>
+
+        <section class="demo-section">
+          <h3>Retrait par l'integrateur</h3>
+          <p>Pour desactiver la telemetrie, il suffit de retirer la ligne — ou de poser le kill switch :</p>
+          <div class="code-block"><pre>&lt;!-- Aucune ligne &lt;dsfr-data-beacon&gt; : aucune telemetrie declarative --&gt;
+
+&lt;!-- ...ou neutralisation explicite, même si un element traine ailleurs : --&gt;
+&lt;script&gt;window.DSFR_DATA_BEACON = false;&lt;/script&gt;</pre></div>
+        </section>
+
+        <h2 id="comportement" class="fr-mt-4w">Comportement</h2>
+        <ul>
+          <li><strong>Invisible :</strong> aucun rendu, aucun footprint de layout.</li>
+          <li><strong>N'emet rien lui-même :</strong> ce sont les composants <code>dsfr-data-*</code> qui envoient
+            le beacon a leur initialisation ; l'element fournit seulement la cible/opt-in.</li>
+          <li><strong>Ordre du DOM indifferent :</strong> l'element est consulte en lookup paresseux au moment de
+            l'envoi ; place après un composant dans le HTML, il est malgre tout pris en compte.</li>
+          <li><strong>Deduplication :</strong> un beacon par composant + variante par chargement de page.</li>
+          <li><strong>Skip en dev :</strong> aucun envoi sur <code>localhost</code> / <code>127.0.0.1</code> ni sur
+            le domaine de collecte lui-même.</li>
+        </ul>
+
+        <h2 id="conseils" class="fr-mt-4w">Conseils d'utilisation</h2>
+        <div class="fr-callout">
+          <p class="fr-callout__text">
+            <strong>Transparence d'abord :</strong> preferez l'element au <code>window.*</code> opaque pour les
+            embeds destines a des sites tiers — l'integrateur voit la collecte et peut l'auditer.
+          </p>
+        </div>
+        <div class="fr-callout fr-mt-2w">
+          <p class="fr-callout__text">
+            <strong>Self-hosting :</strong> pointez <code>url</code> vers votre propre collecteur compatible
+            (endpoint <code>/beacon</code>) pour garder la donnee d'usage chez vous.
+          </p>
+        </div>
+    </div>
+  </app-layout-demo>
+
+  <!-- Footer -->
+  <app-footer base-path="../../"></app-footer>
+
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/specs/index.html
+++ b/specs/index.html
@@ -391,6 +391,25 @@
                 </div>
               </div>
             </div>
+
+            <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
+              <div class="fr-tile fr-enlarge-link">
+                <div class="fr-tile__body">
+                  <div class="fr-tile__content">
+                    <h3 class="fr-tile__title">
+                      <a href="components/dsfr-data-beacon.html">dsfr-data-beacon</a>
+                    </h3>
+                    <p class="fr-tile__detail">Telemetrie declarative</p>
+                    <p class="fr-tile__desc">Cible de telemetrie visible et retirable dans le HTML : opt-in declaratif, pendant de proxy-url.</p>
+                  </div>
+                </div>
+                <div class="fr-tile__header">
+                  <div class="fr-tile__pictogram">
+                    <span class="ri-radar-line ri-3x" aria-hidden="true" style="color: var(--text-action-high-blue-france);"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </section>
 

--- a/tests/apps/builder-ia/skills.test.ts
+++ b/tests/apps/builder-ia/skills.test.ts
@@ -24,6 +24,7 @@ import { DsfrDataMap } from '@/components/dsfr-data-map.js';
 import { DsfrDataMapLayer } from '@/components/dsfr-data-map-layer.js';
 import { DsfrDataMapPopup } from '@/components/dsfr-data-map-popup.js';
 import { DsfrDataPodium } from '@/components/dsfr-data-podium.js';
+import { DsfrDataBeacon } from '@/components/dsfr-data-beacon.js';
 
 // Type/constant imports for alignment checks
 import type { FilterOperator, AggregateFunction } from '@/components/dsfr-data-query.js';
@@ -52,8 +53,8 @@ function getHtmlAttributes(ComponentClass: typeof DsfrDataSource): Set<string> {
 }
 
 describe('builder-ia skills', () => {
-  it('should have 29 skill definitions', () => {
-    expect(Object.keys(SKILLS)).toHaveLength(29);
+  it('should have 30 skill definitions', () => {
+    expect(Object.keys(SKILLS)).toHaveLength(30);
   });
 
   it('should have expected skill IDs', () => {
@@ -82,6 +83,7 @@ describe('builder-ia skills', () => {
     expect(SKILLS).toHaveProperty('troubleshooting');
     expect(SKILLS).toHaveProperty('dsfrDataJoin');
     expect(SKILLS).toHaveProperty('dsfrDataPodium');
+    expect(SKILLS).toHaveProperty('dsfrDataBeacon');
   });
 
   it('each skill should have required properties', () => {
@@ -384,6 +386,14 @@ describe('builder-ia skills', () => {
           DsfrDataPodium as unknown as typeof DsfrDataSource,
           'dsfrDataPodium',
           'dsfr-data-podium'
+        );
+      });
+
+      it('dsfrDataBeacon skill covers all <dsfr-data-beacon> attributes', () => {
+        assertAttributesCovered(
+          DsfrDataBeacon as unknown as typeof DsfrDataSource,
+          'dsfrDataBeacon',
+          'dsfr-data-beacon'
         );
       });
     });

--- a/tests/beacon.test.ts
+++ b/tests/beacon.test.ts
@@ -34,11 +34,29 @@ describe('sendWidgetBeacon', () => {
     delete (window as any).__gwDbMode;
     delete (window as any).DSFR_DATA_BEACON;
     delete (window as any).DSFR_DATA_BEACON_URL;
+    document.querySelectorAll('dsfr-data-beacon').forEach((e) => e.remove());
     vi.restoreAllMocks();
     vi.resetModules();
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
   });
+
+  /** Pose un <dsfr-data-beacon url="..."> dans le DOM (sans dependre du composant). */
+  function addBeaconElement(url: string): HTMLElement {
+    const el = document.createElement('dsfr-data-beacon');
+    if (url !== null) el.setAttribute('url', url);
+    document.body.appendChild(el);
+    return el;
+  }
+
+  function externalLocation() {
+    vi.stubGlobal('location', {
+      hostname: 'example.gouv.fr',
+      protocol: 'https:',
+      origin: 'https://example.gouv.fr',
+      href: 'https://example.gouv.fr/',
+    });
+  }
 
   async function loadBeacon(beaconUrl = 'https://chartsbuilder.matge.com') {
     // BEACON_BASE_URL est une constante module-level lue depuis import.meta.env
@@ -331,5 +349,75 @@ describe('sendWidgetBeacon', () => {
     sendWidgetBeacon('dsfr-data-kpi');
 
     expect(imageSrcs).toHaveLength(0);
+  });
+
+  // --- Cible declarative <dsfr-data-beacon> (#345) ---
+
+  it('un <dsfr-data-beacon url> vaut opt-in et fournit l URL, sans window.DSFR_DATA_BEACON', async () => {
+    externalLocation();
+    addBeaconElement('https://collecte.ministere.fr');
+
+    // Aucune URL bakee : seul l'element active et cible la collecte.
+    const sendWidgetBeacon = await loadBeacon('');
+    sendWidgetBeacon('dsfr-data-kpi');
+
+    expect(imageSrcs).toHaveLength(1);
+    expect(imageSrcs[0]).toContain('https://collecte.ministere.fr/beacon');
+  });
+
+  it('l URL de l element est prioritaire sur window.DSFR_DATA_BEACON_URL', async () => {
+    externalLocation();
+    (window as any).DSFR_DATA_BEACON = true;
+    (window as any).DSFR_DATA_BEACON_URL = 'https://override.window.fr';
+    addBeaconElement('https://collecte.element.fr/');
+
+    const sendWidgetBeacon = await loadBeacon('https://chartsbuilder.matge.com');
+    sendWidgetBeacon('dsfr-data-kpi');
+
+    expect(imageSrcs).toHaveLength(1);
+    const url = new URL(imageSrcs[0]);
+    expect(url.origin).toBe('https://collecte.element.fr');
+    expect(url.pathname).toBe('/beacon');
+  });
+
+  it('window.DSFR_DATA_BEACON = false neutralise meme un element present (kill switch)', async () => {
+    externalLocation();
+    (window as any).DSFR_DATA_BEACON = false;
+    addBeaconElement('https://collecte.ministere.fr');
+
+    const sendWidgetBeacon = await loadBeacon('');
+    sendWidgetBeacon('dsfr-data-kpi');
+
+    expect(imageSrcs).toHaveLength(0);
+  });
+
+  it('un <dsfr-data-beacon> sans url ne vaut pas opt-in', async () => {
+    externalLocation();
+    addBeaconElement(''); // attribut url vide
+
+    const sendWidgetBeacon = await loadBeacon('');
+    sendWidgetBeacon('dsfr-data-kpi');
+    await Promise.resolve();
+
+    expect(imageSrcs).toHaveLength(0);
+  });
+
+  it('rattrape un element declare APRES le composant (timing DOM order)', async () => {
+    externalLocation();
+    // readyState happy-dom = 'complete' → deferBeacon passe par queueMicrotask.
+    const sendWidgetBeacon = await loadBeacon('');
+
+    // Le composant emet AVANT que l'element existe (connectedCallback synchrone).
+    sendWidgetBeacon('dsfr-data-chart', 'bar');
+    expect(imageSrcs).toHaveLength(0); // rien d'envoye dans le tick synchrone
+
+    // L'element est parse juste apres, dans le meme tick.
+    addBeaconElement('https://collecte.ministere.fr');
+    // Couvre les deux branches de deferBeacon (DOMContentLoaded / microtask).
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+    await Promise.resolve();
+
+    expect(imageSrcs).toHaveLength(1);
+    expect(imageSrcs[0]).toContain('https://collecte.ministere.fr/beacon');
   });
 });

--- a/tests/components/dsfr-data-beacon.test.ts
+++ b/tests/components/dsfr-data-beacon.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { DsfrDataBeacon } from '@/components/dsfr-data-beacon.js';
+
+/**
+ * #345 : <dsfr-data-beacon> est un element de configuration invisible. Il ne
+ * declenche aucun beacon lui-meme — il expose seulement `url`, que beacon.ts lit
+ * en lookup paresseux via getAttribute('url') au moment de l'envoi.
+ */
+describe('<dsfr-data-beacon> (#345)', () => {
+  afterEach(() => {
+    document.querySelectorAll('dsfr-data-beacon').forEach((e) => e.remove());
+  });
+
+  it('est enregistre comme custom element', () => {
+    expect(customElements.get('dsfr-data-beacon')).toBe(DsfrDataBeacon);
+  });
+
+  it('expose url en propriete ET via getAttribute (le canal lu par beacon.ts)', async () => {
+    const el = document.createElement('dsfr-data-beacon') as DsfrDataBeacon;
+    el.setAttribute('url', 'https://collecte.ministere.fr');
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    expect(el.url).toBe('https://collecte.ministere.fr');
+    expect(el.getAttribute('url')).toBe('https://collecte.ministere.fr');
+  });
+
+  it('est invisible et ne rend aucun contenu', async () => {
+    const el = document.createElement('dsfr-data-beacon') as DsfrDataBeacon;
+    el.setAttribute('url', 'https://x.fr');
+    document.body.appendChild(el);
+    await el.updateComplete;
+
+    expect(el.style.display).toBe('none');
+    expect(el.textContent?.trim()).toBe('');
+  });
+
+  it('url vaut "" par defaut', () => {
+    const el = new DsfrDataBeacon();
+    expect(el.url).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #345.

Élément déclaratif `<dsfr-data-beacon url="...">` — pendant de `proxy-url` (#340) côté télémétrie. Rend la collecte d'usage **visible et retirable dans le HTML** au lieu d'un `window.*` opaque : un intégrateur voit qu'une télémétrie part et vers où (et peut la retirer), un opérateur souverain la pointe vers son propre collecteur sans toucher au JS de la page.

## Comportement

- **Opt-in** : la présence d'un `<dsfr-data-beacon url="...">` (avec `url` non vide) **active** la collecte ET en fournit la cible — équivaut à `window.DSFR_DATA_BEACON = true` + `window.DSFR_DATA_BEACON_URL`.
- **Précédence de l'URL** : élément `url` > `window.DSFR_DATA_BEACON_URL` (#340) > URL bakée au build.
- **Kill switch** : `window.DSFR_DATA_BEACON = false` neutralise **même** un élément présent (cohérent avec `window.DSFR_DATA_PROXY = false`).
- **Ordre DOM indifférent** : lookup paresseux au moment de l'envoi (#156) + micro-défer (`DOMContentLoaded`/microtask) car les composants émettent en `connectedCallback` synchrone — un élément déclaré *après* un composant est quand même pris en compte.
- Élément **invisible**, n'émet aucun beacon lui-même, dans le bundle **core**.
- **Off par défaut** : sans élément ni global, rien ne change.

## Détails

- `packages/core/src/components/dsfr-data-beacon.ts` (nouveau)
- `packages/core/src/utils/beacon.ts` : `beaconElementUrl()` (lazy), précédence dans `resolveBeaconBase()`, opt-in + kill switch + `deferBeacon()`, `emitBeacon()` extrait. Regex `/\/+$/` remplacé par parcours linéaire (leçon ReDoS #340).
- Enregistrement `index-core.ts` + `index.ts`.
- Skill `dsfrDataBeacon` + alignement test (29→30, ID, couverture attribut).
- Spec `specs/components/dsfr-data-beacon.html` + nav (`app-layout-demo` + `specs/index.html`) + section CLAUDE.md.
- Tests : opt-in via élément, précédence, kill switch, timing DOM order, composant.

## Vérifs locales

- build (core + tous bundles, `skills.json` = 30 skills) ✅
- typecheck ✅ · lint 0 erreur ✅ · format ✅ · `check:accents` ✅
- tests : **3519/3519** ✅

Changeset **minor** (nouveau composant public). ⚠️ Note version : un nouveau composant est un *minor* par la convention du repo → prochaine release **0.10.0** (pas 0.9.1). À ajuster en `patch` si 0.9.1 souhaité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)