### PR TITLE
refactor: standardize attribute names to English (camelCase/kebab-case)

### DIFF
--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -422,13 +422,13 @@ Les donnees de la source sont transmises directement au composant de visualisati
   base-url="https://data.economie.gouv.fr"></dsfr-data-source>
 
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem;">
-  <dsfr-data-kpi source="data" valeur="sum:nombre_beneficiaires"
+  <dsfr-data-kpi source="data" value="nombre_beneficiaires:sum"
     label="Total beneficiaires" format="nombre"></dsfr-data-kpi>
-  <dsfr-data-kpi source="data" valeur="avg:nombre_beneficiaires"
+  <dsfr-data-kpi source="data" value="nombre_beneficiaires:avg"
     label="Moyenne" format="decimal"></dsfr-data-kpi>
-  <dsfr-data-kpi source="data" valeur="max:montant_investissement"
-    label="Investissement max" format="euro" couleur="vert"></dsfr-data-kpi>
-  <dsfr-data-kpi source="data" valeur="count"
+  <dsfr-data-kpi source="data" value="montant_investissement:max"
+    label="Investissement max" format="euro" color="vert"></dsfr-data-kpi>
+  <dsfr-data-kpi source="data" value="count"
     label="Enregistrements" format="nombre"></dsfr-data-kpi>
 </div>
 ```
@@ -441,9 +441,9 @@ Les donnees de la source sont transmises directement au composant de visualisati
   resource="2876a346-d50c-4911-934e-19ee07b0e503"></dsfr-data-query>
 
 <dsfr-data-list source="data"
-  colonnes="Nom de l'élu:Nom, Prénom de l'élu:Prenom, Libellé du département:Departement, Libellé de la commune:Commune"
-  recherche="true" filtres="Libellé du département"
-  tri="Nom de l'élu:asc" pagination="10" export="csv">
+  columns="Nom de l'élu:Nom, Prénom de l'élu:Prenom, Libellé du département:Departement, Libellé de la commune:Commune"
+  search filters="Libellé du département"
+  sort="Nom de l'élu:asc" pagination="10" export="csv">
 </dsfr-data-list>
 ```
 
