### PR TITLE
fix(docker): superviser Express/MCP/IA-default dans le conteneur web

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,12 +1,44 @@
 #!/bin/sh
-# Docker entrypoint: periodic beacon log parsing + nginx
-# Parses beacon logs every 5 minutes OR immediately when triggered via
-# /api/refresh-monitoring (nginx writes to /tmp/beacon-refresh as trigger)
+# Docker entrypoint: supervised background services + periodic beacon parsing + nginx.
+#
+# Express, MCP server et IA default proxy tournent dans le meme conteneur que
+# nginx ; ils sont superviseur-restartes en cas de crash (le restart natif
+# `unless-stopped` du compose ne s'applique qu'a PID 1 = nginx). Sans cette
+# boucle, un crash d'Express au boot — typiquement MariaDB pas encore prete —
+# laisse l'API morte indefiniment (cf. incident 2026-06-23 chartsbuilder).
 
 PARSE_SCRIPT="/usr/local/bin/parse-beacon-logs.sh"
 TRIGGER="/tmp/beacon-refresh"
 INTERVAL=300  # 5 minutes
 CHECK=3       # check trigger every 3 seconds
+
+# Restart un service en boucle. Backoff progressif (5s, 10s, ..., cap 60s) si
+# le service crashe en moins de MIN_UPTIME secondes — evite le flap rapide
+# qui sature les logs quand une dependance (DB) n'est pas encore joignable.
+MIN_UPTIME=5
+MAX_BACKOFF=60
+supervise() {
+  label="$1"
+  shift
+  fast_restarts=0
+  while true; do
+    start=$(date +%s)
+    "$@"
+    rc=$?
+    end=$(date +%s)
+    uptime=$((end - start))
+    if [ "$uptime" -lt "$MIN_UPTIME" ]; then
+      fast_restarts=$((fast_restarts + 1))
+      backoff=$((fast_restarts * 5))
+      [ "$backoff" -gt "$MAX_BACKOFF" ] && backoff="$MAX_BACKOFF"
+      echo "[entrypoint] $label exited (code $rc) after ${uptime}s, restart #${fast_restarts} in ${backoff}s..."
+      sleep "$backoff"
+    else
+      fast_restarts=0
+      echo "[entrypoint] $label exited (code $rc) after ${uptime}s, restarting..."
+    fi
+  done
+}
 
 # Parse immediately on startup (restore monitoring-data.json from persisted logs)
 sh "$PARSE_SCRIPT" 2>&1
@@ -28,34 +60,28 @@ sh "$PARSE_SCRIPT" 2>&1
   done
 ) &
 
-# Start backend Express server in database mode
+# Express backend (mode DB seulement). Supervise plutot que best-effort :
+# si MariaDB n'est pas encore healthy au boot, Express crashe avec
+# ECONNREFUSED — la boucle re-essaie jusqu'a ce que la DB reponde.
 if [ "$GOUV_WIDGETS_MODE" = "database" ] && [ -f /app/server/dist/index.js ]; then
-  echo "[entrypoint] Database mode detected, starting Express backend on port 3002..."
-  cd /app/server && node dist/index.js 2>&1 &
-  EXPRESS_PID=$!
-  # Wait briefly and check if it survived startup
-  sleep 2
-  if kill -0 "$EXPRESS_PID" 2>/dev/null; then
-    echo "[entrypoint] Express backend started (PID $EXPRESS_PID)"
-  else
-    echo "[entrypoint] ERROR: Express backend crashed on startup (PID $EXPRESS_PID)"
-  fi
+  echo "[entrypoint] Database mode detected, starting Express backend on port 3002 (supervised)..."
+  (cd /app/server && supervise "Express" node dist/index.js) &
 fi
 
-# Start IA default proxy if token is configured (serves /ia-server-config and /ia-proxy-default)
+# IA default proxy (port 3003) — actif uniquement si IA_DEFAULT_TOKEN fourni.
 if [ -n "$IA_DEFAULT_TOKEN" ]; then
-  node /app/scripts/ia-default-server.js &
-  echo "[entrypoint] IA default proxy started on port 3003"
+  echo "[entrypoint] Starting IA default proxy on port 3003 (supervised)..."
+  supervise "IA-default" node /app/scripts/ia-default-server.js &
 fi
 
-# Start MCP server in background (reads skills from local file, no network dependency)
+# MCP server (port 3001) — lecture skills locale, pas de dependance reseau.
 SKILLS_FILE="/usr/share/nginx/html/dist/skills.json"
 if [ -f "$SKILLS_FILE" ]; then
-  node /app/mcp-server/dist/index.js --http --skills-file "$SKILLS_FILE" &
-  echo "[entrypoint] MCP server started on port 3001"
+  echo "[entrypoint] Starting MCP server on port 3001 (supervised)..."
+  supervise "MCP" node /app/mcp-server/dist/index.js --http --skills-file "$SKILLS_FILE" &
 else
   echo "[entrypoint] WARNING: $SKILLS_FILE not found, MCP server not started"
 fi
 
-# Start nginx in foreground
+# Start nginx in foreground (PID 1)
 exec nginx -g "daemon off;"


### PR DESCRIPTION
## Résumé

- Le `restart: unless-stopped` du compose ne s'applique qu'à PID 1 (nginx). Express, MCP et IA-default tournent en background dans le même conteneur ; s'ils crashent au boot (typiquement MariaDB pas encore healthy au redémarrage), ils restent morts sans limite de durée.
- Ajoute `supervise()` dans `scripts/docker-entrypoint.sh` : restart en boucle avec backoff linéaire (5s, 10s, ..., cap 60s) tant que le service crashe en moins de 5s, retour à 0 dès qu'un démarrage tient.
- Applique aux 3 services background (Express, MCP, IA-default). Aucun changement de comportement nominal.

## Contexte — incident chartsbuilder 2026-06-23

Sur `chartsbuilder.miweb.run`, Express a planté le 23/06 avec `Error: connect ECONNREFUSED 172.23.0.2:3306` (MariaDB pas encore prête au démarrage). nginx est resté up donc le conteneur paraissait healthy, mais `/api/auth/me` renvoyait 502 → le front masquait le bouton login. État resté en place 3 jours avant détection.

## Test plan

- [x] `sh -n scripts/docker-entrypoint.sh` — syntaxe POSIX OK
- [x] Fonction `supervise()` testée en isolation avec une commande qui exit 1 rapidement → backoff 5s/10s/15s observé comme attendu
- [ ] Déploiement sur `chartsbuilder.miweb.run` via `spawn up chartsbuilder` après merge → vérifier que le bouton login réapparaît
- [ ] Vérifier dans `docker compose logs web` que le label `[entrypoint] ... (supervised)` apparaît au boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)