### PR TITLE
fix(a11y): dsfr-data-kpi — color-token canonique, color en alias déprécié (#367)

### DIFF
--- a/.changeset/kpi-color-token.md
+++ b/.changeset/kpi-color-token.md
@@ -1,0 +1,10 @@
+---
+'dsfr-data': patch
+---
+
+`dsfr-data-kpi` : nouvel attribut canonique `color-token` (token sémantique DSFR
+`vert|orange|rouge|bleu`), remplaçant `color` dont le nom évoquait l'attribut de
+présentation HTML déprécié (faux positif d'audit RGAA 10.1.2). `color` reste
+supporté comme alias déprécié (warning console, retrait prévu à la prochaine
+version majeure) ; `color-token` prime quand les deux sont présents. Doc,
+exemples et skill builder-IA migrés (#367).

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -916,7 +916,7 @@ Attend un tableau d'objets. L'attribut \`valeur\` determine comment extraire/agr
 | format | String | \`"nombre"\` | non | Format : nombre, pourcentage, euro, decimal |
 | trend | String | \`""\` | non | RACCOURCI HERITE (preferez \`lines\`). Expression d'agregation \`"champ:fn"\` (\`"evolution:avg"\`) — PAS un litteral. Rendue avec une fleche en pourcentage fr-FR (\`↑ 5,2 %\`). Alias deprecie : \`tendance\` |
 | lines | String | \`""\` | non | Lignes secondaires declaratives (JSON), rendues ENTRE la valeur et le \`label\`. Chaque item : \`value\` (expression \`champ:fn\`) OU \`text\` (statique), + \`format\`, \`sign\`, \`prefix\`, \`suffix\`, \`color\` (\`"auto"\`=vert si >=0/rouge si <0, token DSFR, ou couleur CSS), \`na\` (repli si non fini). Ex. \`[{"value":"evol:avg","sign":true,"suffix":"vs mai 2025","color":"auto"}]\` |
-| color | String | \`""\` | non | Forcer la couleur : vert, orange, rouge, bleu. Alias deprecie : \`couleur\` |
+| color-token | String | \`""\` | non | Forcer la couleur (token semantique DSFR) : vert, orange, rouge, bleu. Alias deprecies : \`color\`, \`couleur\` |
 | threshold-green | Number | - | non | Seuil au-dessus duquel couleur = vert. Alias deprecie : \`seuil-vert\` |
 | threshold-orange | Number | - | non | Seuil au-dessus duquel couleur = orange (en-dessous = rouge). Alias deprecie : \`seuil-orange\` |
 | col | Number | - | non | Largeur en colonnes DSFR (1-12), actif uniquement dans un \`<dsfr-data-kpi-group>\` |
@@ -936,7 +936,7 @@ Utiliser \`<dsfr-data-kpi-group>\` pour disposer plusieurs KPIs en grille respon
 - Responsive automatique : empile en mobile
 
 ### Logique des couleurs
-1. Si \`couleur\` est défini : applique cette couleur directement
+1. Si \`color-token\` est défini : applique cette couleur directement
 2. Si \`seuil-vert\` et \`seuil-orange\` sont définis : couleur automatique selon la valeur
    - valeur >= seuil-vert -> vert (success)
    - valeur >= seuil-orange -> orange (warning)
@@ -977,7 +977,7 @@ Utiliser \`<dsfr-data-kpi-group>\` pour disposer plusieurs KPIs en grille respon
 <dsfr-data-kpi source="data"
   valeur="count:status:active"
   label="Sites actifs"
-  couleur="bleu"
+  color-token="bleu"
   trend="evolution:avg">
 </dsfr-data-kpi>
 

--- a/apps/playground/src/examples/examples-data.ts
+++ b/apps/playground/src/examples/examples-data.ts
@@ -166,7 +166,7 @@ export const examples: Record<string, string> = {
       value="montant_investissement:max"
       label="Investissement max"
       format="euro"
-      color="vert">
+      color-token="vert">
     </dsfr-data-kpi>
 
     <dsfr-data-kpi source="data"
@@ -401,14 +401,14 @@ export const examples: Record<string, string> = {
       value="nombre_beneficiaires:sum"
       label="Total beneficiaires"
       format="nombre"
-      color="bleu">
+      color-token="bleu">
     </dsfr-data-kpi>
 
     <dsfr-data-kpi source="all"
       value="montant_investissement:sum"
       label="Investissement total"
       format="euro"
-      color="vert">
+      color-token="vert">
     </dsfr-data-kpi>
   </div>
 
@@ -1066,7 +1066,7 @@ export const examples: Record<string, string> = {
     <dsfr-data-kpi source="searched"
       value="count"
       label="Projets"
-      color="bleu">
+      color-token="bleu">
     </dsfr-data-kpi>
 
     <dsfr-data-kpi source="searched"

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -427,7 +427,7 @@ Les donnees de la source sont transmises directement au composant de visualisati
   <dsfr-data-kpi source="data" value="nombre_beneficiaires:avg"
     label="Moyenne" format="decimal"></dsfr-data-kpi>
   <dsfr-data-kpi source="data" value="montant_investissement:max"
-    label="Investissement max" format="euro" color="vert"></dsfr-data-kpi>
+    label="Investissement max" format="euro" color-token="vert"></dsfr-data-kpi>
   <dsfr-data-kpi source="data" value="count"
     label="Enregistrements" format="nombre"></dsfr-data-kpi>
 </div>
@@ -617,7 +617,7 @@ Les donnees passent par `dsfr-data-query` qui les filtre, regroupe et/ou agrege 
   <dsfr-data-kpi source="data" value="count"
     label="Total des maires" format="nombre"></dsfr-data-kpi>
   <dsfr-data-kpi source="q-femmes" value="count"
-    label="Dont femmes" format="nombre" color="bleu"></dsfr-data-kpi>
+    label="Dont femmes" format="nombre" color-token="bleu"></dsfr-data-kpi>
 </div>
 ```
 

--- a/guide/examples/education-gouv-1.html
+++ b/guide/examples/education-gouv-1.html
@@ -172,7 +172,7 @@
       label="Élèves recensés (cumul)"
       format="nombre"
       icon="ri-graduation-cap-line"
-      color="bleu">
+      color-token="bleu">
     </dsfr-data-kpi>
 
     <dsfr-data-kpi
@@ -181,7 +181,7 @@
       label="Enregistrements école‑année"
       format="nombre"
       icon="ri-building-line"
-      color="bleu">
+      color-token="bleu">
     </dsfr-data-kpi>
 
     <dsfr-data-kpi
@@ -190,7 +190,7 @@
       label="Élèves en secteur public"
       format="nombre"
       icon="ri-government-line"
-      color="bleu">
+      color-token="bleu">
     </dsfr-data-kpi>
 
     <dsfr-data-kpi
@@ -199,7 +199,7 @@
       label="Élèves en secteur privé"
       format="nombre"
       icon="ri-home-heart-line"
-      color="bleu">
+      color-token="bleu">
     </dsfr-data-kpi>
 
   </dsfr-data-kpi-group>

--- a/guide/examples/exemple-france-num.html
+++ b/guide/examples/exemple-france-num.html
@@ -131,10 +131,10 @@
             </div>
           </div>
           <dsfr-data-kpi-group cols="4" gap="md" aria-label="Indicateurs clés du programme FranceNum">
-            <dsfr-data-kpi source="src-kpi" value="nb_total" label="Bénéficiaires au total" icon="ri-team-line" format="nombre" color="bleu"></dsfr-data-kpi>
-            <dsfr-data-kpi source="src-kpi" value="total_montant" label="Montant total distribué" icon="ri-money-euro-circle-line" format="euro" color="vert"></dsfr-data-kpi>
-            <dsfr-data-kpi source="src-kpi" value="moy_montant" label="Montant moyen / bénéficiaire" icon="ri-bar-chart-grouped-line" format="euro" color="bleu"></dsfr-data-kpi>
-            <dsfr-data-kpi source="src-kpi" value="total_accompagnements" label="Accompagnements réalisés" icon="ri-award-line" format="nombre" color="bleu"></dsfr-data-kpi>
+            <dsfr-data-kpi source="src-kpi" value="nb_total" label="Bénéficiaires au total" icon="ri-team-line" format="nombre" color-token="bleu"></dsfr-data-kpi>
+            <dsfr-data-kpi source="src-kpi" value="total_montant" label="Montant total distribué" icon="ri-money-euro-circle-line" format="euro" color-token="vert"></dsfr-data-kpi>
+            <dsfr-data-kpi source="src-kpi" value="moy_montant" label="Montant moyen / bénéficiaire" icon="ri-bar-chart-grouped-line" format="euro" color-token="bleu"></dsfr-data-kpi>
+            <dsfr-data-kpi source="src-kpi" value="total_accompagnements" label="Accompagnements réalisés" icon="ri-award-line" format="nombre" color-token="bleu"></dsfr-data-kpi>
           </dsfr-data-kpi-group>
         </section>
         <hr class="fr-hr fr-my-6w">

--- a/guide/examples/exemple-masa-v1.html
+++ b/guide/examples/exemple-masa-v1.html
@@ -108,7 +108,7 @@
   <div class="fr-grid-row fr-grid-row--gutters fr-mb-3w">
     <div class="fr-col-12 fr-col-sm-6 fr-col-md-3">
       <dsfr-data-kpi source="dnc-last" value="count:statut:3"
-        label="Foyers confirm&eacute;s" color="rouge">
+        label="Foyers confirm&eacute;s" color-token="rouge">
       </dsfr-data-kpi>
     </div>
     <div class="fr-col-12 fr-col-sm-6 fr-col-md-3">
@@ -118,7 +118,7 @@
     </div>
     <div class="fr-col-12 fr-col-sm-6 fr-col-md-3">
       <dsfr-data-kpi source="dnc-last" value="count:statut:2"
-        label="En surveillance" color="orange">
+        label="En surveillance" color-token="orange">
       </dsfr-data-kpi>
     </div>
     <div class="fr-col-12 fr-col-sm-6 fr-col-md-3">

--- a/guide/examples/exemple-masa-v2.html
+++ b/guide/examples/exemple-masa-v2.html
@@ -205,7 +205,7 @@
     </div>
     <div class="fr-col-12 fr-col-sm-6 fr-col-md-3">
       <dsfr-data-kpi source="c1" value="count:liste_index:2"
-        label="Depts Coord. Rurale gagnants" color="orange">
+        label="Depts Coord. Rurale gagnants" color-token="orange">
       </dsfr-data-kpi>
     </div>
   </div>

--- a/guide/examples/observatoire-afa-v1.html
+++ b/guide/examples/observatoire-afa-v1.html
@@ -42,17 +42,17 @@
   <!-- ══ KPIs ══ -->
   <dsfr-data-kpi-group cols="3" gap="md" class="fr-mb-6w" aria-label="Indicateurs clés du corpus">
     <dsfr-data-kpi source="src-all" value="count"
-      label="Décisions analysées" color="bleu"></dsfr-data-kpi>
+      label="Décisions analysées" color-token="bleu"></dsfr-data-kpi>
     <dsfr-data-kpi source="src-all" value="count:issue_court:Condamnation"
-      label="Condamnations" color="vert"></dsfr-data-kpi>
+      label="Condamnations" color-token="vert"></dsfr-data-kpi>
     <dsfr-data-kpi source="src-all" value="count:issue_court:Relaxe"
-      label="Relaxes" color="rouge"></dsfr-data-kpi>
+      label="Relaxes" color-token="rouge"></dsfr-data-kpi>
     <dsfr-data-kpi source="src-globals" value="taux"
-      label="Taux de condamnation" format="pourcentage" color="orange"></dsfr-data-kpi>
+      label="Taux de condamnation" format="pourcentage" color-token="orange"></dsfr-data-kpi>
     <dsfr-data-kpi source="src-globals" value="qualifications"
-      label="Qualifications pénales distinctes" color="bleu"></dsfr-data-kpi>
+      label="Qualifications pénales distinctes" color-token="bleu"></dsfr-data-kpi>
     <dsfr-data-kpi source="src-all" value="count:juridiction:Cour d'appel"
-      label="Affaires jugées en appel" color="bleu"></dsfr-data-kpi>
+      label="Affaires jugées en appel" color-token="bleu"></dsfr-data-kpi>
   </dsfr-data-kpi-group>
 
   <hr>

--- a/guide/guide-demo-complete.html
+++ b/guide/guide-demo-complete.html
@@ -156,7 +156,7 @@
             label="Nombre de films"
             format="nombre"
             icon="ri-film-line"
-            color="bleu">
+            color-token="bleu">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi
@@ -175,7 +175,7 @@
             label="Durée moyenne (minutes)"
             format="nombre"
             icon="ri-time-line"
-            color="orange">
+            color-token="orange">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi

--- a/guide/guide-exemples-ghibli.html
+++ b/guide/guide-exemples-ghibli.html
@@ -202,7 +202,7 @@
             threshold-green="90"
             threshold-orange="75"
             icon="ri-star-line"
-            color="bleu">
+            color-token="bleu">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi source="films"
@@ -210,7 +210,7 @@
             label="Duree moyenne (minutes par film)"
             format="nombre"
             icon="ri-time-line"
-            color="orange">
+            color-token="orange">
           </dsfr-data-kpi>
         </div>
 
@@ -412,14 +412,14 @@
     label="Score Rotten Tomatoes moyen (sur 100)"
     format="nombre"
     threshold-green="90" threshold-orange="75"
-    icon="ri-star-line" color="bleu"&gt;
+    icon="ri-star-line" color-token="bleu"&gt;
   &lt;/dsfr-data-kpi&gt;
 
   &lt;dsfr-data-kpi source="films"
     value="running_time:avg"
     label="Duree moyenne (minutes par film)"
     format="nombre"
-    icon="ri-time-line" color="orange"&gt;
+    icon="ri-time-line" color-token="orange"&gt;
   &lt;/dsfr-data-kpi&gt;
 &lt;/div&gt;
 

--- a/guide/guide-exemples-insee-erfs.html
+++ b/guide/guide-exemples-insee-erfs.html
@@ -174,13 +174,13 @@
 
         <div class="kpi-row">
           <dsfr-data-kpi source="q-kpi-mean" value="value" label="Revenu disponible moyen"
-            format="euro" icon="ri-money-euro-circle-line" color="bleu"></dsfr-data-kpi>
+            format="euro" icon="ri-money-euro-circle-line" color-token="bleu"></dsfr-data-kpi>
           <dsfr-data-kpi source="q-kpi-d1" value="value" label="1er décile (D1)"
-            format="euro" icon="ri-arrow-down-line" color="rouge"></dsfr-data-kpi>
+            format="euro" icon="ri-arrow-down-line" color-token="rouge"></dsfr-data-kpi>
           <dsfr-data-kpi source="q-kpi-med" value="value" label="Revenu médian"
-            format="euro" icon="ri-bar-chart-horizontal-line" color="vert"></dsfr-data-kpi>
+            format="euro" icon="ri-bar-chart-horizontal-line" color-token="vert"></dsfr-data-kpi>
           <dsfr-data-kpi source="q-kpi-d9" value="value" label="9e décile (D9)"
-            format="euro" icon="ri-arrow-up-line" color="orange"></dsfr-data-kpi>
+            format="euro" icon="ri-arrow-up-line" color-token="orange"></dsfr-data-kpi>
         </div>
 
         <!-- Evolution revenu moyen -->
@@ -392,7 +392,7 @@
 
 &lt;div class="kpi-row"&gt;
   &lt;dsfr-data-kpi source="q-kpi-mean" value="value" label="Revenu disponible moyen"
-    format="euro" icon="ri-money-euro-circle-line" color="bleu"&gt;&lt;/dsfr-data-kpi&gt;
+    format="euro" icon="ri-money-euro-circle-line" color-token="bleu"&gt;&lt;/dsfr-data-kpi&gt;
   &lt;!-- + D1, Median, D9 (meme pattern) --&gt;
 &lt;/div&gt;
 

--- a/guide/guide-exemples-maires.html
+++ b/guide/guide-exemples-maires.html
@@ -174,21 +174,21 @@ dsfr-data-source "s-browse" (tabular, server-side, 15/p) --> dsfr-data-normalize
             value="total"
             label="Maires en France"
             icon="ri-government-line"
-            color="bleu">
+            color-token="bleu">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi source="d-femmes"
             value="total"
             label="Femmes maires"
             icon="ri-women-line"
-            color="rouge">
+            color-token="rouge">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi source="d-hommes"
             value="total"
             label="Hommes maires"
             icon="ri-men-line"
-            color="bleu">
+            color-token="bleu">
           </dsfr-data-kpi>
 
 

--- a/guide/guide-exemples-query.html
+++ b/guide/guide-exemples-query.html
@@ -366,7 +366,7 @@
   &lt;dsfr-data-kpi source="src" value="count"
     label="Total des rappels" format="nombre"&gt;&lt;/dsfr-data-kpi&gt;
   &lt;dsfr-data-kpi source="q-alim" value="count"
-    label="Dont alimentaires" format="nombre" color="bleu"&gt;&lt;/dsfr-data-kpi&gt;
+    label="Dont alimentaires" format="nombre" color-token="bleu"&gt;&lt;/dsfr-data-kpi&gt;
 &lt;/div&gt;</pre>
           </div>
         </section>
@@ -392,7 +392,7 @@
   &lt;dsfr-data-kpi source="src" value="count"
     label="Total des rappels" format="nombre"&gt;&lt;/dsfr-data-kpi&gt;
   &lt;dsfr-data-kpi source="q-combine" value="count"
-    label="Alimentaires (Lait)" format="nombre" color="bleu"&gt;&lt;/dsfr-data-kpi&gt;
+    label="Alimentaires (Lait)" format="nombre" color-token="bleu"&gt;&lt;/dsfr-data-kpi&gt;
 &lt;/div&gt;</pre>
           </div>
         </section>
@@ -526,7 +526,7 @@
   &lt;dsfr-data-kpi source="global-stats" value="total:sum"
     label="Total des rappels" format="nombre"&gt;&lt;/dsfr-data-kpi&gt;
   &lt;dsfr-data-kpi source="global-alim" value="total_alim:sum"
-    label="Dont alimentaires" format="nombre" color="bleu"&gt;&lt;/dsfr-data-kpi&gt;
+    label="Dont alimentaires" format="nombre" color-token="bleu"&gt;&lt;/dsfr-data-kpi&gt;
 &lt;/div&gt;
 
 &lt;dsfr-data-list source="browse"

--- a/guide/guide-exemples-search.html
+++ b/guide/guide-exemples-search.html
@@ -187,7 +187,7 @@
 
 &lt;div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 1rem;"&gt;
   &lt;dsfr-data-kpi source="searched" value="count"
-    label="Projets" color="bleu"&gt;&lt;/dsfr-data-kpi&gt;
+    label="Projets" color-token="bleu"&gt;&lt;/dsfr-data-kpi&gt;
   &lt;dsfr-data-kpi source="searched" value="montant_investissement:sum"
     label="Investissement total" format="euro"&gt;&lt;/dsfr-data-kpi&gt;
   &lt;dsfr-data-kpi source="searched" value="nombre_beneficiaires:sum"

--- a/guide/guide-exemples-source.html
+++ b/guide/guide-exemples-source.html
@@ -229,7 +229,7 @@
   &lt;dsfr-data-kpi source="data" value="nombre_beneficiaires:avg"
     label="Moyenne" format="decimal"&gt;&lt;/dsfr-data-kpi&gt;
   &lt;dsfr-data-kpi source="data" value="montant_investissement:max"
-    label="Investissement max" format="euro" color="vert"&gt;&lt;/dsfr-data-kpi&gt;
+    label="Investissement max" format="euro" color-token="vert"&gt;&lt;/dsfr-data-kpi&gt;
   &lt;dsfr-data-kpi source="data" value="count"
     label="Enregistrements" format="nombre"&gt;&lt;/dsfr-data-kpi&gt;
 &lt;/div&gt;</pre>

--- a/guide/guide-exemples-world-map.html
+++ b/guide/guide-exemples-world-map.html
@@ -153,7 +153,7 @@ dsfr-data-source "src-pays"                         --> dsfr-data-kpi (count pay
             label="Valeur exportee (Mds)"
             format="decimal"
             icon="ri-money-euro-circle-line"
-            color="bleu">
+            color-token="bleu">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi source="src-global"
@@ -161,7 +161,7 @@ dsfr-data-source "src-pays"                         --> dsfr-data-kpi (count pay
             label="Flux d'exportation (millions)"
             format="decimal"
             icon="ri-exchange-funds-line"
-            color="bleu">
+            color-token="bleu">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi source="src-global"
@@ -169,7 +169,7 @@ dsfr-data-source "src-pays"                         --> dsfr-data-kpi (count pay
             label="Masse totale (Mt)"
             format="decimal"
             icon="ri-scales-3-line"
-            color="bleu">
+            color-token="bleu">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi source="src-pays"
@@ -177,7 +177,7 @@ dsfr-data-source "src-pays"                         --> dsfr-data-kpi (count pay
             label="Pays partenaires"
             format="nombre"
             icon="ri-global-line"
-            color="vert">
+            color-token="vert">
           </dsfr-data-kpi>
         </div>
 
@@ -274,12 +274,12 @@ dsfr-data-source "src-pays"                         --> dsfr-data-kpi (count pay
 &lt;!-- KPIs --&gt;
 &lt;dsfr-data-kpi source="src-global" value="valeur_mds"
   label="Valeur exportee (Mds)" format="decimal"
-  icon="ri-money-euro-circle-line" color="bleu"&gt;
+  icon="ri-money-euro-circle-line" color-token="bleu"&gt;
 &lt;/dsfr-data-kpi&gt;
 
 &lt;dsfr-data-kpi source="src-pays" value="pays:count"
   label="Pays partenaires" format="nombre"
-  icon="ri-global-line" color="vert"&gt;
+  icon="ri-global-line" color-token="vert"&gt;
 &lt;/dsfr-data-kpi&gt;
 
 &lt;!-- Top 15 : bar chart --&gt;

--- a/packages/core/src/components/dsfr-data-kpi.ts
+++ b/packages/core/src/components/dsfr-data-kpi.ts
@@ -121,11 +121,16 @@ export class DsfrDataKpi extends SourceSubscriberMixin(LitElement) {
   @property({ type: Number, attribute: 'seuil-orange' })
   seuilOrange?: number;
 
-  /** Couleur forcée: vert, orange, rouge, bleu */
+  /** Couleur forcée (token sémantique DSFR) : vert, orange, rouge, bleu */
+  @property({ type: String, attribute: 'color-token' })
+  colorToken: KpiColor | '' = '';
+
+  /** @deprecated alias de `color-token` (#367) — le nom `color` évoque l'attribut
+   * de présentation HTML déprécié (faux positif d'audit RGAA 10.1.2) */
   @property({ type: String })
   color: KpiColor | '' = '';
 
-  /** @deprecated alias français de `color` (#300) */
+  /** @deprecated alias français de `color-token` (#300) */
   @property({ type: String })
   couleur: KpiColor | '' = '';
 
@@ -143,7 +148,7 @@ export class DsfrDataKpi extends SourceSubscriberMixin(LitElement) {
     const aliases: Array<[string, string]> = [
       ['valeur', 'value'],
       ['icone', 'icon'],
-      ['couleur', 'color'],
+      ['couleur', 'color-token'],
       ['seuil-vert', 'threshold-green'],
       ['seuil-orange', 'threshold-orange'],
       ['tendance', 'trend'],
@@ -156,9 +161,19 @@ export class DsfrDataKpi extends SourceSubscriberMixin(LitElement) {
     }
   }
 
+  /** Warn-once : `color` déprécié au profit de `color-token` (#367) */
+  private _warnDeprecatedColorAttr() {
+    if (this.hasAttribute('color')) {
+      console.warn(
+        `dsfr-data-kpi: attribut "color" déprécié — utilisez "color-token" (token sémantique DSFR). L'alias sera retiré à la prochaine version majeure (#367)`
+      );
+    }
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this._warnDeprecatedFrenchAttrs();
+    this._warnDeprecatedColorAttr();
     sendWidgetBeacon('dsfr-data-kpi');
   }
 
@@ -171,7 +186,7 @@ export class DsfrDataKpi extends SourceSubscriberMixin(LitElement) {
   }
 
   private _getColor(): KpiColor {
-    const explicitColor = this.color || this.couleur;
+    const explicitColor = this.colorToken || this.color || this.couleur;
     if (explicitColor) return explicitColor;
 
     const value = this._computeValue();

--- a/specs/components/dsfr-data-kpi.html
+++ b/specs/components/dsfr-data-kpi.html
@@ -46,7 +46,7 @@
             <tr><td><code>lines</code></td><td>String (JSON)</td><td>Lignes secondaires entre la valeur et le label. Items : <code>value</code> (expression) ou <code>text</code> (statique), + <code>sign</code>, <code>suffix</code>, <code>color</code> (<code>auto</code> / token DSFR / couleur CSS), <code>na</code></td></tr>
             <tr><td><code>format</code></td><td>String</td><td>Format d'affichage (défaut : <code>nombre</code>)</td></tr>
             <tr><td><code>icon</code></td><td>String</td><td>Classe d'icone Remix Icon (ex: <code>ri-global-line</code>)</td></tr>
-            <tr><td><code>color</code></td><td>String</td><td>Couleur forcee : <code>vert</code>, <code>orange</code>, <code>rouge</code>, <code>bleu</code></td></tr>
+            <tr><td><code>color-token</code></td><td>String</td><td>Couleur forcee (token semantique DSFR) : <code>vert</code>, <code>orange</code>, <code>rouge</code>, <code>bleu</code>. Alias deprecie : <code>color</code></td></tr>
             <tr><td><code>threshold-green</code></td><td>Number</td><td>Seuil au-dessus duquel la couleur est verte</td></tr>
             <tr><td><code>threshold-orange</code></td><td>Number</td><td>Seuil au-dessus duquel la couleur est orange</td></tr>
             <tr><td><code>col</code></td><td>Number</td><td>Largeur en colonnes (1-12), actif uniquement dans un <code>&lt;dsfr-data-kpi-group&gt;</code></td></tr>
@@ -122,27 +122,27 @@
         <section class="demo-section">
           <h3>3. KPI avec comptage conditionnel</h3>
           <div class="kpi-grid">
-            <dsfr-data-kpi source="sites" value="count:statut:actif" label="Sites actifs" icon="ri-checkbox-circle-line" color="vert"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" value="count:statut:inactif" label="Sites inactifs" icon="ri-close-circle-line" color="orange"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" value="count:certificat_valide:false" label="Certificats expires" icon="ri-shield-cross-line" color="rouge"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="count:statut:actif" label="Sites actifs" icon="ri-checkbox-circle-line" color-token="vert"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="count:statut:inactif" label="Sites inactifs" icon="ri-close-circle-line" color-token="orange"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="count:certificat_valide:false" label="Certificats expires" icon="ri-shield-cross-line" color-token="rouge"></dsfr-data-kpi>
           </div>
           <div class="code-block"><pre>&lt;dsfr-data-kpi
   source="sites"
   value="count:statut:actif"
   label="Sites actifs"
   icon="ri-checkbox-circle-line"
-  color="vert"&gt;
+  color-token="vert"&gt;
 &lt;/dsfr-data-kpi&gt;</pre></div>
         </section>
 
         <section class="demo-section">
           <h3>4. KPI avec min/max</h3>
           <div class="kpi-grid">
-            <dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur score RGAA" format="pourcentage" color="vert"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas score RGAA" format="pourcentage" color="rouge"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur score RGAA" format="pourcentage" color-token="vert"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas score RGAA" format="pourcentage" color-token="rouge"></dsfr-data-kpi>
           </div>
-          <div class="code-block"><pre>&lt;dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur score" format="pourcentage" color="vert"&gt;&lt;/dsfr-data-kpi&gt;
-&lt;dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas score" format="pourcentage" color="rouge"&gt;&lt;/dsfr-data-kpi&gt;</pre></div>
+          <div class="code-block"><pre>&lt;dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur score" format="pourcentage" color-token="vert"&gt;&lt;/dsfr-data-kpi&gt;
+&lt;dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas score" format="pourcentage" color-token="rouge"&gt;&lt;/dsfr-data-kpi&gt;</pre></div>
         </section>
 
         <section class="demo-section">
@@ -175,7 +175,7 @@
             <dsfr-data-kpi source="meta" value="total" label="Sites suivis" icon="ri-global-line" format="nombre"></dsfr-data-kpi>
             <dsfr-data-kpi source="sites" value="score_rgaa:avg" label="RGAA moyen" format="pourcentage" threshold-green="80" threshold-orange="50"></dsfr-data-kpi>
             <dsfr-data-kpi source="sites" value="score_dsfr:avg" label="DSFR moyen" format="pourcentage" threshold-green="80" threshold-orange="50"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" value="count:certificat_valide:false" label="Certificats expires" icon="ri-shield-cross-line" color="rouge"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="count:certificat_valide:false" label="Certificats expires" icon="ri-shield-cross-line" color-token="rouge"></dsfr-data-kpi>
           </div>
         </section>
 
@@ -187,7 +187,7 @@
             <dsfr-data-kpi source="meta" value="total" label="Sites suivis" icon="ri-global-line" format="nombre"></dsfr-data-kpi>
             <dsfr-data-kpi source="sites" value="score_rgaa:avg" label="RGAA moyen" format="pourcentage" threshold-green="80" threshold-orange="50"></dsfr-data-kpi>
             <dsfr-data-kpi source="sites" value="score_dsfr:avg" label="DSFR moyen" format="pourcentage" threshold-green="80" threshold-orange="50"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" value="count:certificat_valide:false" label="Certificats expires" icon="ri-shield-cross-line" color="rouge"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="count:certificat_valide:false" label="Certificats expires" icon="ri-shield-cross-line" color-token="rouge"></dsfr-data-kpi>
           </dsfr-data-kpi-group>
           <div class="code-block"><pre>&lt;dsfr-data-kpi-group cols="4"&gt;
   &lt;dsfr-data-kpi source="meta" value="total" label="Sites suivis"&gt;&lt;/dsfr-data-kpi&gt;
@@ -202,7 +202,7 @@
           <dsfr-data-kpi-group>
             <dsfr-data-kpi source="meta" value="total" label="Sites suivis" icon="ri-global-line" format="nombre" col="6"></dsfr-data-kpi>
             <dsfr-data-kpi source="sites" value="score_rgaa:avg" label="RGAA moyen" format="pourcentage" threshold-green="80" threshold-orange="50" col="3"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur RGAA" format="pourcentage" color="vert" col="3"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur RGAA" format="pourcentage" color-token="vert" col="3"></dsfr-data-kpi>
           </dsfr-data-kpi-group>
           <div class="code-block"><pre>&lt;dsfr-data-kpi-group&gt;
   &lt;dsfr-data-kpi source="meta" value="total" label="Sites suivis" col="6"&gt;&lt;/dsfr-data-kpi&gt;
@@ -214,12 +214,12 @@
         <section class="demo-section">
           <h3>9. Espacement large (gap="lg")</h3>
           <dsfr-data-kpi-group cols="2" gap="lg">
-            <dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas RGAA" format="pourcentage" color="rouge"></dsfr-data-kpi>
-            <dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur RGAA" format="pourcentage" color="vert"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas RGAA" format="pourcentage" color-token="rouge"></dsfr-data-kpi>
+            <dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur RGAA" format="pourcentage" color-token="vert"></dsfr-data-kpi>
           </dsfr-data-kpi-group>
           <div class="code-block"><pre>&lt;dsfr-data-kpi-group cols="2" gap="lg"&gt;
-  &lt;dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas RGAA" color="rouge"&gt;&lt;/dsfr-data-kpi&gt;
-  &lt;dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur RGAA" color="vert"&gt;&lt;/dsfr-data-kpi&gt;
+  &lt;dsfr-data-kpi source="sites" value="score_rgaa:min" label="Plus bas RGAA" color-token="rouge"&gt;&lt;/dsfr-data-kpi&gt;
+  &lt;dsfr-data-kpi source="sites" value="score_rgaa:max" label="Meilleur RGAA" color-token="vert"&gt;&lt;/dsfr-data-kpi&gt;
 &lt;/dsfr-data-kpi-group&gt;</pre></div>
         </section>
     </div>

--- a/specs/components/dsfr-data-search.html
+++ b/specs/components/dsfr-data-search.html
@@ -241,7 +241,7 @@
           <dsfr-data-kpi source="industrie-searched"
             value="count"
             label="Projets"
-            color="bleu">
+            color-token="bleu">
           </dsfr-data-kpi>
 
           <dsfr-data-kpi source="industrie-searched"
@@ -279,7 +279,7 @@
   count&gt;
 &lt;/dsfr-data-search&gt;
 
-&lt;dsfr-data-kpi source="searched" value="count" label="Projets" color="bleu"&gt;&lt;/dsfr-data-kpi&gt;
+&lt;dsfr-data-kpi source="searched" value="count" label="Projets" color-token="bleu"&gt;&lt;/dsfr-data-kpi&gt;
 &lt;dsfr-data-kpi source="searched" value="montant_investissement:sum" label="Investissement" format="euro"&gt;&lt;/dsfr-data-kpi&gt;
 
 &lt;dsfr-data-query id="stats" source="searched"

--- a/tests/dsfr-data-kpi.test.ts
+++ b/tests/dsfr-data-kpi.test.ts
@@ -78,6 +78,34 @@ describe('DsfrDataKpi', () => {
   });
 
   describe('_getColor', () => {
+    it('returns forced color when color-token is set (#367)', () => {
+      kpi.colorToken = 'vert';
+      expect((kpi as any)._getColor()).toBe('vert');
+    });
+
+    it('returns forced color when legacy color alias is set (#367)', () => {
+      kpi.color = 'orange';
+      expect((kpi as any)._getColor()).toBe('orange');
+    });
+
+    it('color-token takes precedence over the color alias (#367)', () => {
+      kpi.colorToken = 'vert';
+      kpi.color = 'rouge';
+      expect((kpi as any)._getColor()).toBe('vert');
+    });
+
+    it('falls back to bleu when neither color-token nor color is set (#367)', () => {
+      expect((kpi as any)._getColor()).toBe('bleu');
+    });
+
+    it('warns once about the deprecated color attribute on connect (#367)', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      kpi.setAttribute('color', 'vert');
+      (kpi as any)._warnDeprecatedColorAttr();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('color-token'));
+      warn.mockRestore();
+    });
+
     it('returns forced color when couleur is set', () => {
       kpi.couleur = 'rouge';
       expect((kpi as any)._getColor()).toBe('rouge');


### PR DESCRIPTION
Closes #367.

- Nouvel attribut canonique `color-token` (token sémantique DSFR `vert|orange|rouge|bleu`) — le nom `color` évoquait l'attribut de présentation HTML déprécié (faux positif d'audit RGAA 10.1.2).
- Résolution : `color-token` > `color` > `couleur` (alias #300). Warning de dépréciation (1×/instance) si `color` est utilisé ; retrait planifié pour la prochaine majeure.
- Doc (spec, USER-GUIDE), tous les exemples guide/playground et le skill builder-IA migrés — seul `color-token` est documenté.
- `dsfr-data-map-layer` conserve `color` : il prend une **vraie couleur CSS libre**, pas un token — un renommage serait mensonger.
- Changeset patch inclus.

Validation : 147 fichiers / **3524 tests verts** (dont 5 nouveaux : token seul, alias seul, priorité, défaut, warning) + `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)