@@ -491,8 +491,8 @@ Les donnees passent par `dsfr-data-normalize` qui nettoie les valeurs (conversio
 </dsfr-data-normalize>
 
 <dsfr-data-list source="clean"
-  colonnes="Nom, Prenom, Commune, Departement, Sexe"
-  recherche pagination="10" export="csv">
+  columns="Nom, Prenom, Commune, Departement, Sexe"
+  search pagination="10" export="csv">
 </dsfr-data-list>
 ```
 
@@ -516,8 +516,7 @@ Les sources Grist renvoient des enregistrements imbriques `{id, fields: {col1, c
 </dsfr-data-query>
 
 <dsfr-data-chart source="stats" type="bar"
-  label-field="Pays" value-field="PIB__avg"
-  titre="PIB moyen par pays">
+  label-field="Pays" value-field="PIB__avg">
 </dsfr-data-chart>
 ```
 
@@ -615,10 +614,10 @@ Les donnees passent par `dsfr-data-query` qui les filtre, regroupe et/ou agrege 
 </dsfr-data-query>
 
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem;">
-  <dsfr-data-kpi source="data" valeur="count"
+  <dsfr-data-kpi source="data" value="count"
     label="Total des maires" format="nombre"></dsfr-data-kpi>
-  <dsfr-data-kpi source="q-femmes" valeur="count"
-    label="Dont femmes" format="nombre" couleur="bleu"></dsfr-data-kpi>
+  <dsfr-data-kpi source="q-femmes" value="count"
+    label="Dont femmes" format="nombre" color="bleu"></dsfr-data-kpi>
 </div>
 ```
 
@@ -634,8 +633,8 @@ Les donnees passent par `dsfr-data-query` qui les filtre, regroupe et/ou agrege 
 </dsfr-data-query>
 
 <dsfr-data-list source="q"
-  colonnes="Nom de l'élu:Nom, Prénom de l'élu:Prenom, Libellé de la commune:Commune, Libellé du département:Departement"
-  recherche="true" tri="Nom de l'élu:asc" pagination="10" export="csv">
+  columns="Nom de l'élu:Nom, Prénom de l'élu:Prenom, Libellé de la commune:Commune, Libellé du département:Departement"
+  search sort="Nom de l'élu:asc" pagination="10" export="csv">
 </dsfr-data-list>
 ```
 

--- a/guide/examples/observatoire-afa-v1.html
+++ b/guide/examples/observatoire-afa-v1.html
@@ -40,7 +40,7 @@
   </div>
 
   <!-- ══ KPIs ══ -->
-  <dsfr-data-kpi-group cols="3" gap="md" fr-mb-6w aria-label="Indicateurs clés du corpus">
+  <dsfr-data-kpi-group cols="3" gap="md" class="fr-mb-6w" aria-label="Indicateurs clés du corpus">
     <dsfr-data-kpi source="src-all" value="count"
       label="Décisions analysées" color="bleu"></dsfr-data-kpi>
     <dsfr-data-kpi source="src-all" value="count:issue_court:Condamnation"

--- a/guide/guide-demo-complete.html
+++ b/guide/guide-demo-complete.html
@@ -148,7 +148,7 @@
         <dsfr-data-kpi-group cols="4">
           <dsfr-data-kpi
             source="films"
-            value="count:title"
+            value="title:count"
             label="Nombre de films"
             format="nombre"
             icon="ri-film-line"
@@ -401,7 +401,7 @@
           name="Entrées simulées (milliers)"
           unit-tooltip=" k"
           selected-palette="sequentialAscending"
-          zoom="continent">
+          zoom-mode="continent">
         </dsfr-data-world-map>
 
         <!-- Tableau accessible pour la carte mondiale (dsfr-data-a11y ne supporte pas dsfr-data-world-map) -->

--- a/guide/guide-exemples-ghibli.html
+++ b/guide/guide-exemples-ghibli.html
@@ -467,7 +467,7 @@
 
 &lt;dsfr-data-list source="films-filtered"
   columns="title:Titre, director:Realisateur, release_date:Annee, running_time:Duree (min), rt_score:Score RT (%)"
-  recherche tri="rt_score:desc" pagination="10" export="csv"&gt;
+  search sort="rt_score:desc" pagination="10" export="csv"&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>
         </section>

--- a/guide/guide-exemples-insee-erfs.html
+++ b/guide/guide-exemples-insee-erfs.html
@@ -442,7 +442,7 @@
 
 &lt;dsfr-data-list source="q-table"
   columns="TIME_PERIOD:Annee, ERFS_MEASURE:Indicateur, value:Valeur"
-  recherche filters="ERFS_MEASURE" tri="TIME_PERIOD:desc"
+  search filters="ERFS_MEASURE" sort="TIME_PERIOD:desc"
   pagination="15" export="csv"&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>

--- a/guide/guide-exemples-normalize.html
+++ b/guide/guide-exemples-normalize.html
@@ -101,8 +101,7 @@
 &lt;/dsfr-data-query&gt;
 
 &lt;dsfr-data-chart source="stats" type="bar"
-  label-field="nom_region" value-field="Beneficiaires"
-  titre="Beneficiaires par region (normalize + query)"&gt;
+  label-field="nom_region" value-field="Beneficiaires"&gt;
 &lt;/dsfr-data-chart&gt;</pre>
           </div>
         </section>
@@ -126,8 +125,8 @@
 
 &lt;dsfr-data-list source="clean"
   columns="Produit, Marque, Categorie, Sous-categorie, Date"
-  recherche="true" filters="Categorie"
-  tri="Produit:asc" pagination="10" export="csv"&gt;
+  search filters="Categorie"
+  sort="Produit:asc" pagination="10" export="csv"&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>
         </section>

--- a/guide/guide-exemples-query.html
+++ b/guide/guide-exemples-query.html
@@ -418,7 +418,7 @@
 
 &lt;dsfr-data-list source="q"
   columns="modeles_ou_references:Produit, marque_produit:Marque, sous_categorie_produit:Sous-categorie"
-  recherche="true" tri="modeles_ou_references:asc" pagination="10" export="csv"&gt;
+  search sort="modeles_ou_references:asc" pagination="10" export="csv"&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>
         </section>
@@ -442,7 +442,7 @@
 
 &lt;dsfr-data-list source="q"
   columns="modeles_ou_references:Produit, categorie_produit:Categorie, marque_produit:Marque, date_publication:Date"
-  recherche="true" tri="categorie_produit:asc" pagination="10" export="csv"&gt;
+  search sort="categorie_produit:asc" pagination="10" export="csv"&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>
         </section>

--- a/guide/guide-exemples-world-map.html
+++ b/guide/guide-exemples-world-map.html
@@ -173,7 +173,7 @@ dsfr-data-source "src-pays"                         --> dsfr-data-kpi (count pay
           </dsfr-data-kpi>
 
           <dsfr-data-kpi source="src-pays"
-            value="count:pays"
+            value="pays:count"
             label="Pays partenaires"
             format="nombre"
             icon="ri-global-line"
@@ -231,7 +231,7 @@ dsfr-data-source "src-pays"                         --> dsfr-data-kpi (count pay
             name="Exportations francaises"
             unit-tooltip="M"
             selected-palette="sequentialAscending"
-            zoom="continent">
+            zoom-mode="continent">
           </dsfr-data-world-map>
         </div>
 
@@ -277,7 +277,7 @@ dsfr-data-source "src-pays"                         --> dsfr-data-kpi (count pay
   icon="ri-money-euro-circle-line" color="bleu"&gt;
 &lt;/dsfr-data-kpi&gt;
 
-&lt;dsfr-data-kpi source="src-pays" value="count:pays"
+&lt;dsfr-data-kpi source="src-pays" value="pays:count"
   label="Pays partenaires" format="nombre"
   icon="ri-global-line" color="vert"&gt;
 &lt;/dsfr-data-kpi&gt;
@@ -310,7 +310,7 @@ dsfr-data-source "src-pays"                         --> dsfr-data-kpi (count pay
   name="Exportations francaises"
   unit-tooltip="M"
   selected-palette="sequentialAscending"
-  zoom="continent"&gt;
+  zoom-mode="continent"&gt;
 &lt;/dsfr-data-world-map&gt;</pre>
           </div>
         </section>
@@ -318,10 +318,10 @@ dsfr-data-source "src-pays"                         --> dsfr-data-kpi (count pay
         <!-- Points cles -->
         <h4 class="fr-mt-3w">Points cles de cet exemple</h4>
         <ul>
-          <li><strong>dsfr-data-world-map</strong> : carte choropleth mondiale. Attributs principaux : <code>code-field</code> (champ contenant le code pays), <code>value-field</code> (champ numerique), <code>code-format</code> (<code>iso-a2</code>, <code>iso-a3</code> ou <code>iso-num</code>), <code>zoom="continent"</code> (boutons de zoom par continent).</li>
+          <li><strong>dsfr-data-world-map</strong> : carte choropleth mondiale. Attributs principaux : <code>code-field</code> (champ contenant le code pays), <code>value-field</code> (champ numerique), <code>code-format</code> (<code>iso-a2</code>, <code>iso-a3</code> ou <code>iso-num</code>), <code>zoom-mode="continent"</code> (boutons de zoom par continent).</li>
           <li><strong>Agregation server-side</strong> : <code>dsfr-data-source</code> utilise <code>select</code> avec <code>sum()</code> et <code>count()</code>, <code>group-by</code> et <code>order-by</code> pour agreger directement cote serveur OpenDataSoft.</li>
           <li><strong>Pipeline de transformation</strong> : <code>dsfr-data-query</code> applique <code>limit</code> et <code>order-by</code> sur les donnees agregees pour alimenter les graphiques top 15 et top 8, tandis que la carte recoit toutes les donnees.</li>
-          <li><strong>KPI derives</strong> : <code>value="count:pays"</code> compte le nombre de valeurs distinctes du champ <code>pays</code> sans source supplementaire.</li>
+          <li><strong>KPI derives</strong> : <code>value="pays:count"</code> compte le nombre de valeurs du champ <code>pays</code> sans source supplementaire.</li>
           <li><strong>Accessibilite</strong> : <code>dsfr-data-a11y</code> sur chaque graphique pour le telechargement CSV.</li>
           <li><strong>0 ligne de JavaScript</strong> : tout le dashboard est 100% declaratif en HTML.</li>
         </ul>

--- a/specs/apis/generic.html
+++ b/specs/apis/generic.html
@@ -179,7 +179,7 @@
 &lt;dsfr-data-chart
   source="src"
   type="bar"
-  name-field="catégorie"
+  label-field="catégorie"
   value-field="valeur"&gt;
 &lt;/dsfr-data-chart&gt;</code></pre>
 
@@ -188,20 +188,21 @@
 &lt;dsfr-data-source
   id="src"
   url="https://mon-api.example.com/endpoint"
-  data-path="results.items"&gt;
+  transform="results.items"&gt;
 &lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-query
+  id="stats"
   source="src"
   group-by="type"
   aggregate="montant:sum"&gt;
 &lt;/dsfr-data-query&gt;
 
 &lt;dsfr-data-chart
-  source="src"
+  source="stats"
   type="pie"
-  name-field="type"
-  value-field="montant"&gt;
+  label-field="type"
+  value-field="montant__sum"&gt;
 &lt;/dsfr-data-chart&gt;</code></pre>
 
           <h3 class="fr-mt-2w">Avec normalize pour des données imbriquees</h3>
@@ -219,7 +220,7 @@
 &lt;dsfr-data-list
   source="flat"
   columns="nom,valeur,date"
-  page-size="20"&gt;
+  pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</code></pre>
         </section>
     </div>

--- a/specs/apis/grist.html
+++ b/specs/apis/grist.html
@@ -380,7 +380,7 @@
 &lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-list source="src"
-  colonnes="nom,prenom,commune"
+  columns="nom,prenom,commune"
   pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</code></pre>
 
@@ -402,7 +402,7 @@
 &lt;/dsfr-data-search&gt;
 
 &lt;dsfr-data-list source="src"
-  colonnes="nom,catégorie,region"
+  columns="nom,catégorie,region"
   pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</code></pre>
         </section>

--- a/specs/apis/insee.html
+++ b/specs/apis/insee.html
@@ -268,7 +268,7 @@
 
 &lt;dsfr-data-kpi
   source="src"
-  valeur="OBS_VALUE"
+  value="OBS_VALUE"
   label="Population municipale 2023"
   format="nombre"&gt;
 &lt;/dsfr-data-kpi&gt;</code></pre>
@@ -284,15 +284,16 @@
 &lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-query
+  id="deps"
   source="src"
   filter="GEO:contains:DEP"
   order-by="OBS_VALUE:desc"&gt;
 &lt;/dsfr-data-query&gt;
 
 &lt;dsfr-data-chart
-  source="src"
+  source="deps"
   type="bar"
-  name-field="GEO"
+  label-field="GEO"
   value-field="OBS_VALUE"&gt;
 &lt;/dsfr-data-chart&gt;</code></pre>
 
@@ -320,7 +321,7 @@
 &lt;dsfr-data-chart
   source="decoded"
   type="bar"
-  name-field="AGE"
+  label-field="AGE"
   value-field="OBS_VALUE"&gt;
 &lt;/dsfr-data-chart&gt;</code></pre>
 
@@ -338,7 +339,7 @@
 &lt;dsfr-data-list
   source="src"
   columns="GEO,OBS_VALUE"
-  page-size="50"&gt;
+  pagination="50"&gt;
 &lt;/dsfr-data-list&gt;</code></pre>
         </section>
     </div>

--- a/specs/apis/opendatasoft.html
+++ b/specs/apis/opendatasoft.html
@@ -216,15 +216,16 @@
 &lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-query
+  id="stats"
   source="src"
   group-by="region"
-  select="region, sum(valeur) as valeur__sum"&gt;
+  aggregate="valeur:sum"&gt;
 &lt;/dsfr-data-query&gt;
 
 &lt;dsfr-data-chart
-  source="src"
+  source="stats"
   type="bar"
-  name-field="region"
+  label-field="region"
   value-field="valeur__sum"&gt;
 &lt;/dsfr-data-chart&gt;</code></pre>
 

--- a/specs/apis/tabular.html
+++ b/specs/apis/tabular.html
@@ -107,7 +107,8 @@
           </div>
           <div class="fr-highlight fr-mt-2w">
             <p>
-              La pagination serveur est geree par <code>dsfr-data-source</code> avec l'attribut <code>auto-pagination</code>.
+              La pagination est geree automatiquement par l'adapter (suivi de <code>links.next</code>) ;
+              le mode page-a-page se pilote avec l'attribut <code>server-side</code> de <code>dsfr-data-source</code>.
               Les metadonnees serveur sont accessibles via <code>meta.page</code>, <code>meta.page_size</code>
               et <code>meta.total</code>.
             </p>
@@ -203,7 +204,7 @@
           </div>
           <p class="fr-mt-1w">
             Les facettes sont calculees sur les données deja recuperees cote client.
-            Si le jeu de données est volumineux, pensez a utiliser <code>auto-pagination</code>
+            Si le jeu de données est volumineux, pensez a relever <code>max-records</code>
             pour charger plus de données avant le calcul des facettes.
           </p>
         </section>
@@ -254,24 +255,25 @@
           <h2>Exemple d'utilisation</h2>
 
           <h3>Graphique avec agrégation</h3>
-          <pre><code>&lt;dsfr-data-source
+          <pre><code>&lt;!-- La pagination de l'API Tabular est geree automatiquement par l'adapter --&gt;
+&lt;dsfr-data-source
   id="src"
   api-type="tabular"
-  resource="2876a346-d50c-4911-934e-19ee07b0e503"
-  auto-pagination&gt;
+  resource="2876a346-d50c-4911-934e-19ee07b0e503"&gt;
 &lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-query
+  id="stats"
   source="src"
   group-by="region"
   aggregate="population:sum"&gt;
 &lt;/dsfr-data-query&gt;
 
 &lt;dsfr-data-chart
-  source="src"
+  source="stats"
   type="bar"
-  name-field="region"
-  value-field="population"&gt;
+  label-field="region"
+  value-field="population__sum"&gt;
 &lt;/dsfr-data-chart&gt;</code></pre>
 
           <h3 class="fr-mt-2w">Datalist avec pagination serveur</h3>
@@ -285,7 +287,7 @@
 &lt;dsfr-data-list
   source="src"
   columns="nom,prenom,commune"
-  page-size="20"&gt;
+  pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</code></pre>
         </section>
     </div>

--- a/specs/components/dsfr-data-a11y.html
+++ b/specs/components/dsfr-data-a11y.html
@@ -86,7 +86,7 @@
             group-by="statut" aggregate="statut:count:total">
           </dsfr-data-query>
           <dsfr-data-chart id="demo-chart" source="data-chart" type="bar"
-            label-field="statut" value-field="total" titre="Sites par statut">
+            label-field="statut" value-field="total">
           </dsfr-data-chart>
           <dsfr-data-a11y for="demo-chart" source="data-chart" table download></dsfr-data-a11y>
           <div class="code-block"><pre>&lt;dsfr-data-chart id="mon-graph" source="data" type="bar"

--- a/specs/components/dsfr-data-chart.html
+++ b/specs/components/dsfr-data-chart.html
@@ -53,6 +53,11 @@
           <tr><td><code>gauge-value</code></td><td>Number</td><td>Valeur de la jauge 0-100 (type gauge)</td></tr>
           <tr><td><code>value-field-2</code></td><td>String</td><td>2e série de valeurs (bar-line)</td></tr>
           <tr><td><code>value-fields</code></td><td>String</td><td>Series supplementaires separees par virgules</td></tr>
+          <tr><td><code>series-field</code></td><td>String</td><td>Champ "clé de série" pour données au format long/tidy : chaque valeur distincte devient une série (bar, line, radar). Prioritaire sur <code>value-fields</code></td></tr>
+          <tr><td><code>name</code></td><td>String</td><td>Noms des séries (ex: <code>'["Série 1", "Série 2"]'</code>)</td></tr>
+          <tr><td><code>unit-tooltip-bar</code></td><td>String</td><td>Unite des barres dans les tooltips (bar-line uniquement)</td></tr>
+          <tr><td><code>x-min</code> / <code>x-max</code></td><td>String</td><td>Bornes de l'axe X</td></tr>
+          <tr><td><code>y-min</code> / <code>y-max</code></td><td>String</td><td>Bornes de l'axe Y</td></tr>
           <tr><td><code>highlight-index</code></td><td>String</td><td>Indices a mettre en avant : <code>"[0, 2]"</code></td></tr>
           <tr><td><code>reference-lines</code></td><td>String (JSON)</td><td>Lignes de référence (overlay) — graphiques cartésiens uniquement (line, bar, bar-line, scatter).
             Chaque item : <code>{ axis: "x"|"y", value, label?, color?, dash?, position? }</code>.
@@ -76,6 +81,12 @@
           <tr><td><code>databox-screenshot</code></td><td>Boolean</td><td>Bouton screenshot PNG</td></tr>
           <tr><td><code>databox-fullscreen</code></td><td>Boolean</td><td>Bouton plein écran</td></tr>
           <tr><td><code>databox-trend</code></td><td>String</td><td>Tendance (ex: "+5.2" ou "-3.1")</td></tr>
+          <tr><td><code>databox-tooltip-title</code></td><td>String</td><td>Titre du tooltip info</td></tr>
+          <tr><td><code>databox-tooltip-content</code></td><td>String</td><td>Contenu du tooltip info</td></tr>
+          <tr><td><code>databox-modal-title</code></td><td>String</td><td>Titre de la modale</td></tr>
+          <tr><td><code>databox-modal-content</code></td><td>String</td><td>Contenu de la modale</td></tr>
+          <tr><td><code>databox-default-source</code></td><td>String</td><td>Source par défaut dans le selecteur multi-source</td></tr>
+          <tr><td><code>databox-actions</code></td><td>String (JSON)</td><td>Actions personnalisees (ex: <code>'["Source officielle","Pole emploi"]'</code>)</td></tr>
         </tbody>
       </table>
       <div class="fr-callout fr-callout--brown-caramel fr-mt-2w fr-mb-4w">

--- a/specs/components/dsfr-data-facets.html
+++ b/specs/components/dsfr-data-facets.html
@@ -114,6 +114,9 @@
             <tr><td><code>cols</code></td><td>String</td><td><code>""</code></td><td>Colonnage DSFR des facettes. Global : <code>"6"</code> (2 par ligne), <code>"4"</code> (3 par ligne). Par facette : <code>"region:4 | type:6"</code> (défaut fr-col-6 pour les non-specifies).</td></tr>
             <tr><td><code>server-facets</code></td><td>Boolean</td><td><code>false</code></td><td>Deleguer le calcul des facettes au serveur via l'adapter (ODS, Grist). L'attribut <code>fields</code> est requis (pas d'auto-detection).</td></tr>
             <tr><td><code>static-values</code></td><td>String</td><td><code>""</code></td><td>Valeurs de facettes pre-calculees (JSON). Affiche les valeurs sans les calculer depuis les données, les selections envoient des commandes WHERE a la source. Ex : <code>'{"sexe":["F","M"]}'</code>. Les compteurs sont masques automatiquement.</td></tr>
+            <tr><td><code>url-params</code></td><td>Boolean</td><td><code>false</code></td><td>Lire les parametres d'URL comme pre-selections de facettes.</td></tr>
+            <tr><td><code>url-param-map</code></td><td>String</td><td><code>""</code></td><td>Mapping parametre URL vers champ facette : <code>"param:field | param2:field2"</code>. Vide = correspondance directe.</td></tr>
+            <tr><td><code>url-sync</code></td><td>Boolean</td><td><code>false</code></td><td>Synchroniser l'URL quand l'utilisateur change les facettes (replaceState).</td></tr>
           </tbody>
         </table>
 
@@ -162,8 +165,8 @@
         </dsfr-data-facets>
 
         <dsfr-data-list source="ct-filtered1"
-          colonnes="cct_commune, nom_departement, cat_vehicule_libelle, cat_energie_libelle, prix_visite"
-          server-tri
+          columns="cct_commune, nom_departement, cat_vehicule_libelle, cat_energie_libelle, prix_visite"
+          server-sort
           pagination="10">
         </dsfr-data-list>
 
@@ -185,8 +188,8 @@
 &lt;/dsfr-data-facets&gt;
 
 &lt;dsfr-data-list source="filtered"
-  colonnes="cct_commune, nom_departement, cat_vehicule_libelle, cat_energie_libelle, prix_visite"
-  server-tri
+  columns="cct_commune, nom_departement, cat_vehicule_libelle, cat_energie_libelle, prix_visite"
+  server-sort
   pagination="10"&gt;
 &lt;/dsfr-data-list&gt;</code></pre>
 
@@ -263,13 +266,13 @@
 
         <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin: 1.5rem 0;">
           <dsfr-data-kpi source="ct-filtered3"
-            valeur="count"
+            value="count"
             label="Centres"
             format="nombre">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi source="ct-filtered3"
-            valeur="avg:prix_visite"
+            value="prix_visite:avg"
             label="Prix moyen"
             format="euros">
           </dsfr-data-kpi>
@@ -302,8 +305,8 @@
 &lt;/dsfr-data-facets&gt;
 
 &lt;!-- KPI sur les données filtrees --&gt;
-&lt;dsfr-data-kpi source="filtered" valeur="count" label="Centres" format="nombre"&gt;&lt;/dsfr-data-kpi&gt;
-&lt;dsfr-data-kpi source="filtered" valeur="avg:prix_visite" label="Prix moyen" format="euros"&gt;&lt;/dsfr-data-kpi&gt;
+&lt;dsfr-data-kpi source="filtered" value="count" label="Centres" format="nombre"&gt;&lt;/dsfr-data-kpi&gt;
+&lt;dsfr-data-kpi source="filtered" value="prix_visite:avg" label="Prix moyen" format="euros"&gt;&lt;/dsfr-data-kpi&gt;
 
 &lt;!-- Carte sur les données filtrees et agregees --&gt;
 &lt;dsfr-data-query id="stats" source="filtered"
@@ -336,8 +339,8 @@
         </dsfr-data-facets>
 
         <dsfr-data-list source="ct-display-demo"
-          colonnes="cct_commune, nom_departement, cat_vehicule_libelle, prix_visite"
-          recherche="true"
+          columns="cct_commune, nom_departement, cat_vehicule_libelle, prix_visite"
+          search
           pagination="5">
         </dsfr-data-list>
 
@@ -351,7 +354,7 @@
 &lt;/dsfr-data-facets&gt;
 
 &lt;dsfr-data-list source="filtered"
-  colonnes="cct_commune, nom_departement, cat_vehicule_libelle, prix_visite"
+  columns="cct_commune, nom_departement, cat_vehicule_libelle, prix_visite"
   pagination="5"&gt;
 &lt;/dsfr-data-list&gt;</code></pre>
 
@@ -372,8 +375,8 @@
         </dsfr-data-facets>
 
         <dsfr-data-list source="ct-hide-counts-demo"
-          colonnes="cct_commune, nom_departement, cat_vehicule_libelle, prix_visite"
-          recherche="true"
+          columns="cct_commune, nom_departement, cat_vehicule_libelle, prix_visite"
+          search
           pagination="5">
         </dsfr-data-list>
 
@@ -405,8 +408,8 @@
         </dsfr-data-facets>
 
         <dsfr-data-list source="ct-cols-demo"
-          colonnes="cct_commune, nom_departement, cat_vehicule_libelle, prix_visite"
-          recherche="true"
+          columns="cct_commune, nom_departement, cat_vehicule_libelle, prix_visite"
+          search
           pagination="5">
         </dsfr-data-list>
 

--- a/specs/components/dsfr-data-kpi.html
+++ b/specs/components/dsfr-data-kpi.html
@@ -38,19 +38,21 @@
           <thead><tr><th>Attribut</th><th>Type</th><th>Description</th></tr></thead>
           <tbody>
             <tr><td><code>source</code></td><td>String</td><td>ID du <code>&lt;dsfr-data-source&gt;</code> (requis)</td></tr>
-            <tr><td><code>valeur</code></td><td>String</td><td>Expression de calcul : <code>"champ"</code>, <code>"avg:champ"</code>, <code>"count:champ:valeur"</code></td></tr>
+            <tr><td><code>value</code></td><td>String</td><td>Expression de calcul : <code>"champ"</code>, <code>"champ:avg"</code>, <code>"count:champ:valeur"</code></td></tr>
             <tr><td><code>heading</code></td><td>String</td><td>Titre affiche AU-DESSUS de la valeur (surtitre, majuscules grises)</td></tr>
             <tr><td><code>label</code></td><td>String</td><td>Libelle affiche sous la valeur (et sous les <code>lines</code>)</td></tr>
+            <tr><td><code>description</code></td><td>String</td><td>Description détaillée pour l'accessibilité</td></tr>
             <tr><td><code>trend</code></td><td>String</td><td>Raccourci herite : expression <code>champ:fn</code> (ex. <code>evolution:avg</code>) rendue avec une fleche en %. Preferez <code>lines</code></td></tr>
             <tr><td><code>lines</code></td><td>String (JSON)</td><td>Lignes secondaires entre la valeur et le label. Items : <code>value</code> (expression) ou <code>text</code> (statique), + <code>sign</code>, <code>suffix</code>, <code>color</code> (<code>auto</code> / token DSFR / couleur CSS), <code>na</code></td></tr>
             <tr><td><code>format</code></td><td>String</td><td>Format d'affichage (défaut : <code>nombre</code>)</td></tr>
-            <tr><td><code>icone</code></td><td>String</td><td>Classe d'icone Remix Icon (ex: <code>ri-global-line</code>)</td></tr>
-            <tr><td><code>couleur</code></td><td>String</td><td>Couleur forcee : <code>vert</code>, <code>orange</code>, <code>rouge</code>, <code>bleu</code></td></tr>
-            <tr><td><code>seuil-vert</code></td><td>Number</td><td>Seuil au-dessus duquel la couleur est verte</td></tr>
-            <tr><td><code>seuil-orange</code></td><td>Number</td><td>Seuil au-dessus duquel la couleur est orange</td></tr>
+            <tr><td><code>icon</code></td><td>String</td><td>Classe d'icone Remix Icon (ex: <code>ri-global-line</code>)</td></tr>
+            <tr><td><code>color</code></td><td>String</td><td>Couleur forcee : <code>vert</code>, <code>orange</code>, <code>rouge</code>, <code>bleu</code></td></tr>
+            <tr><td><code>threshold-green</code></td><td>Number</td><td>Seuil au-dessus duquel la couleur est verte</td></tr>
+            <tr><td><code>threshold-orange</code></td><td>Number</td><td>Seuil au-dessus duquel la couleur est orange</td></tr>
             <tr><td><code>col</code></td><td>Number</td><td>Largeur en colonnes (1-12), actif uniquement dans un <code>&lt;dsfr-data-kpi-group&gt;</code></td></tr>
           </tbody>
         </table>
+        <p class="fr-text--sm fr-text--light">Les anciens noms francais (<code>valeur</code>, <code>icone</code>, <code>couleur</code>, <code>seuil-vert</code>, <code>seuil-orange</code>, <code>tendance</code>) restent lus en alias deprecies (#300).</p>
 
         <h2 class="fr-mt-4w">dsfr-data-kpi-group - Attributs</h2>
         <table class="attr-table">
@@ -65,11 +67,13 @@
         <h2 class="fr-mt-4w">Expressions de calcul</h2>
         <ul>
           <li><code>champ</code> : Valeur directe d'un champ (pour objet unique)</li>
-          <li><code>avg:champ</code> : Moyenne des valeurs du champ</li>
-          <li><code>sum:champ</code> : Somme des valeurs</li>
-          <li><code>min:champ</code> / <code>max:champ</code> : Min/max</li>
-          <li><code>count:champ:valeur</code> : Compte les occurrences ou valeur = valeur</li>
+          <li><code>champ:avg</code> : Moyenne des valeurs du champ</li>
+          <li><code>champ:sum</code> : Somme des valeurs</li>
+          <li><code>champ:min</code> / <code>champ:max</code> : Min/max</li>
+          <li><code>count</code> : Compte tous les enregistrements</li>
+          <li><code>count:champ:valeur</code> : Compte les occurrences ou champ = valeur</li>
         </ul>
+        <p class="fr-text--sm fr-text--light">Grammaire commune du pipeline <code>champ:fn</code> (#303) — l'ancienne forme inversee <code>fn:champ</code> reste lue mais est depreciee.</p>
 
         <h2 class="fr-mt-4w">Formats d'affichage</h2>
         <table class="attr-table">
@@ -88,13 +92,13 @@
         <section class="demo-section">
           <h3>1. KPI simple avec valeur directe</h3>
           <div class="kpi-grid">
-            <dsfr-data-kpi source="meta" valeur="total" label="Sites suivis" icone="ri-global-line" format="nombre"></dsfr-data-kpi>
+            <dsfr-data-kpi source="meta" value="total" label="Sites suivis" icon="ri-global-line" format="nombre"></dsfr-data-kpi>
           </div>
           <div class="code-block"><pre>&lt;dsfr-data-kpi
   source="meta"
-  valeur="total"
+  value="total"
   label="Sites suivis"
-  icone="ri-global-line"
+  icon="ri-global-line"
   format="nombre"&gt;
 &lt;/dsfr-data-kpi&gt;</pre></div>
         </section>
@@ -102,43 +106,43 @@
         <section class="demo-section">
           <h3>2. KPI avec moyenne et seuils</h3>
           <div class="kpi-grid">
-            <dsfr-data-kpi source="sites" valeur="avg:score_rgaa" label="Score RGAA moyen" format="pourcentage" seuil-vert="80" seuil-orange="50"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="avg:score_dsfr" label="Score DSFR moyen" format="pourcentage" seuil-vert="80" seuil-orange="50"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:avg" label="Score RGAA moyen" format="pourcentage" threshold-green="80" threshold-orange="50"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_dsfr:avg" label="Score DSFR moyen" format="pourcentage" threshold-green="80" threshold-orange="50"></dsfr-data-kpi>
           </div>
           <div class="code-block"><pre>&lt;dsfr-data-kpi
   source="sites"
-  valeur="avg:score_rgaa"
+  value="score_rgaa:avg"
   label="Score RGAA moyen"
   format="pourcentage"
-  seuil-vert="80"
-  seuil-orange="50"&gt;
+  threshold-green="80"
+  threshold-orange="50"&gt;
 &lt;/dsfr-data-kpi&gt;</pre></div>
         </section>
 
         <section class="demo-section">
           <h3>3. KPI avec comptage conditionnel</h3>
           <div class="kpi-grid">
-            <dsfr-data-kpi source="sites" valeur="count:statut:actif" label="Sites actifs" icone="ri-checkbox-circle-line" couleur="vert"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="count:statut:inactif" label="Sites inactifs" icone="ri-close-circle-line" couleur="orange"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="count:certificat_valide:false" label="Certificats expires" icone="ri-shield-cross-line" couleur="rouge"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="count:statut:actif" label="Sites actifs" icon="ri-checkbox-circle-line" color="vert"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="count:statut:inactif" label="Sites inactifs" icon="ri-close-circle-line" color="orange"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="count:certificat_valide:false" label="Certificats expires" icon="ri-shield-cross-line" color="rouge"></dsfr-data-kpi>
           </div>
           <div class="code-block"><pre>&lt;dsfr-data-kpi
   source="sites"
-  valeur="count:statut:actif"
+  value="count:statut:actif"
   label="Sites actifs"
-  icone="ri-checkbox-circle-line"
-  couleur="vert"&gt;
+  icon="ri-checkbox-circle-line"
+  color="vert"&gt;
 &lt;/dsfr-data-kpi&gt;</pre></div>
         </section>
 
         <section class="demo-section">
           <h3>4. KPI avec min/max</h3>
           <div class="kpi-grid">
-            <dsfr-data-kpi source="sites" valeur="max:score_rgaa" label="Meilleur score RGAA" format="pourcentage" couleur="vert"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="min:score_rgaa" label="Plus bas score RGAA" format="pourcentage" couleur="rouge"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur score RGAA" format="pourcentage" color="vert"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas score RGAA" format="pourcentage" color="rouge"></dsfr-data-kpi>
           </div>
-          <div class="code-block"><pre>&lt;dsfr-data-kpi source="sites" valeur="max:score_rgaa" label="Meilleur score" format="pourcentage" couleur="vert"&gt;&lt;/dsfr-data-kpi&gt;
-&lt;dsfr-data-kpi source="sites" valeur="min:score_rgaa" label="Plus bas score" format="pourcentage" couleur="rouge"&gt;&lt;/dsfr-data-kpi&gt;</pre></div>
+          <div class="code-block"><pre>&lt;dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur score" format="pourcentage" color="vert"&gt;&lt;/dsfr-data-kpi&gt;
+&lt;dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas score" format="pourcentage" color="rouge"&gt;&lt;/dsfr-data-kpi&gt;</pre></div>
         </section>
 
         <section class="demo-section">
@@ -168,10 +172,10 @@
         <section class="demo-section">
           <h3>6. Tableau de bord complet (CSS manuel)</h3>
           <div class="kpi-grid">
-            <dsfr-data-kpi source="meta" valeur="total" label="Sites suivis" icone="ri-global-line" format="nombre"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="avg:score_rgaa" label="RGAA moyen" format="pourcentage" seuil-vert="80" seuil-orange="50"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="avg:score_dsfr" label="DSFR moyen" format="pourcentage" seuil-vert="80" seuil-orange="50"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="count:certificat_valide:false" label="Certificats expires" icone="ri-shield-cross-line" couleur="rouge"></dsfr-data-kpi>
+            <dsfr-data-kpi source="meta" value="total" label="Sites suivis" icon="ri-global-line" format="nombre"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:avg" label="RGAA moyen" format="pourcentage" threshold-green="80" threshold-orange="50"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_dsfr:avg" label="DSFR moyen" format="pourcentage" threshold-green="80" threshold-orange="50"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="count:certificat_valide:false" label="Certificats expires" icon="ri-shield-cross-line" color="rouge"></dsfr-data-kpi>
           </div>
         </section>
 
@@ -180,42 +184,42 @@
         <section class="demo-section">
           <h3>7. Colonnes egales (cols="4")</h3>
           <dsfr-data-kpi-group cols="4">
-            <dsfr-data-kpi source="meta" valeur="total" label="Sites suivis" icone="ri-global-line" format="nombre"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="avg:score_rgaa" label="RGAA moyen" format="pourcentage" seuil-vert="80" seuil-orange="50"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="avg:score_dsfr" label="DSFR moyen" format="pourcentage" seuil-vert="80" seuil-orange="50"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="count:certificat_valide:false" label="Certificats expires" icone="ri-shield-cross-line" couleur="rouge"></dsfr-data-kpi>
+            <dsfr-data-kpi source="meta" value="total" label="Sites suivis" icon="ri-global-line" format="nombre"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:avg" label="RGAA moyen" format="pourcentage" threshold-green="80" threshold-orange="50"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_dsfr:avg" label="DSFR moyen" format="pourcentage" threshold-green="80" threshold-orange="50"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="count:certificat_valide:false" label="Certificats expires" icon="ri-shield-cross-line" color="rouge"></dsfr-data-kpi>
           </dsfr-data-kpi-group>
           <div class="code-block"><pre>&lt;dsfr-data-kpi-group cols="4"&gt;
-  &lt;dsfr-data-kpi source="meta" valeur="total" label="Sites suivis"&gt;&lt;/dsfr-data-kpi&gt;
-  &lt;dsfr-data-kpi source="sites" valeur="avg:score_rgaa" label="RGAA moyen"&gt;&lt;/dsfr-data-kpi&gt;
-  &lt;dsfr-data-kpi source="sites" valeur="avg:score_dsfr" label="DSFR moyen"&gt;&lt;/dsfr-data-kpi&gt;
-  &lt;dsfr-data-kpi source="sites" valeur="count:certificat_valide:false" label="Expires"&gt;&lt;/dsfr-data-kpi&gt;
+  &lt;dsfr-data-kpi source="meta" value="total" label="Sites suivis"&gt;&lt;/dsfr-data-kpi&gt;
+  &lt;dsfr-data-kpi source="sites" value="score_rgaa:avg" label="RGAA moyen"&gt;&lt;/dsfr-data-kpi&gt;
+  &lt;dsfr-data-kpi source="sites" value="score_dsfr:avg" label="DSFR moyen"&gt;&lt;/dsfr-data-kpi&gt;
+  &lt;dsfr-data-kpi source="sites" value="count:certificat_valide:false" label="Expires"&gt;&lt;/dsfr-data-kpi&gt;
 &lt;/dsfr-data-kpi-group&gt;</pre></div>
         </section>
 
         <section class="demo-section">
           <h3>8. Largeurs personnalisees (col)</h3>
           <dsfr-data-kpi-group>
-            <dsfr-data-kpi source="meta" valeur="total" label="Sites suivis" icone="ri-global-line" format="nombre" col="6"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="avg:score_rgaa" label="RGAA moyen" format="pourcentage" seuil-vert="80" seuil-orange="50" col="3"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="max:score_rgaa" label="Meilleur RGAA" format="pourcentage" couleur="vert" col="3"></dsfr-data-kpi>
+            <dsfr-data-kpi source="meta" value="total" label="Sites suivis" icon="ri-global-line" format="nombre" col="6"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:avg" label="RGAA moyen" format="pourcentage" threshold-green="80" threshold-orange="50" col="3"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur RGAA" format="pourcentage" color="vert" col="3"></dsfr-data-kpi>
           </dsfr-data-kpi-group>
           <div class="code-block"><pre>&lt;dsfr-data-kpi-group&gt;
-  &lt;dsfr-data-kpi source="meta" valeur="total" label="Sites suivis" col="6"&gt;&lt;/dsfr-data-kpi&gt;
-  &lt;dsfr-data-kpi source="sites" valeur="avg:score_rgaa" label="RGAA moyen" col="3"&gt;&lt;/dsfr-data-kpi&gt;
-  &lt;dsfr-data-kpi source="sites" valeur="max:score_rgaa" label="Meilleur RGAA" col="3"&gt;&lt;/dsfr-data-kpi&gt;
+  &lt;dsfr-data-kpi source="meta" value="total" label="Sites suivis" col="6"&gt;&lt;/dsfr-data-kpi&gt;
+  &lt;dsfr-data-kpi source="sites" value="score_rgaa:avg" label="RGAA moyen" col="3"&gt;&lt;/dsfr-data-kpi&gt;
+  &lt;dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur RGAA" col="3"&gt;&lt;/dsfr-data-kpi&gt;
 &lt;/dsfr-data-kpi-group&gt;</pre></div>
         </section>
 
         <section class="demo-section">
           <h3>9. Espacement large (gap="lg")</h3>
           <dsfr-data-kpi-group cols="2" gap="lg">
-            <dsfr-data-kpi source="sites" valeur="min:score_rgaa" label="Plus bas RGAA" format="pourcentage" couleur="rouge"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" valeur="max:score_rgaa" label="Meilleur RGAA" format="pourcentage" couleur="vert"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas RGAA" format="pourcentage" color="rouge"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur RGAA" format="pourcentage" color="vert"></dsfr-data-kpi>
           </dsfr-data-kpi-group>
           <div class="code-block"><pre>&lt;dsfr-data-kpi-group cols="2" gap="lg"&gt;
-  &lt;dsfr-data-kpi source="sites" valeur="min:score_rgaa" label="Plus bas RGAA" couleur="rouge"&gt;&lt;/dsfr-data-kpi&gt;
-  &lt;dsfr-data-kpi source="sites" valeur="max:score_rgaa" label="Meilleur RGAA" couleur="vert"&gt;&lt;/dsfr-data-kpi&gt;
+  &lt;dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas RGAA" color="rouge"&gt;&lt;/dsfr-data-kpi&gt;
+  &lt;dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur RGAA" color="vert"&gt;&lt;/dsfr-data-kpi&gt;
 &lt;/dsfr-data-kpi-group&gt;</pre></div>
         </section>
     </div>

--- a/specs/components/dsfr-data-list.html
+++ b/specs/components/dsfr-data-list.html
@@ -40,15 +40,18 @@
           </thead>
           <tbody>
             <tr><td><code>source</code></td><td>String</td><td>ID du <code>&lt;dsfr-data-source&gt;</code> a ecouter (requis)</td></tr>
-            <tr><td><code>colonnes</code></td><td>String</td><td>Colonnes a afficher : <code>"key:Label, key2:Label2"</code></td></tr>
-            <tr><td><code>recherche</code></td><td>Boolean</td><td>Afficher le champ de recherche</td></tr>
-            <tr><td><code>filtres</code></td><td>String</td><td>Colonnes filtrables : <code>"col1,col2"</code></td></tr>
-            <tr><td><code>tri</code></td><td>String</td><td>Tri par défaut : <code>"col:asc"</code> ou <code>"col:desc"</code></td></tr>
+            <tr><td><code>columns</code></td><td>String</td><td>Colonnes a afficher : <code>"key:Label, key2:Label2"</code></td></tr>
+            <tr><td><code>search</code></td><td>Boolean</td><td>Afficher le champ de recherche</td></tr>
+            <tr><td><code>filters</code></td><td>String</td><td>Colonnes filtrables : <code>"col1,col2"</code></td></tr>
+            <tr><td><code>sort</code></td><td>String</td><td>Tri par défaut : <code>"col:asc"</code> ou <code>"col:desc"</code></td></tr>
             <tr><td><code>pagination</code></td><td>Number</td><td>Nombre d'elements par page (0 = pas de pagination)</td></tr>
             <tr><td><code>export</code></td><td>String</td><td>Formats d'export disponibles : <code>"csv"</code></td></tr>
-            <tr><td><code>server-tri</code></td><td>Boolean</td><td>Deleguer le tri des colonnes au serveur via <code>dsfr-data-source-command</code> (orderBy). Les en-tetes de colonnes envoient des commandes de tri a la source amont au lieu de trier localement.</td></tr>
+            <tr><td><code>url-sync</code></td><td>Boolean</td><td>Synchronise le numero de page dans l'URL (replaceState)</td></tr>
+            <tr><td><code>url-page-param</code></td><td>String</td><td>Nom du parametre URL pour la page (défaut : <code>page</code>)</td></tr>
+            <tr><td><code>server-sort</code></td><td>Boolean</td><td>Deleguer le tri des colonnes au serveur via <code>dsfr-data-source-command</code> (orderBy). Les en-tetes de colonnes envoient des commandes de tri a la source amont au lieu de trier localement.</td></tr>
           </tbody>
         </table>
+        <p class="fr-text--sm fr-text--light">Les anciens noms francais (<code>colonnes</code>, <code>recherche</code>, <code>filtres</code>, <code>tri</code>, <code>server-tri</code>) restent lus en alias deprecies (#300).</p>
 
         <!-- Variante 1: Tableau simple -->
         <h2 class="fr-mt-4w">Variantes</h2>
@@ -59,13 +62,13 @@
 
           <dsfr-data-list
             source="sites"
-            colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)">
+            columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)">
           </dsfr-data-list>
 
           <div class="code-block">
             <pre>&lt;dsfr-data-list
   source="sites"
-  colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"&gt;
+  columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>
         </section>
@@ -77,15 +80,15 @@
 
           <dsfr-data-list
             source="sites"
-            colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
-            recherche="true">
+            columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
+            search>
           </dsfr-data-list>
 
           <div class="code-block">
             <pre>&lt;dsfr-data-list
   source="sites"
-  colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
-  recherche="true"&gt;
+  columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
+  search&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>
         </section>
@@ -97,15 +100,15 @@
 
           <dsfr-data-list
             source="sites"
-            colonnes="nom:Nom du site, ministere:Ministere, statut:Statut, score_rgaa:RGAA (%)"
-            filtres="ministere,statut">
+            columns="nom:Nom du site, ministere:Ministere, statut:Statut, score_rgaa:RGAA (%)"
+            filters="ministere,statut">
           </dsfr-data-list>
 
           <div class="code-block">
             <pre>&lt;dsfr-data-list
   source="sites"
-  colonnes="nom:Nom du site, ministere:Ministere, statut:Statut, score_rgaa:RGAA (%)"
-  filtres="ministere,statut"&gt;
+  columns="nom:Nom du site, ministere:Ministere, statut:Statut, score_rgaa:RGAA (%)"
+  filters="ministere,statut"&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>
         </section>
@@ -117,15 +120,15 @@
 
           <dsfr-data-list
             source="sites"
-            colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
-            tri="score_rgaa:desc">
+            columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
+            sort="score_rgaa:desc">
           </dsfr-data-list>
 
           <div class="code-block">
             <pre>&lt;dsfr-data-list
   source="sites"
-  colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
-  tri="score_rgaa:desc"&gt;
+  columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
+  sort="score_rgaa:desc"&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>
         </section>
@@ -137,14 +140,14 @@
 
           <dsfr-data-list
             source="sites"
-            colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
+            columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
             pagination="5">
           </dsfr-data-list>
 
           <div class="code-block">
             <pre>&lt;dsfr-data-list
   source="sites"
-  colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
+  columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
   pagination="5"&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>
@@ -157,14 +160,14 @@
 
           <dsfr-data-list
             source="sites"
-            colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
+            columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
             export="csv">
           </dsfr-data-list>
 
           <div class="code-block">
             <pre>&lt;dsfr-data-list
   source="sites"
-  colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
+  columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%)"
   export="csv"&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>
@@ -177,10 +180,10 @@
 
           <dsfr-data-list
             source="sites"
-            colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%), score_dsfr:DSFR (%), statut:Statut, certificat_valide:Certificat"
-            recherche="true"
-            filtres="ministere,statut"
-            tri="score_rgaa:desc"
+            columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%), score_dsfr:DSFR (%), statut:Statut, certificat_valide:Certificat"
+            search
+            filters="ministere,statut"
+            sort="score_rgaa:desc"
             pagination="10"
             export="csv">
           </dsfr-data-list>
@@ -188,10 +191,10 @@
           <div class="code-block">
             <pre>&lt;dsfr-data-list
   source="sites"
-  colonnes="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%), score_dsfr:DSFR (%), statut:Statut, certificat_valide:Certificat"
-  recherche="true"
-  filtres="ministere,statut"
-  tri="score_rgaa:desc"
+  columns="nom:Nom du site, ministere:Ministere, score_rgaa:RGAA (%), score_dsfr:DSFR (%), statut:Statut, certificat_valide:Certificat"
+  search
+  filters="ministere,statut"
+  sort="score_rgaa:desc"
   pagination="10"
   export="csv"&gt;
 &lt;/dsfr-data-list&gt;</pre>
@@ -217,9 +220,9 @@
 &lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-list source="rappels"
-  colonnes="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque"
-  recherche="true"
-  tri="date_publication:desc"
+  columns="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque"
+  search
+  sort="date_publication:desc"
   pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</pre>
           </div>

--- a/specs/components/dsfr-data-query.html
+++ b/specs/components/dsfr-data-query.html
@@ -75,12 +75,9 @@
             <tr><td><code>aggregate</code></td><td>String</td><td><code>"champ:fn"</code> ou <code>"champ:fn:alias"</code></td><td>Agrégations. Fonctions : <code>count</code> <code>sum</code> <code>avg</code> <code>min</code> <code>max</code>. Modes <code>generic</code> / <code>tabular</code></td></tr>
             <tr><td><code>order-by</code></td><td>String</td><td><code>"champ:asc"</code> ou <code>"champ:desc"</code></td><td>Tri des resultats. Champs agrégés : <code>"champ__fn:desc"</code> ou <code>"alias:desc"</code></td></tr>
             <tr><td><code>limit</code></td><td>Number</td><td>Entier positif. <code>0</code> = illimite</td><td>Nombre maximum de resultats</td></tr>
-            <tr><td><code>transform</code></td><td>String</td><td><code>"results"</code>, <code>"data.items"</code></td><td>Chemin JSONPath pour extraire les données de la reponse API</td></tr>
-            <tr><td><code>server-side</code></td><td>Boolean</td><td>Presence = <code>true</code></td><td>Active le mode server-side pilotable (une page a la fois, ecoute les commandes des composants en aval)</td></tr>
-            <tr><td><code>page-size</code></td><td>Number</td><td>Entier positif. Défaut : <code>20</code></td><td>Taille de page en mode server-side</td></tr>
-            <tr><td><code>refresh</code></td><td>Number</td><td>Entier en secondes. <code>0</code> = off</td><td>Intervalle de rafraichissement automatique</td></tr>
           </tbody>
         </table>
+        <p class="fr-text--sm fr-text--light">Attributs retires (#277, #279) : <code>transform</code>, <code>page-size</code> et <code>refresh</code> se configurent sur <code>&lt;dsfr-data-source&gt;</code> ; <code>server-side</code> est sans objet (le relais de commandes vers la source est toujours actif).</p>
 
         <h3 class="fr-mt-3w">Syntaxe detaillee des attributs clés</h3>
 

--- a/specs/components/dsfr-data-search.html
+++ b/specs/components/dsfr-data-search.html
@@ -137,8 +137,8 @@
         </dsfr-data-search>
 
         <dsfr-data-list source="elus-searched"
-          colonnes="Produit, Categorie, Marque, Date"
-          tri="Date:desc"
+          columns="Produit, Categorie, Marque, Date"
+          sort="Date:desc"
           pagination="10">
         </dsfr-data-list>
 
@@ -152,8 +152,8 @@
 &lt;/dsfr-data-search&gt;
 
 &lt;dsfr-data-list source="searched"
-  colonnes="Produit, Catégorie, Marque, Date"
-  tri="Date:desc"
+  columns="Produit, Catégorie, Marque, Date"
+  sort="Date:desc"
   pagination="10"&gt;
 &lt;/dsfr-data-list&gt;</code></pre>
 
@@ -239,19 +239,19 @@
 
         <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem; margin: 1.5rem 0;">
           <dsfr-data-kpi source="industrie-searched"
-            valeur="count"
+            value="count"
             label="Projets"
-            couleur="bleu">
+            color="bleu">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi source="industrie-searched"
-            valeur="sum:montant_investissement"
+            value="montant_investissement:sum"
             label="Investissement total"
             format="euro">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi source="industrie-searched"
-            valeur="sum:nombre_beneficiaires"
+            value="nombre_beneficiaires:sum"
             label="Beneficiaires"
             format="nombre">
           </dsfr-data-kpi>
@@ -279,8 +279,8 @@
   count&gt;
 &lt;/dsfr-data-search&gt;
 
-&lt;dsfr-data-kpi source="searched" valeur="count" label="Projets" couleur="bleu"&gt;&lt;/dsfr-data-kpi&gt;
-&lt;dsfr-data-kpi source="searched" valeur="sum:montant_investissement" label="Investissement" format="euro"&gt;&lt;/dsfr-data-kpi&gt;
+&lt;dsfr-data-kpi source="searched" value="count" label="Projets" color="bleu"&gt;&lt;/dsfr-data-kpi&gt;
+&lt;dsfr-data-kpi source="searched" value="montant_investissement:sum" label="Investissement" format="euro"&gt;&lt;/dsfr-data-kpi&gt;
 
 &lt;dsfr-data-query id="stats" source="searched"
   group-by="Region"

--- a/specs/components/dsfr-data-source.html
+++ b/specs/components/dsfr-data-source.html
@@ -271,7 +271,7 @@ where="email:isnull"</pre></div>
 &gt;&lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-list source="browse"
-  colonnes="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque"
+  columns="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque"
   pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</pre></div>
           <div class="fr-callout fr-callout--blue-ecume fr-mt-2w">
@@ -345,8 +345,8 @@ where="email:isnull"</pre></div>
 &gt;&lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-list source="src-ods"
-  colonnes="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque, date_publication:Date"
-  server-tri
+  columns="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque, date_publication:Date"
+  server-sort
   pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</pre></div>
         </section>
@@ -395,8 +395,8 @@ where="email:isnull"</pre></div>
 &gt;&lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-list source="srv"
-  colonnes="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque"
-  server-tri
+  columns="modeles_ou_references:Produit, categorie_produit:Catégorie, marque_produit:Marque"
+  server-sort
   pagination="20"&gt;
 &lt;/dsfr-data-list&gt;</pre></div>
         </section>

--- a/specs/components/dsfr-data-unpivot.html
+++ b/specs/components/dsfr-data-unpivot.html
@@ -89,7 +89,7 @@ Immatriculations VE   | Vehicule Particulier | 2023-02 | 19965</pre></div>
             les valeurs, et on trace une courbe — sans une ligne de JavaScript.
           </p>
           <div class="code-block"><pre>&lt;dsfr-data-source id="grist_wide" api-type="grist"
-  base-url="https://grist.numérique.gouv.fr" doc-id="..." table="Plan_Elec"&gt;
+  base-url="https://grist.numerique.gouv.fr/api/docs/DOC_ID/tables/Plan_Elec/records"&gt;
 &lt;/dsfr-data-source&gt;
 
 &lt;dsfr-data-unpivot id="tidy" source="grist_wide"
@@ -102,7 +102,7 @@ Immatriculations VE   | Vehicule Particulier | 2023-02 | 19965</pre></div>
 &lt;dsfr-data-normalize id="prep" source="tidy" numeric-auto&gt;&lt;/dsfr-data-normalize&gt;
 
 &lt;dsfr-data-query id="ve" source="prep"
-  where="Indicateurs = 'Nombre immatriculations VE'" order-by="mois:asc"&gt;
+  where="Indicateurs:eq:Nombre immatriculations VE" order-by="mois:asc"&gt;
 &lt;/dsfr-data-query&gt;
 
 &lt;dsfr-data-chart source="ve" type="line"
@@ -127,7 +127,7 @@ Immatriculations VE   | Vehicule Particulier | 2023-02 | 19965</pre></div>
   label-field="mois" series-field="groupe" value-field="valeur"&gt;
 &lt;/dsfr-data-chart&gt;</pre></div>
           <p class="fr-text--sm fr-mt-1w">
-            Alternative pour une seule série : filtrer via <code>&lt;dsfr-data-query where="groupe = '...'"&gt;</code>.
+            Alternative pour une seule série : filtrer via <code>&lt;dsfr-data-query where="groupe:eq:..."&gt;</code>.
           </p>
         </section>
 

--- a/specs/components/dsfr-data-world-map.html
+++ b/specs/components/dsfr-data-world-map.html
@@ -48,7 +48,7 @@
             <tr><td><code>name</code></td><td>String</td><td>-</td><td>Titre affiche dans la legende</td></tr>
             <tr><td><code>selected-palette</code></td><td>String</td><td><code>sequentialAscending</code></td><td>Palette de couleurs DSFR (voir ci-dessous)</td></tr>
             <tr><td><code>unit-tooltip</code></td><td>String</td><td>-</td><td>Unite affichee dans les tooltips (ex: "Mds USD")</td></tr>
-            <tr><td><code>zoom</code></td><td>String</td><td><code>continent</code></td><td><code>continent</code> : zoom au clic | <code>none</code> : desactive</td></tr>
+            <tr><td><code>zoom-mode</code></td><td>String</td><td><code>continent</code></td><td><code>continent</code> : zoom au clic | <code>none</code> : desactive. L'ancien nom <code>zoom</code> reste lu en alias deprecie (#299)</td></tr>
           </tbody>
         </table>
 
@@ -182,7 +182,7 @@
           <div class="code-block"><pre>&lt;dsfr-data-world-map source="data"
   code-field="code"
   value-field="valeur"
-  zoom="none"&gt;
+  zoom-mode="none"&gt;
 &lt;/dsfr-data-world-map&gt;</pre></div>
         </section>
 


### PR DESCRIPTION
## Summary

Standardize all component attribute names to English across the documentation and examples. French attribute names are now deprecated aliases, maintaining backward compatibility while establishing English as the primary naming convention.

## Key Changes

- **dsfr-data-kpi**: Renamed attributes to English
  - `valeur` → `value`
  - `icone` → `icon`
  - `couleur` → `color`
  - `seuil-vert` → `threshold-green`
  - `seuil-orange` → `threshold-orange`
  - Added `description` attribute for accessibility
  - Updated calculation expression syntax: `avg:champ` → `champ:avg` (unified `champ:fn` pipeline grammar)

- **dsfr-data-list**: Renamed attributes to English
  - `colonnes` → `columns`
  - `recherche` → `search`
  - `filtres` → `filters`
  - `tri` → `sort`
  - `server-tri` → `server-sort`
  - Added `url-sync` and `url-page-param` for URL state management

- **dsfr-data-facets**: Added URL integration attributes
  - `url-params`: Read URL parameters as facet pre-selections
  - `url-param-map`: Map URL parameters to facet fields
  - `url-sync`: Synchronize URL when facets change

- **dsfr-data-chart**: Enhanced attribute support
  - Added `series-field` for long/tidy data format
  - Added `name`, `unit-tooltip-bar`, `x-min`, `x-max`, `y-min`, `y-max`
  - Renamed `name-field` → `label-field` (consistent across all chart examples)

- **dsfr-data-world-map**: Renamed `zoom` → `zoom-mode`

- **dsfr-data-source**: Updated documentation for pagination and adapter behavior

- **Documentation**: Updated all spec files and guides with new attribute names and examples

## Backward Compatibility

All French attribute names remain functional as deprecated aliases (issue #300). A deprecation notice is added to component documentation indicating the old names will continue to work but should not be used in new code.

## Implementation Details

- Expression syntax unified to `champ:fn` pattern (e.g., `score_rgaa:avg` instead of `avg:score_rgaa`)
- Boolean attributes simplified (e.g., `search` instead of `search="true"`)
- Consistent kebab-case for multi-word attributes across all components
- Updated all example code in specs and guides to use new naming

https://claude.ai/code/session_018fYG2CB6SE3uHXYy8Px7WU