### PR TITLE
feat(ui): bouton SSO conditionnel + email OIDC generique (PR-3 de #359)

### DIFF
--- a/packages/app-ui/src/auth-modal.ts
+++ b/packages/app-ui/src/auth-modal.ts
@@ -11,7 +11,14 @@
 
 import { LitElement, html, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { login, register, forgotPassword, resetPassword } from '@dsfr-data/shared';
+import {
+  login,
+  register,
+  forgotPassword,
+  resetPassword,
+  fetchAuthProviders,
+  type AuthProvider,
+} from '@dsfr-data/shared';
 
 type Tab = 'login' | 'register' | 'forgot' | 'reset';
 
@@ -30,6 +37,10 @@ export class AuthModal extends LitElement {
   @state() private _successMessage = '';
   @state() private _resetToken = '';
 
+  // External providers (OIDC) — populated on open()
+  @state() private _providers: AuthProvider[] = [];
+  @state() private _oidcOnly = false;
+
   // Light DOM for DSFR
   createRenderRoot() {
     return this;
@@ -45,6 +56,16 @@ export class AuthModal extends LitElement {
     this._displayName = '';
     this._resetToken = resetToken || '';
     this._open = true;
+    void this._loadProviders();
+  }
+
+  private async _loadProviders(): Promise<void> {
+    const { providers, oidcOnly } = await fetchAuthProviders();
+    this._providers = providers;
+    this._oidcOnly = oidcOnly;
+    if (oidcOnly && (this._tab === 'register' || this._tab === 'forgot')) {
+      this._tab = 'login';
+    }
   }
 
   close(): void {
@@ -267,10 +288,41 @@ export class AuthModal extends LitElement {
     `;
   }
 
+  private _renderProviderButtons() {
+    if (this._providers.length === 0) return nothing;
+    if (this._tab !== 'login' && this._tab !== 'register') return nothing;
+    return html`
+      <div style="margin-bottom:1rem">
+        ${this._providers.map(
+          (p) => html`
+            <a
+              class="fr-btn fr-btn--secondary"
+              style="width:100%;justify-content:center;margin-bottom:0.5rem"
+              href=${p.loginUrl}
+            >
+              Se connecter avec ${p.label}
+            </a>
+          `
+        )}
+        ${this._oidcOnly
+          ? nothing
+          : html`
+              <div
+                style="text-align:center;color:var(--text-mention-grey);margin:0.5rem 0;font-size:0.875rem"
+              >
+                — ou —
+              </div>
+            `}
+      </div>
+    `;
+  }
+
   render() {
     if (!this._open) return nothing;
 
-    const showTabs = this._tab === 'login' || this._tab === 'register';
+    // OIDC_ONLY=true → no register tab, no forgot link, no local form.
+    const showTabs = !this._oidcOnly && (this._tab === 'login' || this._tab === 'register');
+    const showLocalForm = !this._oidcOnly || this._tab === 'reset';
 
     return html`
       <dialog
@@ -361,21 +413,32 @@ export class AuthModal extends LitElement {
                         </div>
                       `
                     : nothing}
+                  ${this._renderProviderButtons()}
+                  ${showLocalForm
+                    ? html`
+                        <form @submit=${this._handleSubmit}>
+                          ${this._renderForm()}
 
-                  <form @submit=${this._handleSubmit}>
-                    ${this._renderForm()}
-
-                    <div class="fr-input-group" style="margin-top:1.5rem">
-                      <button
-                        class="fr-btn"
-                        type="submit"
-                        ?disabled=${this._loading}
-                        style="width:100%"
-                      >
-                        ${this._renderSubmitLabel()}
-                      </button>
-                    </div>
-                  </form>
+                          <div class="fr-input-group" style="margin-top:1.5rem">
+                            <button
+                              class="fr-btn"
+                              type="submit"
+                              ?disabled=${this._loading}
+                              style="width:100%"
+                            >
+                              ${this._renderSubmitLabel()}
+                            </button>
+                          </div>
+                        </form>
+                      `
+                    : html`
+                        <p
+                          style="color:var(--text-mention-grey);font-size:0.875rem;text-align:center;margin:0"
+                        >
+                          La connexion locale par mot de passe est desactivee sur cette instance.
+                          Utilisez le bouton ci-dessus pour vous connecter.
+                        </p>
+                      `}
                 </div>
               </div>
             </div>

--- a/packages/shared/src/auth/auth-service.ts
+++ b/packages/shared/src/auth/auth-service.ts
@@ -465,3 +465,43 @@ export function _setCsrfTokenForTest(token: string | null): void {
 export async function authenticatedFetch(path: string, options?: RequestInit): Promise<Response> {
   return apiFetch(path, options);
 }
+
+// ──────────────────────────────────────────────────────────────
+// External auth providers (SSO / OIDC) — epic #359
+// ──────────────────────────────────────────────────────────────
+
+export interface AuthProvider {
+  id: string;
+  label: string;
+  loginUrl: string;
+}
+
+export interface AuthProvidersResponse {
+  providers: AuthProvider[];
+  /** When true, local register / login / forgot / reset are 403. Front hides the local form. */
+  oidcOnly: boolean;
+}
+
+const EMPTY_PROVIDERS: AuthProvidersResponse = { providers: [], oidcOnly: false };
+
+/**
+ * GET /api/auth/providers — public endpoint, no auth.
+ * Returns the list of external SSO providers the server has configured
+ * (empty in self-hosted deployments that don't use SSO). Drives the
+ * conditional "Se connecter avec…" button in the login modal.
+ */
+export async function fetchAuthProviders(): Promise<AuthProvidersResponse> {
+  try {
+    const res = await fetch(`${shared.baseUrl}/api/auth/providers`, {
+      credentials: 'include',
+    });
+    if (!res.ok) return EMPTY_PROVIDERS;
+    const data = (await res.json()) as Partial<AuthProvidersResponse>;
+    return {
+      providers: Array.isArray(data.providers) ? data.providers : [],
+      oidcOnly: data.oidcOnly === true,
+    };
+  } catch {
+    return EMPTY_PROVIDERS;
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -131,6 +131,9 @@ export {
   getAuthState,
   getUser,
   isAuthenticated,
+  fetchAuthProviders,
+  type AuthProvider,
+  type AuthProvidersResponse,
 } from './auth/auth-service.js';
 export { registerServerCacheProvider } from './api/server-cache-provider.js';
 export { registerDbBeaconTransport } from './api/beacon-transport.js';

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -14,7 +14,11 @@ import type { AuthenticatedRequest } from '../middleware/auth.js';
 import { generateCsrfToken } from '../middleware/csrf.js';
 import { authLimiter } from '../middleware/rate-limit.js';
 import { isValidEmail, isStrongPassword } from '../utils/validation.js';
-import { sendVerificationEmail, sendPasswordResetEmail } from '../utils/mailer.js';
+import {
+  sendVerificationEmail,
+  sendPasswordResetEmail,
+  sendWelcomeEmail,
+} from '../utils/mailer.js';
 import { createSession, revokeSession, revokeAllUserSessions } from '../utils/sessions.js';
 import { logAudit } from '../utils/audit.js';
 import {
@@ -24,6 +28,7 @@ import {
   getOidcIssuer,
   getOidcRedirectUri,
   getOidcDefaultRole,
+  getOidcProviderLabel,
   OIDC_STATE_COOKIE,
   OIDC_STATE_MAX_AGE_MS,
   OIDC_COOKIE_PATH,
@@ -247,6 +252,10 @@ router.get('/oidc/callback', authLimiter, async (req, res) => {
       );
       await logAudit(req, 'oidc.user.provisioned', 'user', newId, { email, issuer, sub, role });
       user = { id: newId, email, role, is_active: 1 };
+
+      sendWelcomeEmail(email, displayName, getOidcProviderLabel(), role).catch((mailErr) => {
+        console.error('[oidc] Welcome email failed (non-blocking):', mailErr);
+      });
     } else {
       await execute('UPDATE users SET last_login = NOW() WHERE id = ?', [user.id]);
     }

--- a/server/src/utils/mailer.ts
+++ b/server/src/utils/mailer.ts
@@ -78,22 +78,31 @@ export async function sendVerificationEmail(email: string, token: string): Promi
 }
 
 /**
- * Send a welcome email for ProConnect users (first login).
- * Non-blocking: failure does not prevent login.
+ * Send a welcome email when a user is auto-provisioned via SSO/OIDC.
+ * `providerLabel` is the human-readable IdP name (OIDC_PROVIDER_LABEL, e.g.
+ * "Authentik", "ProConnect"). `role` defaults to "editeur" (the OIDC default).
+ * Non-blocking at the call site: failure does not prevent login.
  */
-export async function sendWelcomeEmail(email: string, displayName: string): Promise<void> {
+export async function sendWelcomeEmail(
+  email: string,
+  displayName: string,
+  providerLabel = 'SSO',
+  role = 'editeur'
+): Promise<void> {
   const appUrl = APP_URL();
+  const safeProvider = esc(providerLabel);
+  const safeRole = esc(role);
   await getTransporter().sendMail({
     from: `"DSFR Data" <${FROM()}>`,
     to: email,
     subject: 'Bienvenue sur DSFR Data',
     html: `
       <p>Bonjour ${esc(displayName)},</p>
-      <p>Votre compte a ete cree sur <a href="${appUrl}">DSFR Data</a> via ProConnect.</p>
-      <p>Vous disposez du role <strong>editeur</strong> et pouvez creer des visualisations de donnees.</p>
+      <p>Votre compte a ete cree sur <a href="${appUrl}">DSFR Data</a> via <strong>${safeProvider}</strong>.</p>
+      <p>Vous disposez du role <strong>${safeRole}</strong> et pouvez creer des visualisations de donnees.</p>
       <p>Si vous n'etes pas a l'origine de cette connexion, contactez l'administrateur.</p>
     `,
-    text: `Bonjour ${displayName},\n\nVotre compte a ete cree sur DSFR Data (${appUrl}) via ProConnect.\nRole : editeur.`,
+    text: `Bonjour ${displayName},\n\nVotre compte a ete cree sur DSFR Data (${appUrl}) via ${providerLabel}.\nRole : ${role}.`,
   });
 }
 


### PR DESCRIPTION
## Summary

PR-3 de l'epic #359 (auth OIDC optionnelle). Couvre la partie **frontend** : bouton "Se connecter avec…" dans la modale d'auth, conditionné à la réponse de `GET /api/auth/providers` (ajouté en PR-1, peuplé en PR-2). Côté serveur, généralise le template email "ProConnect" en **welcome OIDC générique** paramétré par `OIDC_PROVIDER_LABEL` et le branche au first-login d'un user OIDC.

> ⚠️ **Basée sur [PR #361](https://github.com/bmatge/dsfr-data/pull/361) (PR-2) qui dépend elle-même de [PR #360](https://github.com/bmatge/dsfr-data/pull/360) (PR-1).** Ces 3 PRs forment la stack complète de l'epic — à merger dans l'ordre.

### Aucun changement visible si OIDC désactivé

`OIDC_ENABLED=false` (défaut) → `/providers` retourne `{"providers":[],"oidcOnly":false}` → le bouton SSO ne s'affiche pas, le formulaire local reste identique à avant. Pas de régression possible pour les déploiements existants.

### Changements

#### Frontend
- **`packages/shared/src/auth/auth-service.ts`** — nouvelle fonction `fetchAuthProviders()` (best-effort, retourne `{providers:[], oidcOnly:false}` en cas d'erreur réseau ou réponse non-OK). Types `AuthProvider` et `AuthProvidersResponse` exposés via le barrel `packages/shared/src/index.ts` (app-side, pas `lib.ts` — pas utile aux Web Components publics).
- **`packages/app-ui/src/auth-modal.ts`** :
  - Chargement asynchrone des providers à chaque `open()`.
  - Rendu d'un bouton `fr-btn--secondary` "Se connecter avec <label>" en tête de modale (au-dessus du formulaire local), avec séparateur "— ou —".
  - Si `oidcOnly=true` : formulaire local + onglets register/forgot masqués entièrement, seul le bouton SSO et un message d'explication s'affichent. Le tab `reset` reste accessible (pour les liens email envoyés avant l'activation du mode).
  - Si on est en oidcOnly=true et qu'on était sur le tab register/forgot, switch automatique vers login.

#### Email template
- **`server/src/utils/mailer.ts`** — `sendWelcomeEmail(email, displayName, providerLabel='SSO', role='editeur')`. Le providerLabel est inline dans le sujet du message (escape HTML appliqué). Plus aucune mention de "ProConnect" en dur.
- **`server/src/routes/auth.ts`** — envoi du welcome email **best-effort** (`.catch()` silencieux) après le `INSERT users ...` du callback OIDC. Une erreur SMTP n'empêche pas le redirect `/`.

### Mockups UI

Mode normal (un provider OIDC, comptes locaux actifs) :

```
┌──────────────────────────────────────┐
│  Connexion         [Inscription]     │
│                                      │
│  [ Se connecter avec Authentik ]     │
│              — ou —                  │
│                                      │
│  Email     [ ........................│
│  Mot de passe [ .....................│
│  Mot de passe oublié ?               │
│                                      │
│  [        Se connecter        ]      │
└──────────────────────────────────────┘
```

Mode `OIDC_ONLY=true` (compte gouv / instance restreinte) :

```
┌──────────────────────────────────────┐
│  Connexion                           │
│                                      │
│  [ Se connecter avec Authentik ]     │
│                                      │
│  La connexion locale par mot de      │
│  passe est desactivee sur cette      │
│  instance. Utilisez le bouton        │
│  ci-dessus pour vous connecter.      │
└──────────────────────────────────────┘
```

## Test plan

- [ ] CI : typecheck + lint OK (validés en local).
- [ ] CI : tests serveur intacts (les mocks de `sendWelcomeEmail` dans 8 fichiers de tests restent compatibles avec la nouvelle signature à 4 params dont 2 optionnels).
- [ ] Visuel : sur main (PR mergées), ouvrir `chartsbuilder.miweb.run`, click "Se connecter" → modale s'affiche sans bouton SSO (OIDC pas encore configuré). ✓ Aucune régression.
- [ ] Après config OIDC (PR-2 mergée + `.env` rempli côté VPS) :
  - GET `/api/auth/providers` retourne le provider OIDC.
  - Modale affiche le bouton "Se connecter avec Authentik (lab)" au-dessus du formulaire.
  - Click sur le bouton → redirect vers Authentik /authorize.
  - Login Authentik → callback → user provisionné en rôle `editor` → email de bienvenue reçu mentionnant "Authentik (lab)" (et pas "ProConnect").
- [ ] Bascule `OIDC_ONLY=true` → modale n'affiche plus que le bouton SSO.

## Note CI

Modification de `packages/shared/src/` déclenche le warning **"changeset manquant"** sur cette PR. Pas de changeset créé volontairement :
- `packages/shared` est `private: true` (jamais publié sur npm).
- `packages/core/src` (le package npm `dsfr-data` publié) n'est pas touché.
- `packages/shared/src/lib.ts` (l'export lib-safe consommé par `packages/core`) n'est pas modifié.

Donc aucun consommateur npm n'est affecté → un bump de version serait artificiel.

## Suite

- ADR vault à créer après merge final des 3 PRs : `ADR-NNN-auth-oidc-generique-optionnelle.md` documentant les 5 décisions verrouillées de l'epic.
- Provisioning Authentik côté `vibelab-platform` (skill `vps-spawn` ou nouvelle skill) : App + OAuth2 Provider + groupe `chartsbuilder-users` + policy binding. Idempotent dans `vibelab-platform/authentik/provision.py`.
- Test e2e grandeur nature sur `chartsbuilder.miweb.run` une fois Authentik configuré.

Refs: #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)