### PR TITLE
feat(server): typage authProvider 'local'|'oidc' + endpoint /providers (PR-1 de #359)

### DIFF
--- a/apps/admin/src/api.ts
+++ b/apps/admin/src/api.ts
@@ -7,7 +7,7 @@ export interface User {
   email: string;
   displayName: string;
   role: 'admin' | 'editor' | 'viewer';
-  authProvider: 'local' | 'proconnect';
+  authProvider: 'local' | 'oidc';
   isActive: boolean;
   emailVerified: boolean;
   lastLogin: string | null;

--- a/apps/admin/src/main.ts
+++ b/apps/admin/src/main.ts
@@ -341,7 +341,7 @@ function renderStats(): void {
     <h3 class="fr-mt-4w">Par provider</h3>
     <div class="admin-kpi-row fr-mb-4w">
       ${kpi(stats.byProvider.local || 0, 'Local')}
-      ${kpi(stats.byProvider.proconnect || 0, 'ProConnect')}
+      ${kpi(stats.byProvider.oidc || 0, 'SSO (OIDC)')}
     </div>
   `;
 }

--- a/server/src/db/database.ts
+++ b/server/src/db/database.ts
@@ -187,6 +187,9 @@ async function runMigrations(): Promise<void> {
   if (currentVersion < 7) {
     await migrateV7();
   }
+  if (currentVersion < 8) {
+    await migrateV8();
+  }
 }
 
 /**
@@ -432,6 +435,61 @@ async function migrateV6(): Promise<void> {
     await conn.query(`ALTER TABLE users ADD COLUMN tour_state JSON NULL`);
     await conn.query('INSERT IGNORE INTO schema_version (version) VALUES (6)');
     console.log('[db] Migration v6 complete');
+  } finally {
+    conn.release();
+  }
+}
+
+/**
+ * Migration v8: generic OIDC support (epic #359).
+ * - Rename ENUM value 'proconnect' → 'oidc' on users.auth_provider and sessions.auth_provider.
+ *   The 'proconnect' value was a type-only placeholder (cf. migrateV2) never wired up; no
+ *   production rows reference it. UPDATE statements are defensive normalization.
+ * - Add users.oidc_issuer to distinguish Authentik / ProConnect / autre at runtime — the
+ *   backend code stays generic (no hardcoded IdP name), the issuer URL is the only marker.
+ * - Add unique index (oidc_issuer, external_id) so the same OIDC subject across re-imports
+ *   maps to one user row, even if a future deployment connects multiple IdPs.
+ */
+async function migrateV8(): Promise<void> {
+  console.log(
+    '[db] Running migration v8: OIDC support (rename proconnect → oidc, add oidc_issuer)'
+  );
+
+  const conn = await getPool().getConnection();
+  try {
+    const [cols] = await conn.query(
+      `SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+       WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'users' AND COLUMN_NAME = 'oidc_issuer'`
+    );
+    if ((cols as unknown[]).length > 0) {
+      await conn.query('INSERT IGNORE INTO schema_version (version) VALUES (8)');
+      return;
+    }
+
+    await conn.beginTransaction();
+
+    await conn.query(`UPDATE users SET auth_provider = 'local' WHERE auth_provider = 'proconnect'`);
+    await conn.query(
+      `UPDATE sessions SET auth_provider = 'local' WHERE auth_provider = 'proconnect'`
+    );
+
+    await conn.query(`ALTER TABLE users
+      MODIFY COLUMN auth_provider ENUM('local', 'oidc') NOT NULL DEFAULT 'local'`);
+    await conn.query(`ALTER TABLE sessions
+      MODIFY COLUMN auth_provider ENUM('local', 'oidc') NOT NULL`);
+
+    await conn.query(`ALTER TABLE users ADD COLUMN oidc_issuer VARCHAR(255) NULL AFTER idp_id`);
+
+    await conn.query(
+      `CREATE UNIQUE INDEX idx_users_oidc_external ON users(oidc_issuer, external_id)`
+    );
+
+    await conn.query('INSERT IGNORE INTO schema_version (version) VALUES (8)');
+    await conn.commit();
+    console.log('[db] Migration v8 complete');
+  } catch (err) {
+    await conn.rollback();
+    throw err;
   } finally {
     conn.release();
   }

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -17,6 +17,25 @@ import { createSession, revokeSession, revokeAllUserSessions } from '../utils/se
 
 const router = Router();
 const SALT_ROUNDS = 10;
+
+/**
+ * GET /api/auth/providers
+ * Public list of external auth providers the server has configured.
+ * Returns [] when no SSO is enabled — front falls back to local login only.
+ * Drives the conditional "Se connecter avec…" button in the login modal.
+ */
+router.get('/providers', (_req, res) => {
+  const providers: Array<{ id: string; label: string; loginUrl: string }> = [];
+  if (process.env.OIDC_ENABLED === 'true') {
+    providers.push({
+      id: 'oidc',
+      label: process.env.OIDC_PROVIDER_LABEL || 'SSO',
+      loginUrl: '/api/auth/oidc/login',
+    });
+  }
+  res.json({ providers });
+});
+
 const VERIFICATION_TOKEN_BYTES = 32;
 const VERIFICATION_EXPIRY_HOURS = 24;
 const RESEND_MAX = 3; // max resend per hour per email

--- a/server/src/utils/sessions.ts
+++ b/server/src/utils/sessions.ts
@@ -20,7 +20,7 @@ export function hashToken(token: string): string {
 export async function createSession(
   userId: string,
   token: string,
-  authProvider: 'local' | 'proconnect',
+  authProvider: 'local' | 'oidc',
   req: Request
 ): Promise<string> {
   const id = uuidv4();

--- a/tests/server/auth.test.ts
+++ b/tests/server/auth.test.ts
@@ -563,6 +563,45 @@ describe('GET /api/auth/users', () => {
   });
 });
 
+describe('GET /api/auth/providers', () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    app = await createTestApp();
+    vi.clearAllMocks();
+    delete process.env.OIDC_ENABLED;
+    delete process.env.OIDC_PROVIDER_LABEL;
+  });
+
+  it('returns an empty list by default (OIDC disabled)', async () => {
+    const res = await request(app).get('/api/auth/providers');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ providers: [] });
+  });
+
+  it('returns the OIDC provider when OIDC_ENABLED=true', async () => {
+    process.env.OIDC_ENABLED = 'true';
+    process.env.OIDC_PROVIDER_LABEL = 'Authentik (lab)';
+    const res = await request(app).get('/api/auth/providers');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      providers: [{ id: 'oidc', label: 'Authentik (lab)', loginUrl: '/api/auth/oidc/login' }],
+    });
+  });
+
+  it('falls back to "SSO" label when OIDC_PROVIDER_LABEL is unset', async () => {
+    process.env.OIDC_ENABLED = 'true';
+    const res = await request(app).get('/api/auth/providers');
+    expect(res.status).toBe(200);
+    expect(res.body.providers[0].label).toBe('SSO');
+  });
+
+  it('requires no authentication', async () => {
+    const res = await request(app).get('/api/auth/providers');
+    expect(res.status).toBe(200);
+  });
+});
+
 afterAll(async () => {
   await closeTestApp();
 });


### PR DESCRIPTION
## Summary

PR-1 de l'epic #359 (auth OIDC optionnelle). Pose le terrain DB et les types pour PR-2 (routes OIDC `openid-client`) et PR-3 (bouton SSO frontend).

**Aucun changement runtime visible** : `OIDC_ENABLED` n'est pas encore lu par les routes (PR-2), et l'endpoint `/providers` retourne `[]` par défaut → le front continue de n'afficher que le login local. Cette PR est mergeable et déployable seule en toute sécurité.

### Changements

- **Migration v8** (`server/src/db/database.ts`) — rename ENUM `auth_provider` `'proconnect'` → `'oidc'` sur `users` et `sessions`, ajoute `users.oidc_issuer VARCHAR(255)` + index unique `(oidc_issuer, external_id)`. Idempotente (check sur l'existence de la colonne). UPDATE défensif des lignes legacy (la valeur `'proconnect'` était un placeholder type-only jamais écrit en prod, cf. epic).
- **Retype `'local' | 'proconnect'` → `'local' | 'oidc'`** dans `server/src/utils/sessions.ts` et `apps/admin/src/api.ts`.
- **KPI admin** — `apps/admin/src/main.ts` renomme la carte "ProConnect" en "SSO (OIDC)" et lit `stats.byProvider.oidc`.
- **Nouvelle route publique `GET /api/auth/providers`** (`server/src/routes/auth.ts`) — retourne `{ providers: [] }` si `OIDC_ENABLED !== 'true'`, sinon `{ providers: [{ id: 'oidc', label: OIDC_PROVIDER_LABEL || 'SSO', loginUrl: '/api/auth/oidc/login' }] }`. Permettra au front (PR-3) de masquer le bouton SSO quand l'auth externe n'est pas configurée — garantit l'autonomie du repo self-hostable (cf. décision verrouillée #1 de l'epic).
- **Tests** (`tests/server/auth.test.ts`) — 4 cas couvrent l'endpoint `/providers` (défaut vide, OIDC activé, fallback label, no auth required).

### Compat ascendante

- Les déploiements existants qui upgradent sans toucher au `.env` continuent comme avant : la migration v8 normalise les colonnes mais aucune ligne en prod n'a `auth_provider='proconnect'` (placeholder jamais câblé).
- Tests existants `auth.test.ts` / `admin.test.ts` non touchés — `createSession(..., 'local', ...)` reste valide (5 call-sites inchangés dans `routes/auth.ts`).

## Test plan

- [ ] CI : typecheck + lint OK (validés en local)
- [ ] CI : tests serveur (incluant les 4 nouveaux cas `/providers`)
- [ ] Apres merge : déploiement VPS sur `chartsbuilder.miweb.run` — `curl https://chartsbuilder.miweb.run/api/auth/providers` doit retourner `{"providers":[]}`
- [ ] Apres merge : `docker exec dsfr-data-mariadb mariadb -e "SHOW CREATE TABLE users\\G"` confirme `auth_provider ENUM('local','oidc')` + colonne `oidc_issuer` + index `idx_users_oidc_external`
- [ ] Admin → onglet stats : carte "SSO (OIDC)" remplace "ProConnect", valeur = 0 (attendu : pas encore de users OIDC)

## Suite

- **PR-2** (à venir) — backend OIDC : `openid-client`, routes `/api/auth/oidc/login` + `/api/auth/oidc/callback`, réconciliation par `email_verified=true`, mode `OIDC_ONLY`, `.env.example` section "SSO (optionnel)", doc `docs/DEPLOYMENT.md`.
- **PR-3** (à venir) — frontend : bouton SSO conditionné à `/api/auth/providers`, email template générique.

Pas de changeset (touche `server/`, `apps/`, `tests/` — pas `packages/core` ni `packages/shared`).

Refs: #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)