### PR TITLE
fix(security): sanitizer reconnu par CodeQL pour le log de sessionId (mcp-server)

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -310,8 +310,8 @@ async function startHttp() {
       // perdu ses sessions en mémoire). 404 — et non 400 — pour que le client MCP
       // ré-initialise automatiquement une session fraîche (spec StreamableHTTP).
       // Sinon le connecteur reste bloqué et tous les appels d'outils échouent.
-      // sessionId vient d'un header client : filtré avant log (injection de log)
-      const safeSessionId = String(sessionId).replace(/[^\w-]/g, '');
+      // sessionId vient d'un header client : encodé avant log (injection de log)
+      const safeSessionId = encodeURIComponent(String(sessionId));
       console.error(
         `[dsfr-data-mcp] Unknown session ${safeSessionId} → 404 (client should re-initialize)`,
       );


### PR DESCRIPTION
Suite de #383 : CodeQL a rouvert l'alerte `js/log-injection` (#62) sur le fix — le filtre regex `[^\w-]` neutralise bien les retours à la ligne mais n'est pas un sanitizer **reconnu** par l'analyse de taint. `encodeURIComponent` l'est, et reste neutre pour un UUID légitime.

Validation : `tsc` mcp-server OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)