### PR TITLE
fix(security): corrige les 3 alertes CodeQL (ReDoS, URL suffix, log injection)

### DIFF
--- a/.changeset/codeql-security-fixes.md
+++ b/.changeset/codeql-security-fixes.md
@@ -1,0 +1,9 @@
+---
+'dsfr-data': patch
+---
+
+Sécurité (CodeQL) : corrige une regex à backtracking polynomial (ReDoS) dans la
+détection des permaliens Tabular — le préfixe libre `[^?#]*` est remplacé par un
+préfixe de locale optionnel `(?:[a-z]{2}/)?`. Au passage, les permaliens
+data.gouv.fr modernes sans locale (`data.gouv.fr/datasets/r/{uuid}`) sont
+désormais reconnus.

--- a/apps/sources/src/connections/connection-manager.ts
+++ b/apps/sources/src/connections/connection-manager.ts
@@ -941,7 +941,7 @@ export async function runUrlDetection(): Promise<void> {
   } catch {
     // pas une URL absolue — on laissera l'utilisateur compléter en mode manuel
   }
-  const isGrist = /grist/i.test(host) || host.endsWith('getgrist.com');
+  const isGrist = /grist/i.test(host) || host === 'getgrist.com' || host.endsWith('.getgrist.com');
 
   const resolved = resolveSourceUrl(raw);
 

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -310,7 +310,11 @@ async function startHttp() {
       // perdu ses sessions en mémoire). 404 — et non 400 — pour que le client MCP
       // ré-initialise automatiquement une session fraîche (spec StreamableHTTP).
       // Sinon le connecteur reste bloqué et tous les appels d'outils échouent.
-      console.error(`[dsfr-data-mcp] Unknown session ${sessionId} → 404 (client should re-initialize)`);
+      // sessionId vient d'un header client : filtré avant log (injection de log)
+      const safeSessionId = String(sessionId).replace(/[^\w-]/g, '');
+      console.error(
+        `[dsfr-data-mcp] Unknown session ${safeSessionId} → 404 (client should re-initialize)`,
+      );
       res.writeHead(404, { 'Content-Type': 'application/json' });
       res.end(
         JSON.stringify({

--- a/packages/shared/src/providers/tabular.ts
+++ b/packages/shared/src/providers/tabular.ts
@@ -11,7 +11,7 @@ const TABULAR_API_RE = /tabular-api\.data\.gouv\.fr\/api\/resources\/([^/?#]+)/;
  * dataset holds N resources, so picking one requires a network lookup (Phase 1).
  */
 const TABULAR_PERMALINK_RE =
-  /data\.gouv\.fr\/[^?#]*\/datasets\/r\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i;
+  /data\.gouv\.fr\/(?:[a-z]{2}\/)?datasets\/r\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i;
 
 export const TABULAR_CONFIG: ProviderConfig = {
   id: 'tabular',


### PR DESCRIPTION
## Alertes corrigées

| # | Règle | Sévérité | Fichier | Fix |
|---|---|---|---|---|
| 59 | `js/polynomial-redos` | high | `packages/shared/src/providers/tabular.ts` | `[^?#]*` (ambigu avec `/datasets`) → préfixe de locale optionnel `(?:[a-z]{2}/)?`, non ambigu |
| 60 | `js/incomplete-url-substring-sanitization` | high | `apps/sources/src/connections/connection-manager.ts` | `endsWith('getgrist.com')` → égalité stricte ou suffixe `.getgrist.com` |
| 58 | `js/log-injection` | medium | `mcp-server/src/index.ts` | `sessionId` (header client) filtré `[^\w-]` avant interpolation dans le log |

## Effet de bord (voulu)

La nouvelle regex Tabular reconnaît aussi les permaliens **modernes sans préfixe de locale** (`data.gouv.fr/datasets/r/{uuid}`), que l'ancienne ratait (elle exigeait un segment intermédiaire).

## Validation

- `tests/shared/providers.test.ts` : 100 tests verts
- `npm run build:shared` + `npm run build` + `tsc` mcp-server OK
- Regex : match avec/sans locale, non-match page dataset & host forgé, chaîne pathologique 100 k car. en 0 ms
- Changeset patch inclus (`packages/shared` touché)

🤖 Generated with [Claude Code](https://claude.com/claude-code)