### PR TITLE
docs(examples): rebrancher 5 pages guide sur chartsbuilder.miweb.run + nouvelle politique proxy (#340)

### DIFF
--- a/guide/examples/exemple-france-num.html
+++ b/guide/examples/exemple-france-num.html
@@ -18,8 +18,8 @@
   -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha384-sHL9NAb7lN7rfvG5lfHpm643Xkcjzp4jFvuavGOndn6pjVqS6ny56CAt3nsEVT4H" crossorigin="anonymous">
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha384-cxOPjt7s7Iz04uaHJceBmS+qpjv2JkIHNVcuOrM+YHwZOmJGBXI00mdUXEq65HTH" crossorigin="anonymous"></script>
-    <!-- dsfr-data bundle complet (core + map) -->
-    <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0.7.1/dist/dsfr-data.umd.js" integrity="sha384-I44SvA/CG9VMs3nDjvvORELkUJ0T0xUiZV7ippo+q5nNuv3Tib8c+X2hQ+7sJcAT" crossorigin="anonymous"></script>
+    <!-- dsfr-data : derniere version 0.x (@0, non figee) — evite le fallback proxy chartsbuilder.matge.com bake dans 0.7.1. Bundle complet (core + map) car la page utilise dsfr-data-map. Major flottant : pas de SRI (cf. check:sri). -->
+    <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0/dist/dsfr-data.umd.js"></script>
   </head>
   <body>
     <!-- =============================================
@@ -314,13 +314,13 @@
             </a>
           </div>
           <div class="fr-footer__content">
-            <p class="fr-footer__content-desc"> Dashboard généré avec <a href="https://chartsbuilder.matge.com" class="fr-link" target="_blank" rel="noopener">ChartsBuilder / dsfr-data</a> et les composants officiels <a href="https://www.systeme-de-design.gouv.fr/" class="fr-link" target="_blank" rel="noopener">DSFR</a>. Données issues de <a href="https://data.economie.gouv.fr" class="fr-link" target="_blank" rel="noopener">data.economie.gouv.fr</a> sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" class="fr-link" target="_blank" rel="noopener">Licence Ouverte 2.0</a>. </p>
+            <p class="fr-footer__content-desc"> Dashboard généré avec <a href="https://chartsbuilder.miweb.run" class="fr-link" target="_blank" rel="noopener">ChartsBuilder / dsfr-data</a> et les composants officiels <a href="https://www.systeme-de-design.gouv.fr/" class="fr-link" target="_blank" rel="noopener">DSFR</a>. Données issues de <a href="https://data.economie.gouv.fr" class="fr-link" target="_blank" rel="noopener">data.economie.gouv.fr</a> sous <a href="https://github.com/etalab/licence-ouverte/blob/master/LO.md" class="fr-link" target="_blank" rel="noopener">Licence Ouverte 2.0</a>. </p>
             <ul class="fr-footer__content-list">
               <li class="fr-footer__content-item">
                 <a class="fr-footer__content-link" href="https://data.economie.gouv.fr/explore/dataset/tpe-pme-beneficiaires-des-dispositifs-france-num/" target="_blank" rel="noopener"> Jeu de données open data </a>
               </li>
               <li class="fr-footer__content-item">
-                <a class="fr-footer__content-link" href="https://chartsbuilder.matge.com" target="_blank" rel="noopener"> ChartsBuilder </a>
+                <a class="fr-footer__content-link" href="https://chartsbuilder.miweb.run" target="_blank" rel="noopener"> ChartsBuilder </a>
               </li>
             </ul>
           </div>

--- a/guide/examples/exemple-masa-v1.html
+++ b/guide/examples/exemple-masa-v1.html
@@ -10,7 +10,8 @@
   <!-- Leaflet : charge dynamiquement par dsfr-data.umd.js - NE PAS inclure manuellement -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0.7.1/dist/dsfr-data.umd.js" integrity="sha384-I44SvA/CG9VMs3nDjvvORELkUJ0T0xUiZV7ippo+q5nNuv3Tib8c+X2hQ+7sJcAT" crossorigin="anonymous"></script>
+  <!-- dsfr-data : derniere version 0.x (@0, non figee) — evite le fallback proxy chartsbuilder.matge.com bake dans 0.7.1. Bundle complet (core + map). Major flottant : pas de SRI (cf. check:sri). -->
+  <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0/dist/dsfr-data.umd.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
 </head>
 <body>
@@ -42,8 +43,11 @@
 -->
 
 <!-- SOURCE DNC - etape 1 -->
+<!-- URL Grist reelle + proxy-url declaratif par source (#340). Le proxy nginx
+     de chartsbuilder.miweb.run reecrit vers grist.numerique.gouv.fr. -->
 <dsfr-data-source id="dnc-raw"
-  url="https://chartsbuilder.matge.com/grist-gouv-proxy/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Dnc_epizootie/records"
+  url="https://grist.numerique.gouv.fr/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Dnc_epizootie/records"
+  proxy-url="https://chartsbuilder.miweb.run"
   transform="records">
 </dsfr-data-source>
 

--- a/guide/examples/exemple-masa-v2.html
+++ b/guide/examples/exemple-masa-v2.html
@@ -17,7 +17,8 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
   <!-- dsfr-data core + map -->
-<script src="https://cdn.jsdelivr.net/npm/dsfr-data@0.7.1/dist/dsfr-data.umd.js" integrity="sha384-I44SvA/CG9VMs3nDjvvORELkUJ0T0xUiZV7ippo+q5nNuv3Tib8c+X2hQ+7sJcAT" crossorigin="anonymous"></script>
+<!-- dsfr-data : derniere version 0.x (@0, non figee) — evite le fallback proxy chartsbuilder.matge.com bake dans 0.7.1. Bundle complet (core + map). Major flottant : pas de SRI (cf. check:sri). -->
+<script src="https://cdn.jsdelivr.net/npm/dsfr-data@0/dist/dsfr-data.umd.js"></script>
 
   <!-- DSFR JS (fr-tabs) -->
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
@@ -81,23 +82,30 @@
        cN-top10 (barres top 10 participations)
      ═══════════════════════════════════════════════════════════════ -->
 
-<!-- ── Sources Grist ── -->
+<!-- ── Sources Grist ──
+     base-url : URL Grist reelle (grist.numerique.gouv.fr).
+     proxy-url : proxy CORS declaratif par source (#340) — l'adapter Grist
+                 route automatiquement grist.numerique.gouv.fr via /grist-gouv-proxy/
+                 sur le domaine indique. -->
 <dsfr-data-source id="c1-raw" api-type="grist"
-  base-url="https://chartsbuilder.matge.com/grist-gouv-proxy/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c1/records">
+  base-url="https://grist.numerique.gouv.fr/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c1/records"
+  proxy-url="https://chartsbuilder.miweb.run">
 </dsfr-data-source>
 <dsfr-data-normalize id="c1" source="c1-raw" flatten="fields" trim
   numeric="liste_index,taux_participation,nb_inscrits,nb_sieges">
 </dsfr-data-normalize>
 
 <dsfr-data-source id="c2-raw" api-type="grist"
-  base-url="https://chartsbuilder.matge.com/grist-gouv-proxy/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c2/records">
+  base-url="https://grist.numerique.gouv.fr/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c2/records"
+  proxy-url="https://chartsbuilder.miweb.run">
 </dsfr-data-source>
 <dsfr-data-normalize id="c2" source="c2-raw" flatten="fields" trim
   numeric="liste_index,taux_participation,nb_inscrits,nb_sieges">
 </dsfr-data-normalize>
 
 <dsfr-data-source id="c3-raw" api-type="grist"
-  base-url="https://chartsbuilder.matge.com/grist-gouv-proxy/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c3/records">
+  base-url="https://grist.numerique.gouv.fr/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c3/records"
+  proxy-url="https://chartsbuilder.miweb.run">
 </dsfr-data-source>
 <dsfr-data-normalize id="c3" source="c3-raw" flatten="fields" trim
   numeric="liste_index,taux_participation,nb_inscrits,nb_sieges">
@@ -133,19 +141,22 @@
      à la couleur de la carte (FNSEA/JA → bleu France, etc.).
 -->
 <dsfr-data-source id="c1-pie" api-type="grist"
-  base-url="https://chartsbuilder.matge.com/grist-gouv-proxy/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c1/records"
+  base-url="https://grist.numerique.gouv.fr/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c1/records"
+  proxy-url="https://chartsbuilder.miweb.run"
   group-by="liste_gagnante"
   aggregate="liste_index:count,liste_index:min"
   order-by="liste_index__min:asc">
 </dsfr-data-source>
 <dsfr-data-source id="c2-pie" api-type="grist"
-  base-url="https://chartsbuilder.matge.com/grist-gouv-proxy/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c2/records"
+  base-url="https://grist.numerique.gouv.fr/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c2/records"
+  proxy-url="https://chartsbuilder.miweb.run"
   group-by="liste_gagnante"
   aggregate="liste_index:count,liste_index:min"
   order-by="liste_index__min:asc">
 </dsfr-data-source>
 <dsfr-data-source id="c3-pie" api-type="grist"
-  base-url="https://chartsbuilder.matge.com/grist-gouv-proxy/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c3/records"
+  base-url="https://grist.numerique.gouv.fr/api/docs/pU5HXX7VJC6jdgU6oBJRxn/tables/Scrutin_c3/records"
+  proxy-url="https://chartsbuilder.miweb.run"
   group-by="liste_gagnante"
   aggregate="liste_index:count,liste_index:min"
   order-by="liste_index__min:asc">

--- a/guide/guide-demo-complete.html
+++ b/guide/guide-demo-complete.html
@@ -38,7 +38,7 @@
         <h1>Démo complète — Studio Ghibli</h1>
         <p class="fr-text--lead">
           Tableau de bord filmographique du Studio Ghibli exploitant <strong>tous les composants dsfr-data</strong>
-          et <strong>tous les types de graphiques</strong>. Source principale : Ghibli API (générique, CORS natif).
+          et <strong>tous les types de graphiques</strong>. Source principale : Ghibli API (générique, route via proxy CORS).
           Cartes géographiques : données fictives à titre illustratif.
         </p>
 
@@ -46,9 +46,13 @@
         <!-- PIPELINE INVISIBLE — Sources, normalize, queries               -->
         <!-- ============================================================= -->
 
-        <!-- Source principale : fetch URL directe, JSON plat, CORS natif -->
+        <!-- Source principale : la CSP de la page interdit ghibliapi.vercel.app en direct
+             (whitelist gouv.fr / opendatasoft.com uniquement) : use-proxy route la requete
+             via /cors-proxy sur le domaine indique par proxy-url (#340). -->
         <dsfr-data-source id="raw-films"
-          url="https://ghibliapi.vercel.app/films">
+          url="https://ghibliapi.vercel.app/films"
+          use-proxy
+          proxy-url="https://chartsbuilder.miweb.run">
         </dsfr-data-source>
 
         <!-- Normalisation : conversion numerique des champs string -->
@@ -138,7 +142,7 @@
           <p class="fr-callout__text">
             Analyse des 22 longs-métrages du Studio Ghibli (1984–2023) : scores critiques, durées,
             réalisateurs, évolution dans le temps et diffusion mondiale.
-            Source : <strong>Ghibli API</strong> (générique, CORS natif, aucune clé requise).
+            Source : <strong>Ghibli API</strong> (générique, route via proxy CORS, aucune clé requise).
           </p>
         </div>
 
@@ -474,7 +478,7 @@
           <p>
             <strong>Source principale :</strong>
             <a href="https://ghibliapi.vercel.app" target="_blank" rel="noopener">Ghibli API (ghibliapi.vercel.app)</a>
-            — données publiques, CORS natif, aucune clé d'API requise.<br>
+            — données publiques, route via proxy CORS, aucune clé d'API requise.<br>
             <strong>Pipeline :</strong> dsfr-data-source (URL directe) → dsfr-data-normalize (numeric) →
             8× dsfr-data-query → dsfr-data-kpi-group (4 KPIs) + 13× dsfr-data-chart (tous types) +
             dsfr-data-world-map + dsfr-data-search + dsfr-data-facets + dsfr-data-display + dsfr-data-list + dsfr-data-a11y.<br>

--- a/guide/guide-exemples-ghibli.html
+++ b/guide/guide-exemples-ghibli.html
@@ -95,8 +95,9 @@
         <div class="fr-callout fr-callout--blue-france fr-mt-2w">
           <p class="fr-callout__text">
             <strong>Provider generic :</strong> L'API Ghibli retourne directement un tableau JSON plat
-            (pas d'enveloppe, CORS natif). <code>dsfr-data-source</code> utilise une URL directe sans <code>api-type</code>
-            ni <code>transform</code>.
+            (pas d'enveloppe). <code>dsfr-data-source</code> utilise une URL directe sans <code>api-type</code>
+            ni <code>transform</code>. La CSP de cette page limite les hotes joignables directement :
+            on route donc via le proxy CORS generique (<code>use-proxy</code> + <code>proxy-url</code>, cf. #340).
             Les champs numeriques (<code>rt_score</code>, <code>running_time</code>,
             <code>release_date</code>) arrivent en string et sont convertis via <code>dsfr-data-normalize numeric</code>.
             Toutes les transformations (tri, filtre, group-by, agregation) sont effectuees client-side
@@ -126,9 +127,13 @@
         <!-- PIPELINE                                                        -->
         <!-- ============================================================= -->
 
-        <!-- 1. Fetch generique (URL directe, JSON plat, CORS natif) -->
+        <!-- 1. Fetch generique. La CSP de la page interdit ghibliapi.vercel.app en direct
+             (connect-src whitelist gouv.fr / opendatasoft.com uniquement) : use-proxy route
+             la requete via /cors-proxy sur le domaine indique par proxy-url. -->
         <dsfr-data-source id="raw-films"
-          url="https://ghibliapi.vercel.app/films">
+          url="https://ghibliapi.vercel.app/films"
+          use-proxy
+          proxy-url="https://chartsbuilder.miweb.run">
         </dsfr-data-source>
 
         <!-- 2. Normalisation : conversion numerique des champs string -->
@@ -355,9 +360,11 @@
         <section class="fr-accordion fr-mt-2w">
           <h3 class="fr-accordion__title"><button class="fr-accordion__btn" aria-expanded="false" aria-controls="code-ghibli">Code source complet</button></h3>
           <div class="fr-collapse" id="code-ghibli">
-<pre class="example-code">&lt;!-- 1. Fetch generique (URL directe, CORS natif) --&gt;
+<pre class="example-code">&lt;!-- 1. Fetch generique via proxy CORS (use-proxy + proxy-url, cf. #340) --&gt;
 &lt;dsfr-data-source id="raw-films"
-  url="https://ghibliapi.vercel.app/films"&gt;
+  url="https://ghibliapi.vercel.app/films"
+  use-proxy
+  proxy-url="https://chartsbuilder.miweb.run"&gt;
 &lt;/dsfr-data-source&gt;
 
 &lt;!-- 2. Normalisation : conversion numerique des champs string --&gt;
@@ -475,7 +482,7 @@
         <!-- Points cles -->
         <h4 class="fr-mt-3w">Points cles de cet exemple</h4>
         <ul>
-          <li><strong>Provider generic</strong> : <code>dsfr-data-source</code> utilise une URL directe vers une API REST qui retourne un tableau JSON plat. Pas besoin d'<code>api-type</code> ni de <code>transform</code> — le cas d'usage le plus simple. L'API Ghibli supporte CORS nativement, donc pas besoin de <code>use-proxy</code>.</li>
+          <li><strong>Provider generic</strong> : <code>dsfr-data-source</code> utilise une URL directe vers une API REST qui retourne un tableau JSON plat. Pas besoin d'<code>api-type</code> ni de <code>transform</code> — le cas d'usage le plus simple. La CSP de cette page limite les hotes joignables directement (whitelist <code>gouv.fr</code> / <code>opendatasoft.com</code>), on route donc via <code>use-proxy</code> + <code>proxy-url</code>.</li>
           <li><strong>Normalisation des types</strong> : l'API retourne <code>rt_score</code>, <code>running_time</code> et <code>release_date</code> en string. <code>dsfr-data-normalize numeric</code> les convertit en nombres pour permettre le tri, les agregations et les filtres numeriques.</li>
           <li><strong>Queries multiples sur une seule source</strong> : 6 <code>dsfr-data-query</code> derivent chacun une vue differente des memes donnees (tri, group-by, aggregate, where) — tout en client-side.</li>
           <li><strong>KPI avec agregation inline</strong> : <code>dsfr-data-kpi value="rt_score:avg"</code> calcule la moyenne directement, sans query intermediaire.</li>


### PR DESCRIPTION
## Contexte

6 pages du guide/exemples ont ete signalees en erreur en prod :

- https://chartsbuilder.miweb.run/guide/guide-exemples-world-map.html
- https://chartsbuilder.miweb.run/guide/guide-exemples-ghibli.html
- https://chartsbuilder.miweb.run/guide/guide-demo-complete.html
- https://chartsbuilder.miweb.run/guide/examples/exemple-masa-v1.html
- https://chartsbuilder.miweb.run/guide/examples/exemple-masa-v2.html
- https://chartsbuilder.miweb.run/guide/examples/exemple-france-num.html

## Diagnostic — 3 causes distinctes

### 1. Lib figee a `dsfr-data@0.7.1` avec `chartsbuilder.matge.com` bake en dur
Concernait `exemple-france-num.html`, `exemple-masa-v1.html`, `exemple-masa-v2.html`.

En v0.7.1, `packages/shared/src/api/proxy-config.ts` contenait :
```js
PROXY_BASE_URL = import.meta.env?.VITE_PROXY_URL || 'https://chartsbuilder.matge.com'
```
Tous les fetches Grist/Tabular/INSEE partaient vers `chartsbuilder.matge.com/*-proxy/*` — domaine qui existe encore mais redirige 308 vers `chartsbuilder.miweb.run/`, ce qui casse les preflights CORS.

### 2. URLs `base-url` codees en dur avec le domaine mort
Concernait `exemple-masa-v1.html` et `exemple-masa-v2.html`.

Ancien pattern (builder pre-composant l'URL proxifiee) :
```html
url="https://chartsbuilder.matge.com/grist-gouv-proxy/api/docs/…/tables/…/records"
```
Depuis #340/#346 (proxy CORS declaratif par source, juin 2026), la lib attend une URL Grist naturelle + un attribut `proxy-url` explicite.

### 3. CSP `connect-src` bloque `ghibliapi.vercel.app`
Concernait `guide-exemples-ghibli.html` et `guide-demo-complete.html`.

La CSP prod (`docker/security-headers.conf`) whitelist uniquement `*.gouv.fr`, `*.opendatasoft.com` et quelques APIs LLM. `ghibliapi.vercel.app` n'est pas whitelistee → fetch direct bloque par le browser.

## Fixes appliques

| Page | Fix |
|---|---|
| `exemple-france-num.html` | `@0.7.1` → `@0` (dsfr-data.umd.js) + liens footer `chartsbuilder.matge.com` → `chartsbuilder.miweb.run` |
| `exemple-masa-v1.html` | `@0.7.1` → `@0` + URL Grist reelle + `proxy-url="https://chartsbuilder.miweb.run"` |
| `exemple-masa-v2.html` | `@0.7.1` → `@0` + reecriture des 6 `base-url` Grist + `proxy-url` par source |
| `guide-exemples-ghibli.html` | ajout `use-proxy` + `proxy-url` + MaJ texte + code source affiche |
| `guide-demo-complete.html` | ajout `use-proxy` + `proxy-url` + MaJ texte |

## Non touche

**`guide-exemples-world-map.html`** : les fetches ODS (`data.economie.gouv.fr`) devraient techniquement marcher en direct :
- ODS retourne `access-control-allow-origin: *` sur GET et OPTIONS
- CSP couvre `*.gouv.fr`
- L'adapter ODS n'utilise pas `proxy-url` (hote non-connu de `rewriteKnownHost`)

Ajouter `proxy-url` sur cette page serait un no-op fonctionnel. **Si l'erreur persiste apres deploiement, un diag browser sera necessaire** (bug lib, dataset, cache, etc.).

## Verifications locales
- `npm run check:accents` : ✓
- `npm run check:sri` : ✓ (major flottant `@0` ignore par `generate-sri.ts`, pattern documente dans `cc5ca2a`)

## Test plan
- [ ] Ouvrir chaque page en preview locale (`npm run dev`) — les 5 doivent charger et rendre les charts/cartes.
- [ ] Apres deploiement : recharger les 6 URLs prod, verifier console browser (0 erreur CSP, 0 CORS, tous les composants rendus).
- [ ] Si `guide-exemples-world-map.html` reste en erreur : ouvrir devtools, capturer l'erreur reelle → nouveau ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)