### PR TITLE
fix(csp): autorise image.tmdb.org dans img-src (posters démo Ghibli)

### DIFF
--- a/docker/security-headers.conf
+++ b/docker/security-headers.conf
@@ -41,6 +41,8 @@ add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autopl
 #     - data.geopf.fr            : tuiles IGN (presets ign-*, cadastre) chargées
 #                                  par dsfr-data-map
 #     - *.tile.openstreetmap.fr  : tuiles OSM-FR (preset par défaut)
+#     - image.tmdb.org           : posters/banners de films (démo Ghibli du guide,
+#                                  api ghibliapi.vercel.app renvoie des URLs TMDB)
 #     - data: blob:              : icônes/images embarquées par les composants
 #
 #   connect-src :
@@ -59,4 +61,4 @@ add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autopl
 #                                      `connect-src 'self'`.
 #
 # Cf. issue #168 — PR-2. Validée par le DAST ZAP (workflow .github/workflows/dast.yml).
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; font-src 'self' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; img-src 'self' data: blob: https://cdn.jsdelivr.net https://unpkg.com https://esm.sh https://*.gouv.fr https://data.geopf.fr https://*.tile.openstreetmap.fr; connect-src 'self' https://*.opendatasoft.com https://*.gouv.fr https://api.openai.com https://api.anthropic.com https://api.mistral.ai https://generativelanguage.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; font-src 'self' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; img-src 'self' data: blob: https://cdn.jsdelivr.net https://unpkg.com https://esm.sh https://*.gouv.fr https://data.geopf.fr https://*.tile.openstreetmap.fr https://image.tmdb.org; connect-src 'self' https://*.opendatasoft.com https://*.gouv.fr https://api.openai.com https://api.anthropic.com https://api.mistral.ai https://generativelanguage.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;


### PR DESCRIPTION
## Contexte

Suite au fix des sources Ghibli en #370 (route via `use-proxy` + `proxy-url`), les fetches JSON passent bien. En revanche, les **images de posters** de films renvoyées par l'API Ghibli (`ghibliapi.vercel.app`) pointent vers `image.tmdb.org` (TMDB) — chargées via `<img src>` dans `guide-demo-complete.html` et `guide-exemples-ghibli.html`.

La CSP `img-src` ne whiteliste pas ce host → le browser bloque avec :

> Refused to load the image because it violates the following Content Security Policy directive: img-src …

## Fix

Ajout de `https://image.tmdb.org` à la whitelist `img-src` dans `docker/security-headers.conf`, avec commentaire explicatif.

Pas d'impact sur `connect-src`, `script-src`, ni les autres directives.

## Test plan
- [ ] Après merge + redéploiement : recharger `/guide/guide-demo-complete.html` et `/guide/guide-exemples-ghibli.html`. Console browser : 0 erreur CSP `img-src`. Les posters de films s'affichent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)