### PR TITLE
docs: dégraisser CLAUDE.md + couplages non-évidents (ADR-053)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,421 +1,80 @@
 # CLAUDE.md - Configuration du projet dsfr-data
 
+> 📐 **Le détail d'architecture vit dans [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)** (carte de navigation, conventions ADR-053).
+> Ce fichier ne garde que l'opérationnel : stack, commandes, conventions, remotes, release, do/don't.
+> Pour tout ce qui touche au pipeline de composants, au proxy, aux bundles, au beacon, à Tauri, aux pièges
+> de build et aux **couplages non-évidents**, lire `docs/ARCHITECTURE.md` AVANT de toucher au code.
+
 ## Contexte du projet
 
 Bibliotheque de Web Components de dataviz pour sites gouvernementaux francais.
-Composants Lit conformes DSFR (Design System de l'Etat).
-Architecture monorepo avec npm workspaces.
+Composants Lit conformes DSFR (Design System de l'Etat), monorepo npm workspaces.
 La bibliotheque npm publiee `dsfr-data` se trouve dans `packages/core/`.
 
-## Architecture
+## Stack
 
-```
-/
-├── index.html               # Hub (page d'accueil)
-├── apps/                    # Applications TypeScript
-│   ├── builder/             # Generateur visuel de graphiques
-│   ├── builder-ia/          # Generateur IA avec Albert
-│   ├── dashboard/           # Editeur visuel de tableaux de bord (grille par ligne, preview, save/delete)
-│   ├── sources/             # Gestionnaire de sources de donnees
-│   ├── playground/          # Environnement de code interactif
-│   ├── favorites/           # Gestion des favoris
-│   └── monitoring/          # Monitoring et logs
-├── packages/
-│   ├── core/                # Bibliotheque npm `dsfr-data` (composants web Lit)
-│   │   ├── src/
-│   │   │   ├── adapters/    # Adapters API (ODS, Tabular, Grist, Generic)
-│   │   │   ├── components/  # Composants Lit (dsfr-data-source, dsfr-data-query, ...)
-│   │   │   └── utils/       # Utilitaires (beacon, etc.)
-│   │   └── dist/            # Build output (ESM + UMD)
-│   └── shared/              # Utilitaires partages (@dsfr-data/shared)
-├── specs/                   # Specifications des composants
-├── guide/                   # Guide utilisateur et exemples
-├── tests/                   # Tests Vitest + Playwright E2E
-├── e2e/                     # Tests E2E Playwright
-├── src-tauri/               # App desktop Tauri
-├── scripts/                 # Scripts de build
-└── app-dist/                # Build output pour Tauri (genere)
-```
+- **Langage** : TypeScript strict.
+- **Composants** : Lit (LitElement, html, css) dans `packages/core/src/`.
+- **Build** : Vite (lib mode + apps), esbuild ; scripts dans `scripts/`.
+- **Tests** : Vitest (unit, jsdom) + Playwright (E2E).
+- **Charts** : `@gouvfr/dsfr-chart`. Carte : Leaflet (lazy). World-map : d3-geo + topojson.
+- **Desktop** : Tauri v2 (Rust + WebView).
+- **Serveur** : Express + MariaDB 11 (`mysql2/promise`).
+- **Versioning** : Changesets.
+- **Mono** : 7 apps dans `apps/`, lib dans `packages/core/`, partagé dans `packages/shared/`, chrome applicatif dans `packages/app-ui/`.
 
-## Commandes disponibles
+## Commandes essentielles
 
 ```bash
-npm run dev           # Serveur de dev Vite (port 5173)
-npm run build         # Build bibliotheque (delegue au workspace packages/core)
+# Dev
+npm run dev                         # Serveur de dev Vite (port 5173, hub + proxy)
+npm run dev --workspace=@dsfr-data/app-builder   # Dev d'une app (idem: builder-ia, dashboard,
+                                    #   sources, playground, favorites, monitoring)
+
+# Build
+npm run build         # Build bibliotheque (delegue a packages/core)
 npm run build:shared  # Build du package shared
 npm run build:apps    # Build de toutes les apps
 npm run build:all     # Build complet (shared + lib + apps)
 npm run build:app     # Assembler app-dist/ pour Tauri
-npm run test          # Tests Vitest en watch mode
-npm run test:run      # Tests une seule fois
-npm run test:coverage # Tests avec couverture
 npm run preview       # Preview du build
+
+# Tests
+npm run test          # Vitest watch
+npm run test:run      # Vitest une fois
+npm run test:coverage # Couverture
+npm run test:e2e      # Playwright E2E
+npx playwright test --config tests/builder-e2e/playwright.config.ts  # Tests exhaustifs Builder
+                      #   (requiert `npm run dev` actif en parallele — voir ARCHITECTURE.md §Tests)
+
+# Lint / garde-fous
+npm run check:accents # Verifie les accents francais dans le HTML (scripts/check-french-accents.sh)
+
+# Tauri
 npm run tauri:dev     # Dev Tauri (app desktop)
-npm run tauri:build   # Build Tauri production (build:all + build:app + tauri build)
+npm run tauri:build   # Build Tauri prod (build:all + build:app + tauri build)
+
+# Release (voir section Versioning)
+npx changeset             # Creer un changeset
+npm run version-packages  # Bumper package.json + CHANGELOG + sync Tauri
+
+# Deploy (plateforme VibeLab — skill vps-spawn)
+ssh vps "spawn up chartsbuilder git@github.com:bmatge/dsfr-data.git --dns api --mail real --keep"
 ```
-
-### Dev d'une app individuelle
-
-```bash
-npm run dev --workspace=@dsfr-data/app-builder
-npm run dev --workspace=@dsfr-data/app-builder-ia
-npm run dev --workspace=@dsfr-data/app-dashboard
-npm run dev --workspace=@dsfr-data/app-sources
-npm run dev --workspace=@dsfr-data/app-playground
-npm run dev --workspace=@dsfr-data/app-favorites
-npm run dev --workspace=@dsfr-data/app-monitoring
-```
-
-## Architecture des composants data
-
-### Pipeline recommande
-
-```
-dsfr-data-source  ──[fetch via adapter]──[paginate]──[cache]──► donnees brutes
-     │                                                         │
-     │ adapters (ODS, Tabular, Grist, Generic)                 ▼
-     │                                               dsfr-data-unpivot (optionnel, sources "wide")
-     │                                                         │
-     │                                                         ▼
-     │                                               dsfr-data-normalize (optionnel)
-     │                                                         │
-     │                                                         ▼
-     │                                               dsfr-data-query [transform seulement]
-     │                                               filter, group-by, aggregate, sort
-     │                                                         │
-     │                                    ┌────────────────────┤
-     │                                    ▼                    ▼
-     │                              dsfr-data-facets          dsfr-data-search
-     │                                    │                    │
-     │◄── commandes (page, where, orderBy)┘                    │
-     │◄── commandes (where) ───────────────────────────────────┘
-     ▼
-  dsfr-data-chart / dsfr-data-list / dsfr-data-kpi / dsfr-data-display
-         │
-         └──► dsfr-data-a11y (companion accessibilite : tableau, CSV, description)
-
-  Tier d'orchestration OPT-IN (#224, ADR-031) — dashboard a filtre commun :
-
-  UI natives (select, input...) ──► dsfr-data-context ──┬──► commandes where (whereKey stable/filtre)
-       │                                │                ├──► dsfr-data-source (A)
-       └── dsfr-data-context-filter ────┘                ├──► dsfr-data-source (B)
-           (eq, in, lt, gte, between,                    └──► dsfr-data-source (C)
-            month-of, year-of, lt-day-after,
-            last-n-days, current-year)
-  dsfr-data-context-tags (recap supprimable des filtres actifs)
-
-  Pipeline multi-sources (jointure) :
-
-  dsfr-data-source (A) ──┐
-                         ├──► dsfr-data-join ──► dsfr-data-query ──► dsfr-data-chart
-  dsfr-data-source (B) ──┘
-
-  Pipeline carte interactive (multi-couches, multi-sources) :
-
-  dsfr-data-source (A) ──► dsfr-data-map-layer (type="geoshape") ──┐
-  dsfr-data-source (B) ──► dsfr-data-map-layer (type="marker")  ──┼──► dsfr-data-map
-  dsfr-data-source (C) ──► dsfr-data-map-layer (type="heatmap") ──┘     │
-                                                                         └──► dsfr-data-a11y
-```
-
-**Regles** :
-- **dsfr-data-source** est le seul composant qui fait du fetch HTTP. Il supporte `api-type` pour ODS, Tabular, Grist et Generic.
-- **dsfr-data-query** est un pur transformateur de donnees (filter, group-by, aggregate, sort). Il ne fait jamais de requete HTTP.
-- **dsfr-data-join** est un pur transformateur multi-sources. Il joint deux sources sur une cle pivot (inner, left, right, full). Il ne fait aucun fetch HTTP.
-- **dsfr-data-unpivot** est un pur transformateur. Il bascule un tableau "wide" (temps dans les noms de colonnes, ex. `c2023_01`) en "long/tidy" (une observation par ligne) via `id-cols` + `value-cols`/`value-cols-pattern` + `var-name`/`var-format`/`value-name`. Inverse exact d'un pivot, aucun fetch HTTP. La valeur reste brute (typage delegue a `numeric-auto`).
-- **dsfr-data-normalize** sait fabriquer des colonnes calculees via `compute` (ligne a ligne, en dernier) : arithmetique `+ - * /`, concatenation texte (`+` avec litteraux quotes), parentheses. Ex. `compute="pct = valeur * 100; groupe = Indicateurs + ' / ' + Sous_theme"`. Evaluateur sur (pas d'`eval`). Hors perimetre : conditions, fonctions, calculs sur valeurs agregees.
-- **dsfr-data-chart** gere le multi-series de deux facons : format LARGE (`value-fields` / `value-field-2`, une colonne par serie) ou format LONG/tidy (`series-field`, une colonne-cle dont les valeurs distinctes deviennent les series). `series-field` est le consommateur naturel de `dsfr-data-unpivot`. Les deux alimentent `y`/`name` multi-series de `@gouvfr/dsfr-chart` (qui supporte le multi-series nativement).
-- Les commandes (page, where, orderBy) remontent vers dsfr-data-source via `dsfr-data-source-command`.
-- dsfr-data-facets et dsfr-data-search delegent la construction des WHERE clauses aux adapters.
-- **Deux mixins de cycle de vie** (#280/#281) : les 6 transformateurs (query, join, unpivot, normalize, facets, search) etendent `TransformerMixin` (`packages/core/src/utils/transformer-mixin.ts`) — abonnement amont, etats `isLoading()`/`getError()`, re-emission aval avec meta posee AVANT le dispatch, relais de commandes, validation de config via hooks (`transformerSources`, `beforeTransformerSubscribe`, `onTransformerData`, `transformMeta`, `transformerReinitProps`/`transformerReprocessProps`). Les composants d'affichage utilisent `SourceSubscriberMixin`. **Jamais de `subscribeToSource` manuel dans un composant** (test-garde statique). Init UNIQUE au montage : connectedCallback initialise, le premier `willUpdate` est consomme sans re-init.
-- Le where de dsfr-data-query est **colon-only** (l'ODSQL reste reserve au where de dsfr-data-source) ; en delegation serveur il est traduit au dialecte de l'adapter (#275). `transform`/`server-side`/`page-size`/`refresh` n'existent plus sur query (#277/#279) — le relais de commandes est toujours actif, le reste se configure sur la source.
-- Les erreurs de configuration passent par `reportConfigError` (console.error + attribut `data-dsfr-config-error`) sur TOUS les composants, source comprise (#283). Les composants d'affichage rendent erreur/loading via les templates partages `utils/status-templates.ts` (#284).
-- **dsfr-data-context** (opt-in, #224/ADR-031) orchestre des filtres transverses multi-sources : il ecoute des UI natives via ses enfants `dsfr-data-context-filter` et diffuse des commandes `where` a N sources nommees (un `whereKey` stable par filtre -> AND par le merge multi-emetteurs ; jamais « le dernier gagne »). Clause construite en colon puis traduite au `whereFormat` de chaque adapter. `url-sync` (defaut OFF) serialise les filtres dans l'URL (l'intention, pas les dates resolues). Sans contexte, chaque source reste autonome — rien ne change.
-- **dsfr-data-map** est le conteneur carte Leaflet. Il ne consomme pas de donnees. Ce sont les **dsfr-data-map-layer** enfants qui utilisent `SourceSubscriberMixin`.
-- **dsfr-data-map-layer** projete les donnees sur la carte (marker, geoshape, circle, heatmap). Chaque layer a sa propre source → multi-source naturel.
-- Le viewport-driven fetch (`bbox`) envoie des commandes `dsfr-data-source-command` avec `whereKey: "map-bbox"` pour le merge avec les autres filtres.
-
-### Pattern HTML
-
-```html
-<!-- Source (fetch) → Query (transform) → Chart (display) -->
-<dsfr-data-source id="src" api-type="opendatasoft"
-  dataset-id="mon-dataset" base-url="https://data.economie.gouv.fr">
-</dsfr-data-source>
-<dsfr-data-query id="data" source="src"
-  group-by="region" aggregate="population:sum:total" order-by="total:desc">
-</dsfr-data-query>
-<dsfr-data-chart id="mon-graph" source="data" type="bar"
-  label-field="region" value-field="total">
-</dsfr-data-chart>
-<!-- Optionnel : accessibilite du graphique -->
-<dsfr-data-a11y for="mon-graph" source="data" table download></dsfr-data-a11y>
-```
-
-Pour les cas sans transformation (datalist, display), dsfr-data-query peut etre omis :
-
-```html
-<dsfr-data-source id="src" api-type="tabular"
-  resource="..." server-side page-size="20">
-</dsfr-data-source>
-<dsfr-data-list source="src" colonnes="..." pagination="20">
-</dsfr-data-list>
-```
-
-### Adapters et ProviderConfig
-
-- **Adapters** (`packages/core/src/adapters/`) : construisent les URLs, parsent les reponses, gerent la pagination. Chaque API a son adapter (ODS, Tabular, Grist, Generic).
-- **ProviderConfig** (`packages/shared/src/providers/`) : configuration declarative par provider (pagination, response parsing, query syntax, code generation).
-- **Registre** (`packages/core/src/adapters/adapter-registry.ts`) : `getAdapter(apiType)` retourne l'adapter pour un type donne.
-- Ajouter un nouveau provider (CKAN...) = 1 ProviderConfig + 1 Adapter, zero modification dans les composants.
-
-### Capacites des adapters
-
-| Capacite | OpenDataSoft | Tabular | Grist | INSEE (Melodi) | Generic |
-|----------|:---:|:---:|:---:|:---:|:---:|
-| serverFetch | oui | oui | oui | oui | non |
-| serverFacets | oui | non | oui | non | non |
-| serverSearch | oui | non | non | non | non |
-| serverGroupBy | oui | oui | oui | non | non |
-| serverOrderBy | oui | oui | oui | non | non |
-| serverGeo | oui | non | non | non | non |
-| whereFormat | odsql | colon | colon | colon | colon |
-| plafond fetchAll (#286) | 1 000 (10×100), relevable via `max-records` (#233) | 25 000 (500×50) | illimite (1 requete) | 100 000 (100×1000) | n/a |
-
-**Formats WHERE** :
-- **ODSQL** (OpenDataSoft) : syntaxe SQL-like — `population > 5000 AND status = 'active'`, clauses jointes par ` AND `
-- **Colon** (Tabular, Grist, INSEE, Generic) : syntaxe structuree — `field:operator:value, field2:operator:value2`. Les caracteres structurels (`,` `:` `|`) presents dans une VALEUR sont percent-encodes (`escapeColonValue`/`unescapeColonValue` dans `packages/core/src/utils/where.ts`, cf. #271) ; tous les parseurs colon decodent apres decoupage.
-
-### Attributs dsfr-data-source
-
-dsfr-data-source fonctionne en deux modes :
-
-**Mode URL (fetch direct)** : `url`, `method`, `headers`, `params`, `refresh`, `transform`, `paginate`, `page-size`, `cache-ttl`, `data` (inline JSON)
-
-**`cache-ttl` et le hook de cache (#307)** : la lib publiee n'appelle aucune API applicative. `cache-ttl` n'a d'effet que si la page hote enregistre un provider via `window.DSFR_DATA_CACHE_PROVIDER = { get(key), put(key, data, ttl) }` AVANT le chargement des composants (sans provider : no-op, embed anonyme). La cle inclut un hash du fingerprint de la requete (URL/params/where/page) — deux requetes differentes ne partagent jamais une entree. Les apps du repo enregistrent le provider `/api/cache` (mode DB) via `registerServerCacheProvider()` de `@dsfr-data/shared`, appele par `@dsfr-data/app-ui`.
-
-**Mode adapter** (api-type != generic ou base-url fourni) : `api-type`, `base-url`, `dataset-id`, `resource`, `where`, `select`, `group-by`, `aggregate`, `order-by`, `server-side`, `page-size`, `limit`, `max-records` (#233 — plafond du fetchAll, 0 = defaut adapter ; a relever en connaissance de cause : requetes en boucle, memoire)
-
-### Grist : mode Records vs SQL
-
-L'adapter Grist choisit automatiquement entre deux modes :
-- **Mode Records** (GET /records) : pour fetch simple, filter equality/IN (`?filter={"col":["v"]}`), sort (`?sort=-col`), pagination (`?limit=N&offset=M`)
-- **Mode SQL** (POST /sql) : pour group-by, aggregation, LIKE search, facettes DISTINCT via SQL parametre
-
-Le mode SQL est un fallback automatique — il est active seulement quand les capacites de l'endpoint Records sont insuffisantes (group-by, aggregate, operateurs avances comme contains/gt/lt). Si le endpoint SQL n'est pas disponible sur l'instance Grist, l'adapter revient au mode Records + client-side. La disponibilite SQL est cachee par hostname (`Map<string, boolean>`).
-
-L'adapter expose aussi `fetchColumns()` et `fetchTables()` pour l'introspection du schema Grist.
 
 ## Conventions de code
 
-- TypeScript strict mode
-- Composants Lit (LitElement, html, css) dans `packages/core/src/`
-- Nommage : `dsfr-data-*` pour les composants publics, `app-*` pour les layouts
-- Tests : fichiers `*.test.ts` dans `/tests/`
-- Pas d'emoji dans le code sauf demande explicite
-- Imports partages via `@dsfr-data/shared`
-
-## Package shared (@dsfr-data/shared)
-
-**Frontiere lib/app (#319)** : `packages/core/src` ne doit importer que l'entree
-lib-safe `@dsfr-data/shared/lib` (utils purs, palettes, providers, proxy).
-Le barrel racine `@dsfr-data/shared` re-exporte en plus les modules app-side
-(auth/, storage/, ui/, tour/) reserves aux apps — une regle ESLint
-`no-restricted-imports` l'interdit dans core (plus aucune exception depuis #306/#307 — le chrome applicatif vit dans `packages/app-ui`, le cache serveur passe par le hook `window.DSFR_DATA_CACHE_PROVIDER`).
-Tout nouvel export lib-safe doit etre ajoute aux DEUX barrels (`src/lib.ts` et
-`src/index.ts`).
-
-Utilitaires partages entre toutes les apps :
-- `escapeHtml()` - Echappement HTML
-- `buildCsv()`, `CSV_BOM` - Export CSV robuste (quoting RFC 4180, BOM UTF-8, neutralisation des formules tableur)
-- `formatKPIValue()`, `formatDateShort()` - Formatage
-- `toNumber()`, `looksLikeNumber()` - Parsing numerique
-- `isValidDeptCode()` - Validation codes departementaux
-- `DSFR_COLORS`, `PALETTE_COLORS` - Palettes DSFR
-- `getProxyConfig()`, `getProxiedUrl()` - Configuration proxy
-- `loadFromStorage()`, `saveToStorage()`, `STORAGE_KEYS` - localStorage
-- `openModal()`, `closeModal()` - Modales DSFR
-- `toastWarning()`, `toastSuccess()` - Notifications toast DSFR
-- `appHref()`, `navigateTo()` - Navigation inter-apps
-- `ProviderConfig`, `getProviderConfig()` - Configuration declarative des providers API
-- `detectProvider()` - Detection automatique du type de provider depuis une URL
-
-## Skills builder-IA (alignement composants)
-
-Le builder-IA (`apps/builder-ia/`) utilise un systeme de skills : des blocs de connaissances injectes dans le prompt de l'IA selon le contexte. Les skills sont definis dans `apps/builder-ia/src/skills.ts`.
-
-**Regle importante** : quand on ajoute/modifie un attribut, un type de graphique, un operateur de filtre ou une fonction d'agregation dans un composant `dsfr-data-*`, il faut mettre a jour le skill correspondant dans `skills.ts`.
-
-Les tests d'alignement dans `tests/apps/builder-ia/skills.test.ts` verifient automatiquement que :
-- Chaque attribut HTML d'un composant est documente dans son skill (via introspection Lit `elementProperties`)
-- Tous les types de graphiques, operateurs de filtre et fonctions d'agregation sont couverts
-- Chaque composant data a un skill correspondant
-
-Si un attribut est ajoute a un composant sans maj du skill, le test echouera.
-
-**Note** : dsfr-data-source a deux modes (voir "Attributs dsfr-data-source" ci-dessus). dsfr-data-query est un pur transformateur et ne fait aucun fetch HTTP.
-
-## Deploiement serveur (VPS)
-
-### Deploiement agnostique (plateforme VibeLab — production miweb.run)
-
-Mode canonique depuis la migration vers VibeLab. Le repo expose a la **racine** :
-- `compose.yml` — stack mode DB (service `web` + `mariadb`), agnostique :
-  reseau `proxy` externe, labels Traefik en `${APP_NAME}`/`${DOMAIN}`, aucun
-  domaine/hebergeur code en dur, pas de `container_name` fige.
-- `deploy.sh` — equivalent agnostique de `docker/deploy-server.sh` : genere les
-  secrets/`.env` (une seule fois), derive `VITE_PROXY_URL`/`APP_URL`/`SMTP_FROM`
-  du `DOMAIN`, build + up sous `-p ${APP_NAME}`.
-
-L'orchestrateur `spawn` (cf. skill `vps-spawn`) cherche le compose racine, exporte
-`APP_NAME`/`DOMAIN`/`MAIL_HOST`/`MAIL_PORT` et lance `./deploy.sh`. Deploiement type :
-
-```bash
-ssh vps "spawn up chartsbuilder git@github.com:bmatge/dsfr-data.git --dns api --mail real --keep"
-# → https://chartsbuilder.miweb.run (cert dedie DKIM, mail reel signe)
-```
-
-DB **vierge** : le premier compte inscrit recoit le role admin. Les secrets
-generes (`ENCRYPTION_KEY`, `JWT_SECRET`, `DB_*`) vivent dans `/opt/apps/chartsbuilder/.env`
-sur le VPS — a sauvegarder hors serveur, ne JAMAIS les regenerer en place.
-
-### Deploiement legacy (ancien VPS, dual-mode)
-
-Le repo s'appelle `dsfr-data` mais le projet Docker historique s'appelle `datasource-charts-webcomponents` (ancien nom).
-Le `.env` doit contenir `COMPOSE_PROJECT_NAME=datasource-charts-webcomponents` pour que Docker reuse les volumes existants.
-
-```bash
-# Premier deploiement depuis le nouveau repo
-cp ~/datasource-charts-webcomponents/.env .env
-echo "COMPOSE_PROJECT_NAME=datasource-charts-webcomponents" >> .env
-
-# Deploiement (arrete les conteneurs, git pull, build, redemarre)
-./docker/deploy-server.sh   # ou ./docker/deploy.sh en mode statique
-```
-
-**Configuration self-hosted** (domaine arbitraire, proxy d'entreprise, reverse externe gerant les routes de proxying) : la procedure complete est dans [`docs/DEPLOYMENT.md` §"Configuration self-hosted"](docs/DEPLOYMENT.md#configuration-self-hosted). Elle couvre les 3 scenarios + le contrat exhaustif des chemins de proxying (`/grist-proxy/`, `/tabular-proxy/`, `/albert-proxy/`, etc.) pour qu'un operateur tiers puisse les repliquer derriere son propre reverse. Chaque bloc `location /*-proxy/` dans `docker/nginx.conf` et `nginx-db.conf` est annote `DESACTIVABLE` avec un renvoi vers cette section.
-
-### Base de donnees MariaDB
-
-Le serveur Express utilise **MariaDB 11** via `mysql2/promise` (requetes async, pool de connexions).
-Le conteneur MariaDB est defini dans `docker-compose.db.yml` avec healthcheck.
-Les donnees sont persistees dans le volume Docker `mariadb-data`.
-
-**Variables d'environnement** (generees automatiquement par `deploy-server.sh`) :
-- `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_ROOT_PASSWORD`
-- `ENCRYPTION_KEY` — cle AES-256-GCM pour chiffrer les `api_key_encrypted` (64 hex chars)
-
-**Schema** : `server/src/db/schema-mariadb.sql` (execute au demarrage, idempotent via `CREATE TABLE IF NOT EXISTS`).
-**Helpers DB** : `server/src/db/database.ts` exporte `query()`, `queryOne()`, `execute()`, `transaction()`.
-
-### Migration SQLite → MariaDB
-
-Pour migrer les donnees d'une installation SQLite existante :
-
-```bash
-# 1. Copier le fichier SQLite depuis le volume Docker
-docker cp <container>:/app/server/data/dsfr-data.db ./dsfr-data.db
-
-# 2. Lancer le script de migration
-DB_PASSWORD=xxx ENCRYPTION_KEY=xxx npx tsx scripts/migrate-sqlite-to-mariadb.ts --sqlite ./dsfr-data.db
-```
-
-### Chiffrement des cles API
-
-Les cles API dans `connections.api_key_encrypted` sont chiffrees en AES-256-GCM (`server/src/utils/crypto.ts`).
-Format : `base64(iv):base64(authTag):base64(ciphertext)`.
-Si `ENCRYPTION_KEY` n'est pas defini, les cles sont stockees en clair (compatibilite).
-
-### Gestion des mots de passe utilisateur
-
-**Changement de mot de passe** (utilisateur connecte) :
-- `PUT /api/auth/me` avec `{ currentPassword, password }` — exige le mot de passe actuel
-- Apres changement, toutes les autres sessions sont revoquees (la session courante est recreee)
-- UI : bouton "Mot de passe" dans le header (composant `<password-change-modal>`)
-- Client : `changePassword(currentPassword, newPassword)` dans `auth-service.ts`
-
-**Mot de passe oublie** (reset par email) :
-- `POST /api/auth/forgot-password` — genere un token SHA-256 (1h), envoie un email, ne revele jamais si le compte existe
-- `POST /api/auth/reset-password` — valide le token, met a jour le password, revoque toutes les sessions, connecte l'utilisateur
-- Colonnes DB : `reset_token_hash` et `reset_token_expires` sur `users` (migration v5)
-- Email : `sendPasswordResetEmail()` dans `mailer.ts`, lien vers `/?reset-password=TOKEN`
-- UI : lien "Mot de passe oublie ?" dans la modale de login, detection automatique du parametre URL `?reset-password=TOKEN` dans `app-header.ts`
-- Client : `forgotPassword(email)` et `resetPassword(token, password)` dans `auth-service.ts`
-- Rate limiting : meme limiter que login/register (10 tentatives / 15 min / IP)
-- Throttle : 1 token de reset toutes les 5 minutes par email
-
-### mcp-server
-
-Le `mcp-server/` est un package **hors workspace npm** (pas dans `workspaces` du root `package.json`).
-Il a son propre `package-lock.json` et son propre `node_modules`.
-Le SDK est en version `1.29.0` (la contrainte de pin a 1.12.1 pour zod v4 ne s'applique plus).
-Dans `Dockerfile.db`, le build mcp-server fait `npm ci && npm run build` depuis son repertoire.
-
-## Versioning et Releases
-
-Le projet utilise [Changesets](https://github.com/changesets/changesets) pour le versioning semantique et la generation du CHANGELOG. `dsfr-data` est un workspace npm dans `packages/core/`, ce qui permet a Changesets de gerer correctement le versioning et la publication.
-
-### Semantic Versioning (semver)
-
-- **patch** (0.4.x) : corrections de bugs, fixes CSS, typos
-- **minor** (0.x.0) : nouvelles fonctionnalites, nouveaux composants, nouveaux adapters
-- **major** (x.0.0) : breaking changes (attributs renommes/supprimes, changement d'API)
-
-### Workflow de release
-
-**1. Pendant le developpement** — creer un changeset pour chaque modification notable :
-```bash
-npx changeset
-# → Selectionner dsfr-data
-# → Choisir major/minor/patch
-# → Decrire le changement (1-2 phrases, en francais)
-```
-Le fichier `.changeset/xxx.md` est commite avec le code.
-
-**2. A la release** — generer la version et publier :
-```bash
-npm run version-packages    # Bumpe package.json + CHANGELOG.md + sync Tauri
-git add .
-git commit -m "chore: release v$(node -p \"require('./package.json').version\")"
-git tag "v$(node -p \"require('./package.json').version\")"
-git push && git push --tags
-```
-
-**3. Automatiquement** — les workflows GitHub se declenchent sur le tag `v*` :
-- `npm-publish.yml` → publie sur npm
-- `release.yml` → build Tauri (macOS ARM+x86, Linux, Windows) + GitHub Release
-- `publish-repos.yml` → publie les sous-repos (grist, proxy, mcp)
-
-### Synchronisation des versions
-
-La version de reference est dans `package.json` (root). Le script `sync-versions` synchronise :
-- `src-tauri/tauri.conf.json`
-- `src-tauri/Cargo.toml`
-
-Il est execute automatiquement par `npm run version-packages`.
-
-### CI : verification des changesets
-
-Sur les PRs, le workflow CI verifie si un changeset est present quand `packages/core/src/` ou `packages/shared/` sont modifies. Un warning est emis si le changeset est manquant.
-
-### Workflow de fin de session Claude Code
-
-A la fin de chaque session de developpement avec Claude Code, suivre ce workflow :
-
-1. **Verifier les modifications** : `git diff --stat` pour voir tous les fichiers modifies
-2. **Creer un changeset si necessaire** : si `packages/core/src/` ou `packages/shared/` ont ete modifies, lancer `npx changeset`
-3. **Commit** : avec un message conventional commit (`feat:`, `fix:`, `refactor:`, etc.)
-4. **Rappel** : ne pas oublier de pousser le changeset avec le code
-5. **Proposer une release** : demander a l'utilisateur s'il souhaite publier une nouvelle version. Si oui :
-   ```bash
-   npm run version-packages    # Bumpe package.json + CHANGELOG.md + sync Tauri
-   git add .
-   git commit -m "chore: release v$(node -p \"require('./package.json').version\")"
-   git tag "v$(node -p \"require('./package.json').version\")"
-   git push && git push --tags
-   ```
-
-Les changesets s'accumulent jusqu'a la prochaine release. Chaque release consomme tous les changesets en attente et genere une entree unique dans le CHANGELOG.
+- TypeScript strict mode, type hints systematiques.
+- Composants Lit dans `packages/core/src/`.
+- Nommage : `dsfr-data-*` pour les composants publics, `app-*` pour le chrome applicatif (`packages/app-ui/`).
+- Tests : fichiers `*.test.ts` dans `/tests/`.
+- Pas d'emoji dans le code sauf demande explicite.
+- Imports partages via `@dsfr-data/shared` — **frontiere lib/app (#319)** : `packages/core/src` ne doit importer
+  que l'entree lib-safe `@dsfr-data/shared/lib` (ESLint `no-restricted-imports`). Tout nouvel export lib-safe
+  va dans les DEUX barrels (`src/lib.ts` et `src/index.ts`). Detail dans `docs/ARCHITECTURE.md`.
+- **Acces `import.meta.env` toujours direct** (jamais d'indirection) — piège de build documenté dans
+  `docs/ARCHITECTURE.md` §Couplages non-évidents.
+- Commits : Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`).
 
 ## Remotes Git (miroir mef-snum-miweb)
 
@@ -426,208 +85,71 @@ Le repo est pousse simultanement sur **deux remotes GitHub** depuis 2026-05-24 :
 Configuration : un seul remote `origin` avec **multi-push URLs**. Un `git push origin <branche>` envoie aux deux destinations en une seule commande.
 
 ```bash
-# Inspection
 git remote -v
 # origin  https://github.com/bmatge/dsfr-data.git (fetch)
 # origin  https://github.com/bmatge/dsfr-data.git (push)
 # origin  https://github.com/mef-snum-miweb/dsfr-data.git (push)
-```
 
-Si la config est perdue (reclone, autre poste) :
-
-```bash
+# Si la config est perdue (reclone, autre poste) :
 git remote set-url --add --push origin https://github.com/bmatge/dsfr-data.git
 git remote set-url --add --push origin https://github.com/mef-snum-miweb/dsfr-data.git
 ```
 
 **Limites** :
-- Les merges effectues directement cote GitHub (UI bmatge, bot Dependabot, Changesets release PR...) **ne se propagent pas** au miroir miweb. Le miroir n'est rafraichi qu'au prochain `git push` local. Pour resynchroniser ponctuellement apres un merge UI :
+- Les merges effectues directement cote GitHub (UI bmatge, Dependabot, Changesets release PR...) **ne se propagent pas** au miroir. Resync ponctuel apres un merge UI :
   ```bash
   git fetch origin && git push origin refs/remotes/origin/main:refs/heads/main
   ```
-- Les workflows GitHub Actions tournent **aussi cote miweb** sur chaque push. Les jobs qui dependent de secrets non configures la-bas (npm token, deploy keys, Tauri release...) vont failer. A desactiver dans `Settings → Actions` du repo miweb si besoin.
-- Tags : pousser explicitement via `git push origin --tags` apres une release pour les propager.
+- Les workflows GitHub Actions tournent **aussi cote miweb** sur chaque push ; les jobs dependant de secrets non configures la-bas vont failer (a desactiver dans `Settings → Actions` du repo miweb si besoin).
+- Tags : `git push origin --tags` apres une release pour les propager.
 
-## APIs externes utilisees
+## Versioning et Releases (résumé)
 
-- Grist : docs.getgrist.com, grist.numerique.gouv.fr
-- Albert IA : albert.api.etalab.gouv.fr
-- OpenDataSoft : *.opendatasoft.com
-- Tabular API : tabular-api.data.gouv.fr
-- INSEE Melodi : api.insee.fr/melodi (catalogue-donnees.insee.fr)
+Le projet utilise [Changesets](https://github.com/changesets/changesets) pour le semver et le CHANGELOG. `dsfr-data` est le workspace `packages/core/`.
 
-## Proxy et URLs
+- **patch** (0.4.x) : bugs, fixes CSS, typos · **minor** (0.x.0) : fonctionnalites/composants/adapters · **major** (x.0.0) : breaking changes.
 
-- Dev : Vite proxy (configure dans vite.config.ts de chaque app)
-- Production : proxy nginx, domaine configurable via `VITE_PROXY_URL` (**requis** pour les deploiements de l'app — aucun fallback code en dur depuis #319)
-- **Defaut sans configuration** (bundle npm/CDN sur un site tiers) : mode `direct` — les URLs externes sont fetchees telles quelles, aucun trafic ne transite par un domaine tiers
-- **Override runtime** : le site deployeur peut definir `window.DSFR_DATA_PROXY` avant le chargement des composants (`'https://mon-proxy.fr'`, `{ baseUrl, endpoints }`, ou `false` pour forcer le direct)
-- Tauri : proxy distant via `VITE_PROXY_URL_EMBED` injectee au build (validate-build-env)
-- `PROXY_BASE_URL` dans `packages/shared/src/api/proxy-config.ts` lit `VITE_PROXY_URL` au build time (source de verite unique)
-- `LIB_URL` dans `packages/shared/src/api/proxy-config.ts` lit `VITE_LIB_URL` au build time (URL du JS dans le code genere)
-  - Non defini / `"jsdelivr"` → `https://cdn.jsdelivr.net/npm/dsfr-data@0/dist` (defaut)
-  - `"unpkg"` → `https://unpkg.com/dsfr-data@0/dist`
-  - `"self"` → `${PROXY_BASE_URL}/dist` (self-hosted)
-- `APP_DOMAIN` dans `.env` configure Traefik (docker-compose.yml) et les scripts de deploiement
-- Voir `.env.example` pour toutes les variables
+**Pendant le dev** : `npx changeset` pour chaque modif notable (selectionner `dsfr-data`, choisir le niveau, decrire en francais). Le `.changeset/xxx.md` est commite avec le code.
 
-## Bundles de la bibliotheque
-
-Le build (`scripts/build-lib.ts`) produit 4 bundles dans `packages/core/dist/` :
-
-| Bundle | Contenu | Taille gzip (ESM) |
-|--------|---------|-------------|
-| `dsfr-data.core.{esm,umd}.js` | Tous composants sauf `dsfr-data-world-map`, `dsfr-data-map*`. **Inclut `dsfr-data-join` et `dsfr-data-unpivot`** (purs transformateurs). | ~61 Ko |
-| `dsfr-data.world-map.{esm,umd}.js` | `dsfr-data-world-map` (d3-geo, topojson) | ~31 Ko |
-| `dsfr-data.map.{esm,umd}.js` | `dsfr-data-map` + `dsfr-data-map-layer` + popup/timeline (Leaflet charge dynamiquement en chunks separes) | ~33 Ko |
-| `dsfr-data.{esm,umd}.js` | Tout-en-un | ~97 Ko |
-
-Le code genere par les builders et le playground utilise le **core** bundle par defaut.
-Le TopoJSON (`packages/core/dist/data/world-countries-110m.json`) est charge par fetch a l'execution.
-Leaflet (~40 Ko gzip) et leaflet.markercluster (~5 Ko) sont charges dynamiquement via `import()` — pas inclus dans les bundles.
-Publication npm : `npm publish` via workflow GitHub Actions sur tag `v*`.
-
-## Beacon de tracking
-
-Les beacons sont **desactives par defaut** (opt-in). Pour les activer, deux voies : poser `window.DSFR_DATA_BEACON = true` avant le chargement des composants, **ou** placer un element declaratif `<dsfr-data-beacon url="...">` dans la page (#345, voir ci-dessous).
-
-Quand active, chaque composant `dsfr-data-*` envoie un beacon fire-and-forget a l'initialisation (`connectedCallback`) via `sendWidgetBeacon()` dans `packages/core/src/utils/beacon.ts`. Le beacon transmet le nom du composant, le type de graphique et l'origine de la page (`window.location.origin` via le parametre `r=`) au proxy nginx qui les enregistre dans `beacon.log`. Un script periodique (`scripts/parse-beacon-logs.sh`) transforme ces logs en `monitoring-data.json` consomme par l'app monitoring.
-
-- **Opt-in** : `window.DSFR_DATA_BEACON = true` **ou** un `<dsfr-data-beacon url="...">` present (avec `url` non vide) requis pour activer l'envoi
-- **`<dsfr-data-beacon url="...">` (#345)** — cible telemetrie **declarative** (pendant de `proxy-url`) : rend la collecte visible et retirable dans le HTML au lieu d'un `window.*` opaque. Sa presence vaut opt-in ET fournit l'URL de collecte. **Precedence de l'URL** : element `url` > `window.DSFR_DATA_BEACON_URL` (#340) > URL bakee au build. **Kill switch** : `window.DSFR_DATA_BEACON = false` neutralise meme un element present (coherent avec `window.DSFR_DATA_PROXY = false`). L'element est invisible, n'emet aucun beacon lui-meme, et vit dans le bundle **core** ; il est consulte en **lookup paresseux** au moment de l'envoi (#156), donc son ordre dans le DOM est indifferent (micro-defer `DOMContentLoaded`/microtask pour le cas « element declare apres un composant »).
-- Le parametre `r=` envoie `window.location.origin` pour identifier le site deployeur (plus fiable que le header HTTP Referer qui depend du Referrer-Policy du site)
-- Les parsers (sh et js) preferent `$arg_r` et tombent en fallback sur `$http_referer` pour compatibilite avec les anciens logs
-- Deduplication par `Set` en memoire (1 beacon par composant+type par page)
-- Skip en dev (localhost/127.0.0.1) et sur le domaine du proxy
-- Utilise un pixel de tracking (`new Image().src`) au lieu de `fetch()` : les requetes image sont regies par `img-src` (CSP) qui est quasi-toujours permissif, contrairement a `connect-src` qui bloque souvent les appels `fetch` cross-origin
-
-## Build : esbuild keepNames
-
-Le `vite.config.ts` contient `esbuild: { keepNames: true }`. Cette option est **obligatoire** :
-sans elle, esbuild supprime les methodes privees non-decorees des prototypes de classes Lit
-lors de la minification (ex: `_processMapData`, `_createChartElement`), ce qui casse le
-fonctionnement des composants en production. Overhead negligeable (~2 Ko).
-
-## DSFR Chart : attributs differes (deferred)
-
-Les composants DSFR Chart (`map-chart`, `map-chart-reg`) sont des Web Components Vue qui
-ecrasent certains attributs (`value`, `date`) avec leurs valeurs par defaut lors du montage Vue.
-`dsfr-data-chart` utilise un mecanisme de `setTimeout(500ms)` pour re-appliquer ces attributs
-apres le montage Vue (voir `_createChartElement` dans `packages/core/src/components/dsfr-data-chart.ts`).
-
-Si un nouveau composant DSFR Chart presente le meme comportement, ajouter les attributs
-concernes dans l'objet `deferred` retourne par `_getTypeSpecificAttributes()`.
-
-## Tauri : zoom par defaut
-
-L'app desktop Tauri applique un zoom de 80% au demarrage via `window.set_zoom(0.8)` dans
-`src-tauri/src/lib.rs`. Cela permet d'afficher plus de contenu dans la fenetre sans
-modifier le CSS des composants. Le zoom est applique cote Rust dans le hook `setup`.
-
-## Communication inter-apps (sessionStorage)
-
-Les builders et les favoris envoient du code au playground via `sessionStorage` :
-1. L'app source stocke le code dans `sessionStorage.setItem('playground-code', code)`
-2. Elle navigue vers le playground avec un parametre `?from=builder` (ou `builder-ia`, `favorites`)
-3. Le playground lit le parametre `from`, charge le code depuis sessionStorage, et le supprime
-
-Le parametre `from` doit etre l'un de : `builder`, `builder-ia`, `favorites`.
-
-## Tests exhaustifs du Builder (Playwright E2E)
-
-Tests dans `tests/builder-e2e/` : verifient la generation de code pour toutes les
-combinaisons source x type de graphique x mode (embedded/dynamic/dynamic+facettes).
-
-**Pre-requis** : le serveur de dev principal doit tourner (port 5173) car les sources
-API (ODS, Tabular) ont besoin du proxy Vite. Playwright doit etre installe.
-
+**A la release** :
 ```bash
-# 1. Lancer le serveur de dev (dans un terminal separe)
-npm run dev
-
-# 2. Lancer les tests exhaustifs du builder
-npx playwright test --config tests/builder-e2e/playwright.config.ts
+npm run version-packages    # Bumpe package.json + CHANGELOG.md + sync Tauri (sync-versions:
+                            #   src-tauri/tauri.conf.json + Cargo.toml)
+git add . && git commit -m "chore: release v$(node -p \"require('./package.json').version\")"
+git tag "v$(node -p \"require('./package.json').version\")"
+git push && git push --tags
 ```
 
-- **110 tests** : 4 sources (locale, ODS, Tabular, Grist) x 11 types de graphique x modes
-- Resultats ecrits dans `tests/builder-e2e/RESULTS.md`
-- Screenshots par combinaison dans `tests/builder-e2e/screenshots/`
-- Sources de test : locale (donnees embarquees), ODS et Tabular (APIs distantes via proxy),
-  Grist (donnees embarquees, pas de proxy en dev)
+**Automatiquement** sur le tag `v*` : `npm-publish.yml` (npm) · `release.yml` (Tauri macOS/Linux/Windows + GitHub Release) · `publish-repos.yml` (sous-repos grist/proxy/mcp).
 
-## Tests de validation des parametres Builder (Playwright E2E)
+**CI** : un warning est emis sur les PRs si `packages/core/src/` ou `packages/shared/` sont modifies sans changeset.
 
-Tests dans `tests/builder-e2e/` : valident que tous les parametres du builder fonctionnent correctement et generent le code attendu avec des donnees de test connues.
+**Fin de session Claude Code** : `git diff --stat` → `npx changeset` si `core/src` ou `shared` touches → commit (Conventional) → proposer une release a l'utilisateur (ne pas releaser sans accord).
 
-**Pre-requis** : le serveur de dev doit tourner (port 5173) pour acceder au builder.
+## Ce que Claude DOIT faire
 
-```bash
-# 1. Lancer le serveur de dev (dans un terminal separe)
-npm run dev
+- Lire `docs/ARCHITECTURE.md` (et sa section **Couplages non-évidents ⚠️**) avant de toucher au pipeline de composants, au proxy, aux bundles, au beacon ou au build.
+- Acceder a `import.meta.env.VITE_*` **en direct**, sans indirection.
+- Apres modif d'un attribut / type de graphique / operateur / agregation d'un composant `dsfr-data-*` :
+  mettre a jour le skill correspondant dans `apps/builder-ia/src/skills.ts` (sinon `tests/apps/builder-ia/skills.test.ts` casse).
+- Ajouter un export lib-safe dans **les deux** barrels (`packages/shared/src/lib.ts` ET `src/index.ts`).
+- Lancer `npm run build` apres modification des composants.
+- Creer un changeset si `packages/core/src/` ou `packages/shared/` sont modifies.
+- Apres un changement proxy/URL : valider empiriquement en grepant les bundles produits (aucune URL ne doit fuir dans la mauvaise dimension — voir ARCHITECTURE.md).
 
-# 2. Lancer les tests de validation des parametres
-cd tests/builder-e2e
-npx playwright test quick-audit.spec.ts
+## Ce que Claude ne doit JAMAIS faire
 
-# 3. Tests de base (elements UI)
-npx playwright test simple-test.spec.ts
+- **Jamais** de commit/push direct sur `main`/`master` sans autorisation explicite ; jamais de `git push --force` sans accord.
+- **Jamais** d'indirection sur `import.meta.env` (`const m = import.meta as any`) — casse la substitution Vite, fait fuiter l'ancienne URL en dur.
+- **Jamais** modifier les `.js` dans `packages/core/src/` (artefacts de build).
+- **Jamais** importer des modules app-side (`auth/`, `storage/`, `ui/`, `tour/`) depuis `packages/core/src` (frontiere lib/app #319).
+- **Jamais** de `subscribeToSource` manuel dans un composant (utiliser `TransformerMixin` / `SourceSubscriberMixin` — test-garde statique).
+- **Jamais** regenerer en place les secrets de prod (`ENCRYPTION_KEY`, `JWT_SECRET`, `DB_*`) dans `/opt/apps/<app>/.env` sur le VPS.
+- **Jamais** retirer `esbuild: { keepNames: true }` de `vite.config.ts` (casse les composants Lit minifies).
 
-# 4. Inspection de la structure (diagnostic)
-npx playwright test inspect-builder.spec.ts --headed
-```
+## Notes
 
-### Tests de validation critiques
-
-**11/12 tests passent** (91.7% de reussite) :
-
-- **Fonctions d'agregation** (5/5) : SUM, AVG, MIN, MAX, COUNT
-- **Types de graphiques** (4/4) : bar, horizontalBar, pie, kpi
-- **Palettes** : Application correcte des couleurs
-- **Tri** : Ordre ascendant et descendant
-- **Mode avance** : Filtres et conditions
-
-### Donnees de test et valeurs attendues
-
-Les tests utilisent un dataset de test avec valeurs connues pour verification :
-
-```typescript
-const TEST_DATA = [
-  { region: 'Ile-de-France', population: 12000, budget: 500, code: '75' },
-  { region: 'Provence', population: 5000, budget: 200, code: '13' },
-  { region: 'Bretagne', population: 3000, budget: 150, code: '35' },
-  { region: 'Normandie', population: 3300, budget: 180, code: '14' }
-];
-```
-
-**Valeurs attendues** (field: population) :
-- SUM = 23300
-- AVG = 5825
-- MIN = 3000
-- MAX = 12000
-- COUNT = 4 (nombre de regions)
-
-### Exposition du state pour les tests
-
-Pour permettre aux tests de verifier les calculs, le state du builder est expose globalement dans `apps/builder/src/main.ts` :
-
-```typescript
-// Expose state for E2E tests
-(window as any).__BUILDER_STATE__ = state;
-```
-
-Cette exposition permet aux tests de :
-- Injecter des donnees de test directement dans le state
-- Verifier que les agregations calculent les valeurs correctes
-- Comparer les resultats avec les valeurs attendues
-- Valider la coherence entre donnees source et resultats affiches
-
-### Documentation
-
-- `tests/builder-e2e/README.md` : Guide d'utilisation des tests
-- `tests/builder-e2e/TESTING_MATRIX.md` : Matrice complete des parametres a tester
-
-## Notes importantes
-
-- Les fichiers `.js` dans `packages/core/src/` sont des artefacts de build, ne pas les modifier
-- Toujours lancer `npm run build` apres modification des composants
-- Docker : `docker compose up -d --build` (utilise un volume `beacon-logs` pour persister les donnees de monitoring entre redemarrages)
+- APIs externes : Grist (docs.getgrist.com, grist.numerique.gouv.fr), Albert IA (albert.api.etalab.gouv.fr), OpenDataSoft (`*.opendatasoft.com`), Tabular (tabular-api.data.gouv.fr), INSEE Melodi (api.insee.fr/melodi).
+- Self-hosting et chemins de proxying : `docs/DEPLOYMENT.md` §"Configuration self-hosted".
+- Docker : `docker compose up -d --build` (volume `beacon-logs` pour persister le monitoring).
+- Detail complet (composants, proxy 3 dimensions, bundles, beacon, Tauri, MariaDB, mcp-server, deploiement) : **`docs/ARCHITECTURE.md`**.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,157 @@
 # Architecture -- dsfr-data
 
+> Carte de navigation du repo ([ADR-053] du vault) : index des couplages **non-évidents** + le *pourquoi*.
+> Le `CLAUDE.md` à la racine ne garde que l'opérationnel (commandes, conventions, do/don't) et pointe ici.
+> Sections clés : §0 Pipeline de composants, §4 Proxy (3 dimensions), §8 Beacon, §11 Pièges de build,
+> **§12 Couplages non-évidents ⚠️** (le cœur — à lire avant toute modif transverse).
+>
+> [ADR-053]: ~/Documents/Obsidian/30-Knowledge/ADR/ADR-053-carte-architecture-repo-et-feature-vault.md
+
+## 0. Pipeline de composants data
+
+> Architecture détaillée déplacée depuis `CLAUDE.md`. Code source : `packages/core/src/components/`.
+
+### Pipeline recommandé
+
+```
+dsfr-data-source  ──[fetch via adapter]──[paginate]──[cache]──► donnees brutes
+     │                                                         │
+     │ adapters (ODS, Tabular, Grist, Generic)                 ▼
+     │                                               dsfr-data-unpivot (optionnel, sources "wide")
+     │                                                         │
+     │                                                         ▼
+     │                                               dsfr-data-normalize (optionnel)
+     │                                                         │
+     │                                                         ▼
+     │                                               dsfr-data-query [transform seulement]
+     │                                               filter, group-by, aggregate, sort
+     │                                                         │
+     │                                    ┌────────────────────┤
+     │                                    ▼                    ▼
+     │                              dsfr-data-facets          dsfr-data-search
+     │                                    │                    │
+     │◄── commandes (page, where, orderBy)┘                    │
+     │◄── commandes (where) ───────────────────────────────────┘
+     ▼
+  dsfr-data-chart / dsfr-data-list / dsfr-data-kpi / dsfr-data-display
+         │
+         └──► dsfr-data-a11y (companion accessibilite : tableau, CSV, description)
+
+  Tier d'orchestration OPT-IN (#224, ADR-031) — dashboard a filtre commun :
+
+  UI natives (select, input...) ──► dsfr-data-context ──┬──► commandes where (whereKey stable/filtre)
+       │                                │                ├──► dsfr-data-source (A)
+       └── dsfr-data-context-filter ────┘                ├──► dsfr-data-source (B)
+           (eq, in, lt, gte, between,                    └──► dsfr-data-source (C)
+            month-of, year-of, lt-day-after,
+            last-n-days, current-year)
+  dsfr-data-context-tags (recap supprimable des filtres actifs)
+
+  Pipeline multi-sources (jointure) :
+
+  dsfr-data-source (A) ──┐
+                         ├──► dsfr-data-join ──► dsfr-data-query ──► dsfr-data-chart
+  dsfr-data-source (B) ──┘
+
+  Pipeline carte interactive (multi-couches, multi-sources) :
+
+  dsfr-data-source (A) ──► dsfr-data-map-layer (type="geoshape") ──┐
+  dsfr-data-source (B) ──► dsfr-data-map-layer (type="marker")  ──┼──► dsfr-data-map
+  dsfr-data-source (C) ──► dsfr-data-map-layer (type="heatmap") ──┘     │
+                                                                         └──► dsfr-data-a11y
+```
+
+### Règles
+
+- **dsfr-data-source** est le seul composant qui fait du fetch HTTP. Il supporte `api-type` pour ODS, Tabular, Grist et Generic.
+- **dsfr-data-query** est un pur transformateur (filter, group-by, aggregate, sort). Jamais de requete HTTP.
+- **dsfr-data-join** est un pur transformateur multi-sources : il joint deux sources sur une cle pivot (inner, left, right, full). Aucun fetch HTTP.
+- **dsfr-data-unpivot** est un pur transformateur. Il bascule un tableau "wide" (temps dans les noms de colonnes, ex. `c2023_01`) en "long/tidy" (une observation par ligne) via `id-cols` + `value-cols`/`value-cols-pattern` + `var-name`/`var-format`/`value-name`. Inverse exact d'un pivot, aucun fetch HTTP. La valeur reste brute (typage delegue a `numeric-auto`).
+- **dsfr-data-normalize** sait fabriquer des colonnes calculees via `compute` (ligne a ligne, en dernier) : arithmetique `+ - * /`, concatenation texte (`+` avec litteraux quotes), parentheses. Ex. `compute="pct = valeur * 100; groupe = Indicateurs + ' / ' + Sous_theme"`. Evaluateur sur (pas d'`eval`). Hors perimetre : conditions, fonctions, calculs sur valeurs agregees.
+- **dsfr-data-chart** gere le multi-series de deux facons : format LARGE (`value-fields` / `value-field-2`, une colonne par serie) ou format LONG/tidy (`series-field`, une colonne-cle dont les valeurs distinctes deviennent les series). `series-field` est le consommateur naturel de `dsfr-data-unpivot`. Les deux alimentent `y`/`name` multi-series de `@gouvfr/dsfr-chart`.
+- Les commandes (page, where, orderBy) remontent vers dsfr-data-source via `dsfr-data-source-command`.
+- dsfr-data-facets et dsfr-data-search delegent la construction des WHERE clauses aux adapters.
+- **Deux mixins de cycle de vie** (#280/#281) : les 6 transformateurs (query, join, unpivot, normalize, facets, search) etendent `TransformerMixin` (`packages/core/src/utils/transformer-mixin.ts`) — abonnement amont, etats `isLoading()`/`getError()`, re-emission aval avec meta posee AVANT le dispatch, relais de commandes, validation de config via hooks (`transformerSources`, `beforeTransformerSubscribe`, `onTransformerData`, `transformMeta`, `transformerReinitProps`/`transformerReprocessProps`). Les composants d'affichage utilisent `SourceSubscriberMixin`. **Jamais de `subscribeToSource` manuel dans un composant** (test-garde statique). Init UNIQUE au montage : connectedCallback initialise, le premier `willUpdate` est consomme sans re-init.
+- Le where de dsfr-data-query est **colon-only** (l'ODSQL reste reserve au where de dsfr-data-source) ; en delegation serveur il est traduit au dialecte de l'adapter (#275). `transform`/`server-side`/`page-size`/`refresh` n'existent plus sur query (#277/#279) — le relais de commandes est toujours actif, le reste se configure sur la source.
+- Les erreurs de configuration passent par `reportConfigError` (console.error + attribut `data-dsfr-config-error`) sur TOUS les composants, source comprise (#283). Les composants d'affichage rendent erreur/loading via les templates partages `utils/status-templates.ts` (#284).
+- **dsfr-data-context** (opt-in, #224/ADR-031) orchestre des filtres transverses multi-sources : il ecoute des UI natives via ses enfants `dsfr-data-context-filter` et diffuse des commandes `where` a N sources nommees (un `whereKey` stable par filtre -> AND par le merge multi-emetteurs ; jamais « le dernier gagne »). Clause construite en colon puis traduite au `whereFormat` de chaque adapter. `url-sync` (defaut OFF) serialise les filtres dans l'URL (l'intention, pas les dates resolues). Sans contexte, chaque source reste autonome.
+- **dsfr-data-map** est le conteneur carte Leaflet. Il ne consomme pas de donnees ; ce sont les **dsfr-data-map-layer** enfants qui utilisent `SourceSubscriberMixin`.
+- **dsfr-data-map-layer** projete les donnees sur la carte (marker, geoshape, circle, heatmap). Chaque layer a sa propre source → multi-source naturel.
+- Le viewport-driven fetch (`bbox`) envoie des commandes `dsfr-data-source-command` avec `whereKey: "map-bbox"` pour le merge avec les autres filtres.
+
+### Pattern HTML
+
+```html
+<!-- Source (fetch) → Query (transform) → Chart (display) -->
+<dsfr-data-source id="src" api-type="opendatasoft"
+  dataset-id="mon-dataset" base-url="https://data.economie.gouv.fr">
+</dsfr-data-source>
+<dsfr-data-query id="data" source="src"
+  group-by="region" aggregate="population:sum:total" order-by="total:desc">
+</dsfr-data-query>
+<dsfr-data-chart id="mon-graph" source="data" type="bar"
+  label-field="region" value-field="total">
+</dsfr-data-chart>
+<dsfr-data-a11y for="mon-graph" source="data" table download></dsfr-data-a11y>
+```
+
+Pour les cas sans transformation (datalist, display), `dsfr-data-query` peut etre omis (source → list directement).
+
+### Adapters et ProviderConfig
+
+- **Adapters** (`packages/core/src/adapters/`) : construisent les URLs, parsent les reponses, gerent la pagination. Un adapter par API (ODS, Tabular, Grist, Generic).
+- **ProviderConfig** (`packages/shared/src/providers/`) : configuration declarative par provider (pagination, response parsing, query syntax, code generation).
+- **Registre** (`packages/core/src/adapters/adapter-registry.ts`) : `getAdapter(apiType)` retourne l'adapter pour un type donne.
+- Ajouter un nouveau provider (CKAN...) = 1 ProviderConfig + 1 Adapter, zero modification dans les composants.
+
+#### Capacités des adapters
+
+| Capacite | OpenDataSoft | Tabular | Grist | INSEE (Melodi) | Generic |
+|----------|:---:|:---:|:---:|:---:|:---:|
+| serverFetch | oui | oui | oui | oui | non |
+| serverFacets | oui | non | oui | non | non |
+| serverSearch | oui | non | non | non | non |
+| serverGroupBy | oui | oui | oui | non | non |
+| serverOrderBy | oui | oui | oui | non | non |
+| serverGeo | oui | non | non | non | non |
+| whereFormat | odsql | colon | colon | colon | colon |
+| plafond fetchAll (#286) | 1 000 (10×100), relevable via `max-records` (#233) | 25 000 (500×50) | illimite (1 requete) | 100 000 (100×1000) | n/a |
+
+**Formats WHERE** :
+- **ODSQL** (OpenDataSoft) : SQL-like — `population > 5000 AND status = 'active'`, clauses jointes par ` AND `.
+- **Colon** (Tabular, Grist, INSEE, Generic) : `field:operator:value, field2:operator:value2`. Les caracteres structurels (`,` `:` `|`) dans une VALEUR sont percent-encodes (`escapeColonValue`/`unescapeColonValue` dans `packages/core/src/utils/where.ts`, #271) ; tous les parseurs colon decodent apres decoupage.
+
+#### Attributs dsfr-data-source
+
+dsfr-data-source fonctionne en deux modes :
+
+- **Mode URL (fetch direct)** : `url`, `method`, `headers`, `params`, `refresh`, `transform`, `paginate`, `page-size`, `cache-ttl`, `data` (inline JSON).
+- **Mode adapter** (api-type != generic ou base-url fourni) : `api-type`, `base-url`, `dataset-id`, `resource`, `where`, `select`, `group-by`, `aggregate`, `order-by`, `server-side`, `page-size`, `limit`, `max-records` (#233 — plafond du fetchAll, 0 = defaut adapter ; a relever en connaissance de cause : requetes en boucle, memoire).
+
+**`cache-ttl` et le hook de cache (#307)** : la lib publiee n'appelle aucune API applicative. `cache-ttl` n'a d'effet que si la page hote enregistre un provider via `window.DSFR_DATA_CACHE_PROVIDER = { get(key), put(key, data, ttl) }` AVANT le chargement des composants (sans provider : no-op, embed anonyme). La cle inclut un hash du fingerprint de la requete (URL/params/where/page) — deux requetes differentes ne partagent jamais une entree. Les apps du repo enregistrent le provider `/api/cache` (mode DB) via `registerServerCacheProvider()` de `@dsfr-data/shared`, appele par `@dsfr-data/app-ui`.
+
+#### Grist : mode Records vs SQL
+
+L'adapter Grist choisit automatiquement entre :
+- **Mode Records** (GET /records) : fetch simple, filter equality/IN (`?filter={"col":["v"]}`), sort (`?sort=-col`), pagination (`?limit=N&offset=M`).
+- **Mode SQL** (POST /sql) : group-by, aggregation, LIKE search, facettes DISTINCT via SQL parametre.
+
+Le mode SQL est un fallback automatique, active seulement quand les capacites de l'endpoint Records sont insuffisantes (group-by, aggregate, operateurs avances). Si le endpoint SQL est indisponible sur l'instance Grist, l'adapter revient au mode Records + client-side. La disponibilite SQL est cachee par hostname (`Map<string, boolean>`). L'adapter expose aussi `fetchColumns()` et `fetchTables()` pour l'introspection du schema.
+
+### Package shared (@dsfr-data/shared)
+
+**Frontiere lib/app (#319)** : `packages/core/src` ne doit importer que l'entree lib-safe `@dsfr-data/shared/lib` (utils purs, palettes, providers, proxy). Le barrel racine `@dsfr-data/shared` re-exporte en plus les modules app-side (auth/, storage/, ui/, tour/) reserves aux apps — une regle ESLint `no-restricted-imports` l'interdit dans core (plus aucune exception depuis #306/#307 : le chrome applicatif vit dans `packages/app-ui`, le cache serveur passe par le hook `window.DSFR_DATA_CACHE_PROVIDER`). **Tout nouvel export lib-safe doit etre ajoute aux DEUX barrels** (`src/lib.ts` et `src/index.ts`).
+
+Utilitaires partages : `escapeHtml()` · `buildCsv()`/`CSV_BOM` (quoting RFC 4180, BOM UTF-8, neutralisation des formules tableur) · `formatKPIValue()`/`formatDateShort()` · `toNumber()`/`looksLikeNumber()` · `isValidDeptCode()` · `DSFR_COLORS`/`PALETTE_COLORS` · `getProxyConfig()`/`getProxiedUrl()` · `loadFromStorage()`/`saveToStorage()`/`STORAGE_KEYS` · `openModal()`/`closeModal()` · `toastWarning()`/`toastSuccess()` · `appHref()`/`navigateTo()` · `ProviderConfig`/`getProviderConfig()` · `detectProvider()`.
+
+### Skills builder-IA (alignement composants)
+
+Le builder-IA (`apps/builder-ia/`) injecte des blocs de connaissances ("skills") dans le prompt de l'IA selon le contexte. Les skills sont definis dans `apps/builder-ia/src/skills.ts`.
+
+**Règle** : quand on ajoute/modifie un attribut, un type de graphique, un operateur de filtre ou une fonction d'agregation dans un composant `dsfr-data-*`, il faut mettre a jour le skill correspondant dans `skills.ts`. Les tests d'alignement `tests/apps/builder-ia/skills.test.ts` verifient automatiquement (introspection Lit `elementProperties`) que chaque attribut HTML est documente, que tous les types/operateurs/agregations sont couverts, et que chaque composant data a un skill. **Un attribut ajoute sans maj du skill fait echouer le test** (voir §12).
+
+---
+
 ## 1. Vue d'ensemble
 
 dsfr-data est un monorepo TypeScript gere par npm workspaces. Il fournit une bibliotheque de Web Components de dataviz conformes au DSFR (Design System de l'Etat) ainsi que sept applications web autonomes pour la creation, la gestion et la visualisation de graphiques.
@@ -189,7 +341,11 @@ A l'interieur d'une meme page, les Web Components communiquent par un bus d'even
 
 ## 4. Architecture proxy
 
-Les APIs externes (Grist, Albert, tabular-api) n'autorisent pas les requetes cross-origin depuis le navigateur. Un proxy est necessaire. Le systeme supporte trois modes, determines automatiquement par `getProxyConfig()` dans `packages/shared/src/api/proxy-config.ts`.
+Les APIs externes (Grist, Albert, tabular-api) n'autorisent pas les requetes cross-origin depuis le navigateur. Un proxy est necessaire. Le systeme supporte trois modes de **détection runtime** (dev / prod / Tauri), determines automatiquement par `getProxyConfig()` dans `packages/shared/src/api/proxy-config.ts`.
+
+> ⚠️ Ne pas confondre les **3 modes runtime** (ci-dessous) avec les **3 dimensions d'URL** au build
+> (app / embed / beacon), décrites en §4.4 et §12. Feature vault transverse :
+> `~/Documents/Obsidian/30-Knowledge/Features/proxy-cors-3-dimensions.md` (ADR-026, ADR-036, ADR-030).
 
 ### 4.1 Mode developpement (Vite proxy)
 
@@ -227,6 +383,26 @@ Tabular         /tabular-proxy/...    <proxy>/tabular-proxy/...           idem p
 Detection       localhost:5173        (defaut)                            window.__TAURI__
 baseUrl         '' (relatif)          VITE_PROXY_URL [REQUISE]            PROXY_BASE_URL
 ```
+
+### 4.4 Les 3 dimensions d'URL (app · embed · beacon)
+
+Au-delà des 3 modes runtime, l'URL de proxy existe en **3 dimensions distinctes au build**, parce que le même code de lib tourne dans 3 contextes : l'app, un widget embarqué sur un site tiers, et la télémétrie. Cascade de fallback (aucune régression sans changement `.env` explicite, #180) — `packages/shared/src/api/proxy-config.ts:74-94` :
+
+```
+PROXY_BASE_URL        = VITE_PROXY_URL                              // app runtime
+PROXY_BASE_URL_EMBED  = VITE_PROXY_URL_EMBED || PROXY_BASE_URL      // code généré pour sites tiers
+BEACON_BASE_URL       = VITE_BEACON_URL || PROXY_BASE_URL_EMBED     // télémétrie
+```
+
+**`getProxyConfig()` est repositionné sur `PROXY_BASE_URL_EMBED`** (`proxy-config.ts:133`, `:246`) : les adapters de `packages/core` tournent dans le bundle lib, chargé indifféremment dans l'app OU sur un site tiers → côté lib, c'est la dimension embed qui fait foi. Voir §12 pour le piège associé.
+
+**Override runtime** (côté site déployeur, avant chargement des composants) :
+- `window.DSFR_DATA_PROXY` : `'https://mon-proxy.fr'`, `{ baseUrl, endpoints }`, ou `false` pour forcer le mode `direct`.
+- **Défaut sans configuration** (bundle npm/CDN sur un site tiers) : mode `direct` — les URLs externes sont fetchées telles quelles, aucun trafic ne transite par un domaine tiers.
+
+**`VITE_LIB_URL`** (`proxy-config.ts:107-110`, `LIB_URL`) : source du JS dans le code généré — `"jsdelivr"` (défaut, `cdn.jsdelivr.net/npm/dsfr-data@0/dist`), `"unpkg"`, `"self"` (`${PROXY_BASE_URL}/dist`), ou URL custom.
+
+`APP_DOMAIN` dans `.env` configure Traefik (compose) et les scripts de déploiement. Voir `.env.example`.
 
 ---
 
@@ -334,6 +510,10 @@ export function isTauriMode(): boolean {
 
 Cela permet de basculer automatiquement vers le proxy externe pour les appels API.
 
+### Zoom par défaut
+
+L'app desktop applique un zoom de 80% au démarrage via `window.set_zoom(0.8)` dans `src-tauri/src/lib.rs` (hook `setup`, côté Rust). Cela affiche plus de contenu sans modifier le CSS des composants.
+
 ---
 
 ## 7. Tests
@@ -389,3 +569,155 @@ tests/
 
 - Les dependances `lit` et `@lit` sont inlinees par le serveur de test pour eviter les problemes de resolution ESM dans jsdom.
 - La couverture inclut tous les fichiers `src/**/*.ts` sauf `src/index.ts` et `src/components/layout/**`.
+
+### 7.1 Tests exhaustifs du Builder (Playwright E2E)
+
+> Procédure déplacée depuis `CLAUDE.md`. Tests dans `tests/builder-e2e/`.
+
+Vérifient la génération de code pour toutes les combinaisons source × type de graphique × mode (embedded/dynamic/dynamic+facettes).
+
+**Pré-requis** : le serveur de dev principal doit tourner (port 5173) car les sources API (ODS, Tabular) ont besoin du proxy Vite. Playwright doit être installé.
+
+```bash
+npm run dev   # terminal séparé
+npx playwright test --config tests/builder-e2e/playwright.config.ts
+```
+
+- **110 tests** : 4 sources (locale, ODS, Tabular, Grist) × 11 types de graphique × modes.
+- Résultats : `tests/builder-e2e/RESULTS.md` · screenshots par combinaison : `tests/builder-e2e/screenshots/`.
+- Sources de test : locale (embarquées), ODS et Tabular (APIs distantes via proxy), Grist (embarquées, pas de proxy en dev).
+
+### 7.2 Validation des paramètres Builder (Playwright E2E)
+
+Valident que tous les paramètres du builder génèrent le code attendu avec des données de test connues. Pré-requis : `npm run dev` actif (port 5173).
+
+```bash
+cd tests/builder-e2e
+npx playwright test quick-audit.spec.ts      # validation des paramètres
+npx playwright test simple-test.spec.ts      # éléments UI de base
+npx playwright test inspect-builder.spec.ts --headed   # diagnostic structure
+```
+
+Couverture : agrégations (SUM, AVG, MIN, MAX, COUNT), types (bar, horizontalBar, pie, kpi), palettes, tri asc/desc, mode avancé (filtres/conditions).
+
+**Données de test** (`field: population`) : `[Ile-de-France 12000, Provence 5000, Bretagne 3000, Normandie 3300]` → SUM=23300, AVG=5825, MIN=3000, MAX=12000, COUNT=4.
+
+**Exposition du state** : le builder expose son state globalement via `(window as any).__BUILDER_STATE__ = state` dans `apps/builder/src/main.ts`, ce qui permet aux tests d'injecter des données et de vérifier les calculs d'agrégation. Doc : `tests/builder-e2e/README.md`, `tests/builder-e2e/TESTING_MATRIX.md`.
+
+---
+
+## 8. Beacon de tracking
+
+> Déplacé depuis `CLAUDE.md`. Code : `packages/core/src/utils/beacon.ts`.
+
+Les beacons sont **désactivés par défaut** (opt-in). Pour les activer : `window.DSFR_DATA_BEACON = true` avant le chargement des composants, **ou** un élément déclaratif `<dsfr-data-beacon url="...">` dans la page (#345).
+
+Quand actif, chaque composant `dsfr-data-*` envoie un beacon fire-and-forget à l'initialisation (`connectedCallback`) via `sendWidgetBeacon()`. Le beacon transmet le nom du composant, le type de graphique et l'origine de la page (`window.location.origin` via le paramètre `r=`) au proxy nginx qui les enregistre dans `beacon.log`. `scripts/parse-beacon-logs.sh` (cron 5 min ou trigger `/api/refresh-monitoring`) transforme ces logs en `monitoring-data.json` consommé par l'app monitoring.
+
+- **`<dsfr-data-beacon url="...">` (#345)** — cible télémétrie **déclarative** (pendant de `proxy-url`). Sa présence vaut opt-in ET fournit l'URL de collecte. **Précédence de l'URL** : élément `url` > `window.DSFR_DATA_BEACON_URL` (#340) > URL bakée au build (`BEACON_BASE_URL`). **Kill switch** : `window.DSFR_DATA_BEACON = false` neutralise même un élément présent. L'élément est invisible, n'émet aucun beacon lui-même, vit dans le bundle **core**, et est consulté en **lookup paresseux** au moment de l'envoi (#156) → son ordre dans le DOM est indifférent (micro-defer `DOMContentLoaded`/microtask).
+- Le paramètre `r=` envoie `window.location.origin` (plus fiable que le header HTTP Referer). Les parsers (sh et js) préfèrent `$arg_r` et tombent en fallback sur `$http_referer` pour les anciens logs.
+- Déduplication par `Set` en mémoire (1 beacon par composant+type par page). Skip en dev (localhost/127.0.0.1) et sur le domaine du proxy.
+- Utilise un **pixel de tracking** (`new Image().src`) au lieu de `fetch()` : les requêtes image sont régies par `img-src` (CSP), quasi-toujours permissif, contrairement à `connect-src` qui bloque souvent les appels `fetch` cross-origin.
+
+---
+
+## 9. Build — pièges esbuild & DSFR Chart
+
+> Déplacé depuis `CLAUDE.md`.
+
+### 9.1 esbuild keepNames (obligatoire)
+
+`vite.config.ts` contient `esbuild: { keepNames: true }`. **Obligatoire** : sans elle, esbuild supprime les méthodes privées non-décorées des prototypes de classes Lit lors de la minification (ex. `_processMapData`, `_createChartElement`), ce qui casse les composants en production. Overhead négligeable (~2 Ko).
+
+### 9.2 DSFR Chart — attributs différés (deferred)
+
+Les composants DSFR Chart (`map-chart`, `map-chart-reg`) sont des Web Components Vue qui écrasent certains attributs (`value`, `date`) avec leurs valeurs par défaut lors du montage Vue. `dsfr-data-chart` utilise un `setTimeout(500ms)` pour ré-appliquer ces attributs après le montage Vue (voir `_createChartElement` dans `packages/core/src/components/dsfr-data-chart.ts`). Pour un nouveau composant DSFR Chart au même comportement, ajouter les attributs concernés dans l'objet `deferred` de `_getTypeSpecificAttributes()`.
+
+---
+
+## 10. Serveur, base de données & déploiement
+
+> Déplacé depuis `CLAUDE.md`. Voir aussi `docs/DEPLOYMENT.md`.
+
+### 10.1 Communication inter-apps (sessionStorage)
+
+Les builders et favoris envoient du code au playground via `sessionStorage` : (1) l'app source stocke `sessionStorage.setItem('playground-code', code)`, (2) navigue vers le playground avec `?from=builder` (ou `builder-ia`, `favorites`), (3) le playground lit `from`, charge le code et le supprime. `from` ∈ { `builder`, `builder-ia`, `favorites` }.
+
+### 10.2 MariaDB
+
+Le serveur Express utilise **MariaDB 11** via `mysql2/promise` (pool de connexions). Conteneur défini dans `docker-compose.db.yml` (healthcheck), données dans le volume `mariadb-data`.
+
+- **Variables d'env** (générées par `deploy-server.sh`) : `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_ROOT_PASSWORD`, `ENCRYPTION_KEY` (AES-256-GCM, 64 hex).
+- **Schéma** : `server/src/db/schema-mariadb.sql` (exécuté au démarrage, idempotent). **Helpers** : `server/src/db/database.ts` (`query()`, `queryOne()`, `execute()`, `transaction()`).
+- **Migration SQLite → MariaDB** : `docker cp <container>:/app/server/data/dsfr-data.db ./dsfr-data.db` puis `DB_PASSWORD=xxx ENCRYPTION_KEY=xxx npx tsx scripts/migrate-sqlite-to-mariadb.ts --sqlite ./dsfr-data.db`.
+
+### 10.3 Chiffrement des clés API
+
+Les clés dans `connections.api_key_encrypted` sont chiffrées en AES-256-GCM (`server/src/utils/crypto.ts`), format `base64(iv):base64(authTag):base64(ciphertext)`. Sans `ENCRYPTION_KEY` : stockage en clair (compat).
+
+### 10.4 Mots de passe utilisateur
+
+- **Changement** (connecté) : `PUT /api/auth/me` `{ currentPassword, password }` (exige le mdp actuel) ; révoque toutes les autres sessions. UI : `<password-change-modal>`. Client : `changePassword()` dans `auth-service.ts`.
+- **Oubli/reset** : `POST /api/auth/forgot-password` (token SHA-256 1h, ne révèle jamais l'existence du compte) → `POST /api/auth/reset-password` (valide, met à jour, révoque les sessions, connecte). Colonnes `reset_token_hash`/`reset_token_expires` (migration v5). Email : `sendPasswordResetEmail()` dans `mailer.ts` (lien `/?reset-password=TOKEN`). UI : lien dans la modale de login, détection auto du paramètre URL dans `app-header.ts`. Client : `forgotPassword()`/`resetPassword()`. Rate limit : 10 / 15 min / IP ; throttle 1 token / 5 min / email.
+
+### 10.5 mcp-server
+
+`mcp-server/` est **hors workspace npm** (pas dans `workspaces` du root). Il a son propre `package-lock.json` et `node_modules`. SDK en `1.29.0` (le pin 1.12.1 pour zod v4 ne s'applique plus). Dans `Dockerfile.db`, son build fait `npm ci && npm run build` depuis son répertoire.
+
+### 10.6 Déploiement VibeLab (production miweb.run)
+
+Mode canonique. Le repo expose à la **racine** : `compose.yml` (stack mode DB `web` + `mariadb`, agnostique : réseau `proxy` externe, labels Traefik en `${APP_NAME}`/`${DOMAIN}`, aucun domaine/hébergeur en dur) et `deploy.sh` (génère secrets/`.env` une seule fois, dérive `VITE_PROXY_URL`/`APP_URL`/`SMTP_FROM` du `DOMAIN`, build + up sous `-p ${APP_NAME}`).
+
+```bash
+ssh vps "spawn up chartsbuilder git@github.com:bmatge/dsfr-data.git --dns api --mail real --keep"
+# → https://chartsbuilder.miweb.run (cert dédié DKIM, mail réel signé)
+```
+
+DB **vierge** : le premier compte inscrit reçoit le rôle admin. Les secrets (`ENCRYPTION_KEY`, `JWT_SECRET`, `DB_*`) vivent dans `/opt/apps/chartsbuilder/.env` sur le VPS — à sauvegarder hors serveur, **ne JAMAIS les régénérer en place**.
+
+### 10.7 Déploiement legacy (ancien VPS, dual-mode)
+
+Le repo s'appelle `dsfr-data` mais le projet Docker historique s'appelle `datasource-charts-webcomponents`. Le `.env` doit contenir `COMPOSE_PROJECT_NAME=datasource-charts-webcomponents` pour réutiliser les volumes existants. Déploiement : `./docker/deploy-server.sh` (ou `./docker/deploy.sh` en mode statique).
+
+**Self-hosting** (domaine arbitraire, reverse externe) : procédure complète dans `docs/DEPLOYMENT.md` §"Configuration self-hosted" (3 scénarios + contrat exhaustif des chemins `/grist-proxy/`, `/tabular-proxy/`, `/albert-proxy/`, etc.). Chaque bloc `location /*-proxy/` dans `docker/nginx.conf` et `nginx-db.conf` est annoté `DESACTIVABLE`.
+
+---
+
+## 11. Notes importantes
+
+- Les fichiers `.js` dans `packages/core/src/` sont des artefacts de build — **ne pas les modifier**.
+- Toujours lancer `npm run build` après modification des composants.
+- Docker : `docker compose up -d --build` (volume `beacon-logs` pour persister le monitoring entre redémarrages).
+- APIs externes : Grist (docs.getgrist.com, grist.numerique.gouv.fr), Albert (albert.api.etalab.gouv.fr), ODS (`*.opendatasoft.com`), Tabular (tabular-api.data.gouv.fr), INSEE Melodi (api.insee.fr/melodi).
+
+---
+
+## 12. Couplages non-évidents ⚠️
+
+> **Le cœur de cette carte** ([ADR-053]). Ce qu'on oublie en touchant le code et qui casse à distance.
+> Liens `chemin:ligne` sans code copié — vérifier la source si un numéro a glissé.
+
+- **Piège `import.meta.env` (substitution statique Vite)** — `packages/shared/src/api/proxy-config.ts:74` (et `:84`, `:94`, `:107`, `:149`). Vite substitue `import.meta.env.VITE_*` par **string-matching** à la compilation. Toute indirection (`const m = import.meta as any; m.env.VITE_PROXY_URL`) **casse le match silencieusement** → le bundle embarque l'ancienne valeur en dur (`chartsbuilder.matge.com` a fui pendant des mois ; corrigé par PR #172, epic #168). **Toujours** accès direct `import.meta.env.VITE_*`. Cf. ADR-026.
+
+- **Cascade proxy 3 dimensions** — `proxy-config.ts:74-94`. `BEACON_BASE_URL = VITE_BEACON_URL || (PROXY_BASE_URL_EMBED = VITE_PROXY_URL_EMBED || (PROXY_BASE_URL = VITE_PROXY_URL))`. Aucune régression sans changement `.env` explicite (#180). Si tu modifies une variable, vérifie l'effet en cascade sur les deux dimensions en aval.
+
+- **`getProxyConfig()` repositionné sur la dimension EMBED** — `proxy-config.ts:133` et `:246` utilisent `PROXY_BASE_URL_EMBED`, **pas** `PROXY_BASE_URL` runtime. Raison : les adapters de `packages/core` tournent dans le bundle lib, chargé **indifféremment** dans l'app OU sur un site tiers → côté lib c'est l'embed qui fait foi. Modifier ça sans comprendre fait pointer les widgets tiers vers le mauvais proxy.
+
+- **Skills builder-IA validés par introspection Lit** — `apps/builder-ia/src/skills.ts` ⇒ couvert par `tests/apps/builder-ia/skills.test.ts`. Le test introspecte les `elementProperties` Lit de chaque composant `dsfr-data-*` : **tout attribut HTML ajouté à un composant DOIT être documenté dans son skill**, sinon le test casse. Idem pour tout nouveau type de graphique, opérateur de filtre ou fonction d'agrégation.
+
+- **`@customElement` enregistre les tags par side-effect (issue #177)** — l'import d'un fichier décoré `@customElement('app-…')` (chrome interne, `packages/app-ui/src/*.ts`) enregistre le tag dès l'évaluation du module. Conséquence : les `app-*` peuvent embarquer dans le bundle npm public **même sans export** si la chaîne d'imports les atteint. Surveiller l'arbre d'imports du point d'entrée lib (`packages/core/src/index.ts`) et la frontière lib/app (#319) ; valider en grepant les bundles produits.
+
+- **Modales DSFR — `data-fr-opened` ne suffit pas** — `packages/app-ui/src/auth-modal.ts:278-282` : il faut forcer `style="display:flex;opacity:1;visibility:visible"` inline en plus de `data-fr-opened="true"`, sinon la modale reste invisible (CSS DSFR). Reproduire ce pattern pour toute nouvelle modale (`password-change-modal.ts`, `share-dialog.ts`, etc.).
+
+- **`check:accents` matchait dans le CHANGELOG généré** — `scripts/check-french-accents.sh` (pré-filtre `git grep`, exclusions ligne 109 ex. `grist.numerique.gouv.fr`). Garde-fou CI : le script peut produire des faux positifs sur du contenu généré (CHANGELOG, sous-repos). Si un nouveau fichier généré contient des mots ciblés, ajouter une exclusion plutôt que de désactiver le check.
+
+- **Validation empirique post-build (anti-fuite d'URL)** — après **tout** changement touchant proxy/URL/dimensions/beacon : `grep` les bundles produits dans `packages/core/dist/` pour vérifier qu'**aucune URL ne fuit dans la mauvaise dimension** (ex. une URL embed dans le bundle runtime, ou l'inverse). C'est le seul moyen fiable d'attraper une régression de substitution Vite (cf. premier point). Décommission `chartsbuilder.matge.com` (#353) : vérifier qu'aucun bundle/`.env` ne le référence avant de couper.
+
+---
+
+## 13. Liens
+
+- ADR transverses : `~/Documents/Obsidian/30-Knowledge/ADR/` (ADR-026 import.meta.env, ADR-031 dsfr-data-context, ADR-036 proxy injectable, ADR-053 carte d'architecture).
+- Feature vault (cross-repo) : `~/Documents/Obsidian/30-Knowledge/Features/proxy-cors-3-dimensions.md`.
+- Fiche projet : `~/Documents/Obsidian/10-Projects/dsfr-data.md`.
+- Déploiement / self-hosting : `docs/DEPLOYMENT.md`.


### PR DESCRIPTION
## Quoi

- **CLAUDE.md : 633 → 155 lignes.** Ne garde que l'opérationnel : contexte projet, stack, commandes essentielles (dev/build/test/lint/release/deploy), conventions de code, remotes Git multi-push (miweb), versioning/release (résumé), « ce que Claude doit / ne doit jamais faire ». Pointeur clair en tête vers `docs/ARCHITECTURE.md`.
- **docs/ARCHITECTURE.md : 391 → 723 lignes.** Reçoit (dédupliqué) tout le détail d'architecture déplacé depuis CLAUDE.md, et une nouvelle **§12 « Couplages non-évidents ⚠️ »**.

## Pourquoi

CLAUDE.md était trop gros (633 l.) et mélangeait opérationnel et détail d'archi. On applique la convention **ADR-053** du vault : une bonne carte d'architecture est un **index de navigation** (points d'entrée, couplages non-évidents, le *pourquoi*) avec des liens `chemin:ligne` — **pas** du code copié ni un call-graph exhaustif. Le détail dérivable du code vit dans `ARCHITECTURE.md` (auto-chargé par Claude Code), CLAUDE.md reste léger.

## Blocs déplacés vers ARCHITECTURE.md

Pipeline de composants data + règles + pattern HTML · adapters/ProviderConfig + table de capacités + formats WHERE · attributs `dsfr-data-source` + hook de cache · Grist Records/SQL · package shared & frontière lib/app (#319) · skills builder-IA · proxy 3 dimensions (app/embed/beacon) + overrides runtime + `VITE_LIB_URL` · bundles · beacon · esbuild keepNames · DSFR chart deferred · Tauri zoom · communication inter-apps · MariaDB/chiffrement/mots de passe · mcp-server · déploiement VibeLab + legacy + self-hosting · procédures de tests Builder (E2E).

## §12 Couplages non-évidents documentés

1. Piège `import.meta.env` (substitution statique Vite par string-matching ; toute indirection casse le match → URL en dur).
2. Cascade proxy 3 dimensions (`VITE_BEACON_URL || VITE_PROXY_URL_EMBED || VITE_PROXY_URL`).
3. `getProxyConfig()` repositionné sur la dimension EMBED (lib chargée aussi sur sites tiers).
4. Skills builder-IA validés par introspection Lit → tout attribut ajouté doit être documenté sinon le test casse.
5. `@customElement` enregistre les tags par side-effect → `app-*` peuvent fuiter dans le bundle npm public (#177).
6. Modales DSFR : `data-fr-opened` insuffisant, forcer `opacity:1;visibility:visible` inline (`auth-modal.ts`).
7. `check:accents` matchait dans le CHANGELOG généré → garde-fou CI à connaître.
8. Validation empirique post-build : grep les bundles pour vérifier qu'aucune URL ne fuit dans la mauvaise dimension.

## Portée

Documentation uniquement (`CLAUDE.md`, `docs/ARCHITECTURE.md`). Aucun code/config touché. Aucune information opérationnelle perdue (déplacée, pas supprimée).

Réf vault : ADR-053 (carte d'architecture repo + feature vault), feature `proxy-cors-3-dimensions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)