### PR TITLE
fix(deploy): expose les vars OIDC_* au conteneur web (#359)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -69,6 +69,17 @@ services:
       - HTTP_PROXY=${HTTP_PROXY:-}
       - HTTPS_PROXY=${HTTPS_PROXY:-}
       - NO_PROXY=${NO_PROXY:-}
+      # SSO / Auth OIDC (epic #359) — opt-in, valeurs posées dans le .env de
+      # déploiement. Vides → flux OIDC inactif, l'app boot comme aujourd'hui
+      # (login/password). Voir .env.example §"SSO / Auth OIDC".
+      - OIDC_ENABLED=${OIDC_ENABLED:-}
+      - OIDC_ONLY=${OIDC_ONLY:-}
+      - OIDC_ISSUER=${OIDC_ISSUER:-}
+      - OIDC_CLIENT_ID=${OIDC_CLIENT_ID:-}
+      - OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET:-}
+      - OIDC_REDIRECT_URI=${OIDC_REDIRECT_URI:-}
+      - OIDC_DEFAULT_ROLE=${OIDC_DEFAULT_ROLE:-}
+      - OIDC_PROVIDER_LABEL=${OIDC_PROVIDER_LABEL:-}
     networks:
       - internal
       - proxy


### PR DESCRIPTION
## Contexte

Dernier maillon manquant de l'epic #359 (auth OIDC optionnelle) : le **code est sur main** (PRs #360/#363/#362) mais le **déploiement n'est pas actif** en prod — `GET https://chartsbuilder.miweb.run/api/auth/providers` renvoie `{"providers":[],"oidcOnly":false}`.

## Cause

Le bloc `environment:` du service `web` (`compose.yml`) liste **explicitement** chaque variable injectée (`- KEY=${KEY}`) — c'est la philosophie *moindre privilège* de `spawn` (le compose n'injecte que les clés qu'il référence, pas un sous-ensemble exporté). Les 8 variables `OIDC_*` lues par le serveur n'y figuraient pas → elles n'atteignaient **jamais** le conteneur, même posées dans `/opt/apps/chartsbuilder/.env`.

Le workaround envisagé (`.spawn-override.yml`) est condamné : `spawn` réécrit ce fichier dès qu'on passe `--mail` (le cas de chartsbuilder en `--mail real`).

## Changement

Ajout des 8 vars `OIDC_*` au bloc `environment:`, avec défaut vide `${VAR:-}` :

- **Non-breaking** : vides → flux OIDC inactif, l'app boot comme aujourd'hui (login/password). Contrat « `OIDC_ENABLED=false` par défaut » de l'epic respecté.
- **Pérenne** : l'injection est in-repo et versionnée, plus de dépendance à un override volatil.

Aucun code TS touché, aucun changeset (hors `packages/core/src` et `shared`).

## Déploiement après merge

```bash
ssh vps "spawn up chartsbuilder git@github.com:bmatge/dsfr-data.git --dns api --mail real --keep"
```
(re-flags complets — un `spawn up` nu dé-promeut). Le `.env` VPS (creds OIDC déjà posés) sera enfin lu → `/api/auth/providers` retournera le provider OIDC.

Refs #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)