### PR TITLE
feat(core): dsfr-data-chart — cibles / objectifs futurs (targets) sur les courbes (#377)

### DIFF
--- a/.changeset/chart-targets.md
+++ b/.changeset/chart-targets.md
@@ -1,0 +1,16 @@
+---
+'dsfr-data': minor
+---
+
+`dsfr-data-chart` : cibles / objectifs futurs sur les courbes (`targets`, #377).
+Trois nouveaux attributs pour les types `line` et `bar-line` : `targets` (JSON —
+échéance, valeur, série, libellé, couleur), `targets-zone` (bande future grisée +
+frontière réalisé/projeté, `"off"` pour désactiver) et `targets-legend` (légende
+« Données historiques / Trajectoire, cible extrapolée », masquable ou
+personnalisable). L'axe X est étendu automatiquement quand l'échéance dépasse
+les données (séries paddées à `null` : trait plein jusqu'au dernier point réel,
+trajectoire pointillée vers un losange à l'échéance), les bornes Y s'élargissent
+si nécessaire, un tooltip DSFR groupé par échéance s'affiche au survol des
+losanges et les cibles sont annoncées dans l'aria-label. Le pipeline d'overlay
+de `reference-lines` (#341) est généralisé (un seul rAF/ResizeObserver/cleanup
+pour les deux familles) sans modifier `chart-reference-lines.ts`.

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -1134,6 +1134,9 @@ ce tableau en format DSFR Chart (tableaux imbriques x/y).
 | code-field | String | \`""\` | type map/map-reg | Champ contenant le code departement ou region (prioritaire sur label-field) |
 | map-highlight | String | \`""\` | non | Departements/regions a surligner |
 | reference-lines | String | \`""\` | non | Lignes de reference (overlay) en JSON. Cartesiens uniquement (line, bar, bar-line, scatter). Chaque item : \`{ axis: "x" ou "y", value (string ou number), label?, color?, dash?, position? }\`. \`axis:"x"\` → ligne verticale a une categorie/date ; \`axis:"y"\` → ligne horizontale a un seuil. Ex : \`reference-lines='[{"axis":"x","value":"2026-02","label":"Lancement","color":"#c9191e","dash":true},{"axis":"y","value":3000,"label":"Objectif"}]'\`. |
+| targets | String | \`""\` | non | Cibles / objectifs futurs (overlay) en JSON. Types line et bar-line uniquement. Chaque item : \`{ x (echeance, string ou number, requis), value (number, requis), series? (nom de dataset ou index, defaut 0), label?, color? }\`. L'axe X est etendu automatiquement si l'echeance depasse les donnees : trait plein jusqu'au dernier point reel, trajectoire pointillee vers un losange a l'echeance, zone future grisee. Ex : \`targets='[{"x":2030,"value":26,"label":"Cible 2030 : 26 %"}]'\`. |
+| targets-zone | String | \`"on"\` | non | Bande grisee + frontiere pointillee realise/projete. \`"off"\` desactive. |
+| targets-legend | String | \`""\` | non | Legende sous le graphe : \`""\` = libelles par defaut (« Donnees historiques » / « Trajectoire, cible extrapolee »), \`"off"\` = masquee, \`'["a","b"]'\` = libelles personnalises. |
 
 ### Attributs par type de graphique
 | Type | Attributs essentiels | Attributs optionnels |

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -48,6 +48,7 @@
         <option value="direct-kpi">KPI — Industrie du futur</option>
         <option value="kpi-barometre">KPI baromètre — titre + évolution (Plan Électrification)</option>
         <option value="chart-reference-lines">Ligne + repères — Immatriculations VE</option>
+        <option value="chart-targets">Ligne + cibles 2030 — Énergies fossiles</option>
         <option value="direct-datalist">Tableau — Maires de France (server-side)</option>
       </optgroup>
       <optgroup label="Pagination serveur">

--- a/apps/playground/src/examples/examples-data.ts
+++ b/apps/playground/src/examples/examples-data.ts
@@ -254,6 +254,42 @@ export const examples: Record<string, string> = {
   </dsfr-data-chart>
 </div>`,
 
+  'chart-targets': `<!--
+  Cibles / objectifs futurs — trajectoire pointillée vers un losange à l'échéance
+  Mode direct : dsfr-data-source (data inline) → dsfr-data-chart (type line)
+  Démontre l'attribut targets (#377) :
+    - l'axe X est étendu automatiquement jusqu'à 2030 (données → 2025)
+    - trait plein jusqu'au dernier point réel, trajectoire pointillée vers le losange
+    - zone future grisée + frontière pointillée (targets-zone="off" pour retirer)
+    - tooltip au survol du losange : toutes les cibles de l'échéance
+    - légende « Données historiques / Trajectoire, cible extrapolée » (targets-legend)
+  Les cibles sont aussi annoncées dans l'aria-label du graphique.
+-->
+
+<div class="fr-container fr-my-4w">
+  <h2>Part des énergies fossiles — cibles 2030</h2>
+
+  <dsfr-data-source id="fossiles" data='[
+    {"annee":"2019","petrole":36.2,"gaz":20.8},
+    {"annee":"2020","petrole":34.5,"gaz":20.1},
+    {"annee":"2021","petrole":35.1,"gaz":20.5},
+    {"annee":"2022","petrole":34.8,"gaz":19.2},
+    {"annee":"2023","petrole":33.9,"gaz":17.8},
+    {"annee":"2024","petrole":32.4,"gaz":16.9},
+    {"annee":"2025","petrole":31.6,"gaz":16.1}
+  ]'></dsfr-data-source>
+
+  <dsfr-data-chart source="fossiles" type="line"
+    label-field="annee" value-fields="petrole,gaz"
+    name='["Pétrole","Gaz naturel"]'
+    unit-tooltip=" %"
+    targets='[
+      {"x":"2030","value":26,"series":0,"label":"Cible 2030 : 26 %"},
+      {"x":"2030","value":12,"series":1}
+    ]'>
+  </dsfr-data-chart>
+</div>`,
+
   'direct-datalist': `<!--
   Tableau — Maires de France (pagination serveur)
   Mode : dsfr-data-source (api-type="tabular", server-side) → dsfr-data-list

--- a/guide/guide-exemples-chart-a11y.html
+++ b/guide/guide-exemples-chart-a11y.html
@@ -142,6 +142,40 @@
           </div>
         </section>
 
+        <!-- Cibles / objectifs futurs -->
+        <h2>Cibles et objectifs futurs</h2>
+        <p>L'attribut <code>targets</code> représente un objectif au-delà des données
+          (types <code>line</code> et <code>bar-line</code>) : l'axe X est étendu jusqu'à
+          l'échéance, une trajectoire pointillée relie le dernier point réel à un losange,
+          la zone future est grisée et une légende « Données historiques / Trajectoire,
+          cible extrapolée » est ajoutée sous le graphe. Le survol du losange affiche un
+          tooltip listant les cibles de toutes les séries à cette échéance. Comme les
+          repères, les cibles sont annoncées dans l'<code>aria-label</code> du graphique
+          pour les lecteurs d'écran.</p>
+
+        <div class="example-container">
+          <dsfr-data-source id="fossiles-guide" data='[{"annee":"2019","part":36.2},{"annee":"2020","part":34.5},{"annee":"2021","part":35.1},{"annee":"2022","part":34.8},{"annee":"2023","part":33.9},{"annee":"2024","part":32.4},{"annee":"2025","part":31.6}]'></dsfr-data-source>
+          <dsfr-data-chart id="guide-targets" source="fossiles-guide" type="line"
+            label-field="annee" value-field="part"
+            name='["Énergies fossiles"]'
+            unit-tooltip=" %"
+            targets='[{"x":"2030","value":26,"label":"Cible 2030 : 26 %"}]'>
+          </dsfr-data-chart>
+        </div>
+
+        <section class="fr-accordion fr-mt-1w">
+          <h3 class="fr-accordion__title"><button class="fr-accordion__btn" aria-expanded="false" aria-controls="code-targets">Code source</button></h3>
+          <div class="fr-collapse" id="code-targets">
+<pre>&lt;dsfr-data-chart id="mon-graph" source="data" type="line"
+  label-field="annee" value-field="part"
+  unit-tooltip=" %"
+  targets='[
+    {"x":"2030","value":26,"label":"Cible 2030 : 26 %"}
+  ]'&gt;
+&lt;/dsfr-data-chart&gt;</pre>
+          </div>
+        </section>
+
         <!-- Avec description -->
         <h2>Avec description textuelle</h2>
         <p>Ajoutez <code>description</code> pour fournir une transcription du graphique :</p>

--- a/packages/core/src/components/dsfr-data-chart.ts
+++ b/packages/core/src/components/dsfr-data-chart.ts
@@ -14,6 +14,22 @@ import {
   referenceLinesAriaSummary,
   type ReferenceLine,
 } from '../utils/chart-reference-lines.js';
+import {
+  parseTargets,
+  isTargetsChartType,
+  padSeriesForTargets,
+  computeTargetGeometries,
+  buildTargetsOverlaySvg,
+  buildTargetTooltip,
+  buildTargetsLegend,
+  parseTargetsLegend,
+  formatTargetValue,
+  targetsAriaSummary,
+  type ChartTarget,
+  type ChartWithDatasetsLike,
+  type TargetsLayout,
+  type TargetMarkerGeometry,
+} from '../utils/chart-targets.js';
 import { escapeHtml, toNumber, isValidDeptCode } from '@dsfr-data/shared/lib';
 
 type DSFRChartType =
@@ -207,18 +223,44 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
   @property({ type: String, attribute: 'reference-lines' })
   referenceLines = '';
 
+  /**
+   * Cibles / objectifs futurs (overlay) au format JSON. Types `line` et
+   * `bar-line` uniquement. Chaque item : `{ x: string|number (échéance,
+   * requis), value: number (requis), series?: string|number (nom de dataset ou
+   * index, défaut 0), label?: string, color?: string }`. L'axe X est étendu
+   * automatiquement si l'échéance est au-delà des données (séries paddées avec
+   * null : trait plein jusqu'au dernier point réel, trajectoire pointillée vers
+   * le losange). Ex : `targets='[{"x":2030,"value":26,"label":"Cible 2030 : 26 %"}]'`.
+   */
+  @property({ type: String })
+  targets = '';
+
+  /** Zone future grisée + frontière pointillée réalisé/projeté. `"off"` désactive. */
+  @property({ type: String, attribute: 'targets-zone' })
+  targetsZone = 'on';
+
+  /**
+   * Légende réalisé/projeté sous le graphe : `""` = libellés par défaut
+   * (« Données historiques » / « Trajectoire, cible extrapolée »), `"off"` =
+   * masquée, `'["a","b"]'` = libellés personnalisés.
+   */
+  @property({ type: String, attribute: 'targets-legend' })
+  targetsLegend = '';
+
   @state()
   private _data: unknown[] = [];
 
   /** Timers differes en vol — annules au disconnect (#305) */
   private _pendingTimers = new Set<number>();
 
-  /** Lignes de reference : poll rAF en cours (annule au disconnect, #341) */
-  private _refOverlayRaf: number | null = null;
-  /** Lignes de reference : observer de resize du canvas (#341) */
-  private _refOverlayResize: ResizeObserver | null = null;
-  /** Lignes de reference : warn-once si l'instance Chart.js reste introuvable */
-  private _refOverlayWarned = false;
+  /** Overlays (reference-lines #341 + targets #377) : poll rAF en cours (annule au disconnect) */
+  private _overlayRaf: number | null = null;
+  /** Overlays : observer de resize du canvas */
+  private _overlayResize: ResizeObserver | null = null;
+  /** Overlays : warn-once si l'instance Chart.js reste introuvable */
+  private _overlayWarned = false;
+  /** Tooltip cible en cours d'affichage (#377) */
+  private _targetTooltipEl: HTMLDivElement | null = null;
 
   /** Attributs poses par la mise a jour incrementale (#305) */
   private _managedChartAttrs = new Set<string>();
@@ -229,15 +271,15 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
     // onSourceData et survivaient au composant
     for (const t of this._pendingTimers) clearTimeout(t);
     this._pendingTimers.clear();
-    this._cleanupReferenceOverlay();
+    this._cleanupChartOverlays();
   }
 
   updated(changed: Map<string, unknown>) {
     super.updated(changed);
-    // Redessine l'overlay de lignes de reference apres chaque rendu (#341).
-    // Chart.js rend de maniere asynchrone → le draw poll en rAF jusqu'a ce que
-    // l'instance soit prete.
-    this._refreshReferenceOverlay();
+    // Redessine les overlays (lignes de reference #341, cibles #377) apres
+    // chaque rendu. Chart.js rend de maniere asynchrone → le draw poll en rAF
+    // jusqu'a ce que l'instance soit prete.
+    this._refreshChartOverlays();
   }
 
   // Light DOM pour les styles DSFR
@@ -318,6 +360,7 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
     labels: string[];
     values: number[];
     values2: number[];
+    allSeries: number[][];
   } {
     const labels: string[] = [];
     const labelIndex = new Map<string, number>();
@@ -355,6 +398,7 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
       labels,
       values,
       values2,
+      allSeries,
     };
   }
 
@@ -366,9 +410,10 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
     labels: string[];
     values: number[];
     values2: number[];
+    allSeries: number[][];
   } {
     if (!this._data || this._data.length === 0) {
-      return { x: '[[]]', y: '[[]]', labels: [], values: [], values2: [] };
+      return { x: '[[]]', y: '[[]]', labels: [], values: [], values2: [], allSeries: [] };
     }
 
     // Tidy/long mode : a single series-key column drives the series dimension.
@@ -400,6 +445,7 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
       labels,
       values,
       values2,
+      allSeries,
     };
   }
 
@@ -457,13 +503,66 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
     return attrs;
   }
 
+  /** Cibles actives : attribut non vide, parse valide, type supporté. */
+  private _activeTargets(): ChartTarget[] {
+    if (!this.targets.trim() || !isTargetsChartType(this.type)) return [];
+    const { targets, error } = parseTargets(this.targets);
+    return error ? [] : targets;
+  }
+
+  /**
+   * Noms de séries à afficher, dans l'ordre des datasets : attribut `name`
+   * (JSON ou simple) prioritaire, sinon noms dérivés des données. Les datasets
+   * de `@gouvfr/dsfr-chart` n'exposent pas de `label`.
+   */
+  private _getDisplaySeriesNames(): string[] {
+    if (this.name) {
+      try {
+        const trimmed = this.name.trim();
+        const parsed: unknown = trimmed.startsWith('[') ? JSON.parse(trimmed) : [trimmed];
+        if (Array.isArray(parsed)) return parsed.map(String);
+      } catch {
+        /* repli sur les noms dérivés des données */
+      }
+    }
+    return this._getSeriesNames();
+  }
+
+  /** Index de dataset visé par une cible (nom de série ou index, défaut 0). */
+  private _targetSeriesIndex(target: ChartTarget): number {
+    if (typeof target.series === 'number') return target.series;
+    if (typeof target.series === 'string') {
+      let i = this._getDisplaySeriesNames().indexOf(target.series);
+      if (i < 0) i = this._getSeriesNames().indexOf(target.series);
+      return i >= 0 ? i : 0;
+    }
+    return 0;
+  }
+
   private _getTypeSpecificAttributes(): {
     attrs: Record<string, string>;
     deferred: Record<string, string>;
   } {
-    const { x, y, yMulti, labels, values, values2 } = this._processData();
+    const { x, y, yMulti, labels, values, allSeries } = this._processData();
     const attrs: Record<string, string> = {};
     const deferred: Record<string, string> = {};
+
+    // Extension de l'axe X pour les cibles au-delà des données (#377) : les
+    // échéances absentes sont ajoutées aux labels, chaque série est paddée
+    // avec null (Chart.js coupe la ligne ; c'est NOTRE segment pointillé qui
+    // rejoint le losange, pas de point parasite dans légende/tooltip natifs).
+    const activeTargets = this._activeTargets();
+    let paddedLabels: unknown[] = labels;
+    let paddedSeries: Array<Array<number | null>> = allSeries;
+    if (activeTargets.length && this._data.length > 0) {
+      const padded = padSeriesForTargets(
+        labels,
+        allSeries,
+        activeTargets.map((t) => t.x)
+      );
+      paddedLabels = padded.labels;
+      paddedSeries = padded.series;
+    }
 
     switch (this.type) {
       case 'gauge': {
@@ -487,9 +586,11 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
       case 'bar-line': {
         // DSFR BarLineChart expects flat arrays (not double-wrapped [[values]])
         // unlike BarChart which uses xparse[0] to unwrap.
-        attrs['x'] = JSON.stringify(labels);
-        attrs['y-bar'] = JSON.stringify(values);
-        attrs['y-line'] = JSON.stringify(values2.length ? values2 : values);
+        attrs['x'] = JSON.stringify(paddedLabels);
+        attrs['y-bar'] = JSON.stringify(paddedSeries[0] ?? values);
+        attrs['y-line'] = JSON.stringify(
+          paddedSeries.length > 1 ? paddedSeries[1] : (paddedSeries[0] ?? values)
+        );
         // BarLineChart uses name-bar/name-line (not name)
         if (this.name) {
           try {
@@ -536,10 +637,64 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
         break;
       }
       default:
-        attrs['x'] = x;
-        // For bar/line/radar with a second séries, combine both into y
-        attrs['y'] = yMulti || y;
+        if (activeTargets.length && this._data.length > 0) {
+          // Re-sérialise depuis les tableaux paddés (mêmes valeurs sinon)
+          attrs['x'] = JSON.stringify([paddedLabels]);
+          attrs['y'] =
+            paddedSeries.length > 1
+              ? JSON.stringify(paddedSeries)
+              : JSON.stringify([paddedSeries[0] ?? []]);
+        } else {
+          attrs['x'] = x;
+          // For bar/line/radar with a second séries, combine both into y
+          attrs['y'] = yMulti || y;
+        }
         break;
+    }
+
+    // Bornes Y élargies automatiquement pour que le losange de cible reste
+    // dans la zone traçable — seulement si l'utilisateur n'a pas fixé les
+    // siennes (#377). Le bar-line a deux axes séparés (y-bar-* / y-line-*).
+    if (activeTargets.length && this._data.length > 0) {
+      const setBound = (
+        attr: string,
+        kind: 'max' | 'min',
+        data: number[],
+        targetVals: number[]
+      ) => {
+        const finite = data.filter((v) => Number.isFinite(v));
+        if (!finite.length || !targetVals.length) return;
+        if (kind === 'max') {
+          const t = Math.max(...targetVals);
+          if (t > Math.max(...finite)) attrs[attr] = String(t);
+        } else {
+          const t = Math.min(...targetVals);
+          if (t < Math.min(...finite)) attrs[attr] = String(t);
+        }
+      };
+      if (this.type === 'bar-line') {
+        const barVals = allSeries[0] ?? [];
+        const lineVals = allSeries.length > 1 ? allSeries[1] : (allSeries[0] ?? []);
+        const barTargets = activeTargets
+          .filter((t) => this._targetSeriesIndex(t) === 0)
+          .map((t) => t.value);
+        const lineTargets = activeTargets
+          .filter((t) => this._targetSeriesIndex(t) !== 0)
+          .map((t) => t.value);
+        if (!this.yMax) {
+          setBound('y-bar-max', 'max', barVals, barTargets);
+          setBound('y-line-max', 'max', lineVals, lineTargets);
+        }
+        if (!this.yMin) {
+          setBound('y-bar-min', 'min', barVals, barTargets);
+          setBound('y-line-min', 'min', lineVals, lineTargets);
+        }
+      } else {
+        const dataValues = allSeries.flat();
+        const targetValues = activeTargets.map((t) => t.value);
+        if (!this.yMax) setBound('y-max', 'max', dataValues, targetValues);
+        if (!this.yMin) setBound('y-min', 'min', dataValues, targetValues);
+      }
     }
 
     if (this.type === 'bar') {
@@ -580,67 +735,100 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
       const { lines } = parseReferenceLines(this.referenceLines);
       if (lines.length) label += `. ${referenceLinesAriaSummary(lines)}`;
     }
+    // Cibles relayées a l'aria-label (overlay SVG aria-hidden, #377)
+    if (this.targets && isTargetsChartType(this.type)) {
+      const { targets } = parseTargets(this.targets);
+      if (targets.length) label += `. ${targetsAriaSummary(targets)}`;
+    }
     return label;
   }
 
-  // --- Lignes de reference (overlay SVG, #341) -------------------------------
+  // --- Overlays SVG : lignes de reference (#341) + cibles (#377) --------------
+  // Pipeline UNIQUE (un seul rAF-poll / ResizeObserver / cleanup) : chaque
+  // famille valide est peinte independamment, les erreurs de config des deux
+  // familles sont jointes par « ; ».
 
-  /** Valide la config et (re)programme le dessin de l'overlay. */
-  private _refreshReferenceOverlay() {
-    if (this._refOverlayRaf !== null) {
-      cancelAnimationFrame(this._refOverlayRaf);
-      this._refOverlayRaf = null;
+  /** Valide les configs et (re)programme le dessin des overlays. */
+  private _refreshChartOverlays() {
+    if (this._overlayRaf !== null) {
+      cancelAnimationFrame(this._overlayRaf);
+      this._overlayRaf = null;
     }
 
-    if (!this.referenceLines.trim()) {
-      this._cleanupReferenceOverlay();
+    const hasRefLines = !!this.referenceLines.trim();
+    const hasTargets = !!this.targets.trim();
+    if (!hasRefLines && !hasTargets) {
+      this._cleanupChartOverlays();
       clearConfigError(this);
       return;
     }
 
-    const { lines, error } = parseReferenceLines(this.referenceLines);
-    if (error) {
-      reportConfigError(this, 'dsfr-data-chart', error);
-      this._removeReferenceOverlay();
-      return;
-    }
-    if (!isCartesianChartType(this.type)) {
-      reportConfigError(
-        this,
-        'dsfr-data-chart',
-        `reference-lines : type "${this.type}" non supporté (cartésiens uniquement : line, bar, bar-line, scatter)`
-      );
-      this._removeReferenceOverlay();
-      return;
+    const errors: string[] = [];
+    let lines: ReferenceLine[] = [];
+    if (hasRefLines) {
+      const parsed = parseReferenceLines(this.referenceLines);
+      if (parsed.error) {
+        errors.push(parsed.error);
+      } else if (!isCartesianChartType(this.type)) {
+        errors.push(
+          `reference-lines : type "${this.type}" non supporté (cartésiens uniquement : line, bar, bar-line, scatter)`
+        );
+      } else {
+        lines = parsed.lines;
+      }
     }
 
-    clearConfigError(this);
-    this._scheduleReferenceDraw(lines, 120);
+    let targets: ChartTarget[] = [];
+    if (hasTargets) {
+      const parsed = parseTargets(this.targets);
+      if (parsed.error) {
+        errors.push(parsed.error);
+      } else if (!isTargetsChartType(this.type)) {
+        errors.push(`targets : type "${this.type}" non supporté (line et bar-line uniquement)`);
+      } else {
+        targets = parsed.targets;
+      }
+    }
+
+    if (errors.length) {
+      reportConfigError(this, 'dsfr-data-chart', errors.join(' ; '));
+    } else {
+      clearConfigError(this);
+    }
+
+    if (!lines.length && !targets.length) {
+      this._removeChartOverlays();
+      return;
+    }
+    this._scheduleOverlayDraw({ lines, targets }, 120);
   }
 
   /** Poll rAF jusqu'a ce que l'instance Chart.js soit prete (chartArea > 0). */
-  private _scheduleReferenceDraw(lines: ReferenceLine[], framesLeft: number) {
+  private _scheduleOverlayDraw(
+    overlays: { lines: ReferenceLine[]; targets: ChartTarget[] },
+    framesLeft: number
+  ) {
     if (typeof requestAnimationFrame === 'undefined') return;
-    this._refOverlayRaf = requestAnimationFrame(() => {
-      this._refOverlayRaf = null;
+    this._overlayRaf = requestAnimationFrame(() => {
+      this._overlayRaf = null;
       if (!this.isConnected) return;
-      if (this._paintReferenceOverlay(lines)) {
-        this._observeReferenceResize(lines);
+      if (this._paintChartOverlays(overlays)) {
+        this._observeOverlayResize(overlays);
         return;
       }
       if (framesLeft > 0) {
-        this._scheduleReferenceDraw(lines, framesLeft - 1);
-      } else if (!this._refOverlayWarned) {
-        this._refOverlayWarned = true;
+        this._scheduleOverlayDraw(overlays, framesLeft - 1);
+      } else if (!this._overlayWarned) {
+        this._overlayWarned = true;
         console.warn(
-          `dsfr-data-chart[${this.id}]: instance Chart.js introuvable, lignes de référence non dessinées`
+          `dsfr-data-chart[${this.id}]: instance Chart.js introuvable, overlays (repères / cibles) non dessinés`
         );
       }
     });
   }
 
   /** Localise le chart rendu + son canvas + le conteneur positionne. */
-  private _resolveOverlayTargets(): {
+  private _resolveOverlayHosts(): {
     container: HTMLElement;
     canvas: HTMLCanvasElement;
     chartEl: HTMLElement;
@@ -656,63 +844,173 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
     return { container, canvas, chartEl };
   }
 
-  /** Dessine l'overlay. Retourne false si l'instance Chart.js n'est pas prete. */
-  private _paintReferenceOverlay(lines: ReferenceLine[]): boolean {
-    const targets = this._resolveOverlayTargets();
-    if (!targets) return false;
-    const { container, canvas, chartEl } = targets;
+  /** Dessine les overlays. Retourne false si l'instance Chart.js n'est pas prete. */
+  private _paintChartOverlays(overlays: {
+    lines: ReferenceLine[];
+    targets: ChartTarget[];
+  }): boolean {
+    const hosts = this._resolveOverlayHosts();
+    if (!hosts) return false;
+    const { container, canvas, chartEl } = hosts;
     const chart = resolveChartInstance(chartEl, canvas);
     if (!chart || !chart.chartArea || chart.chartArea.width <= 0) return false;
 
-    const geometries = computeReferenceGeometries(chart, lines);
-    this._removeReferenceOverlay();
+    this._removeChartOverlays();
 
     const w = canvas.clientWidth || canvas.width || 0;
     const h = canvas.clientHeight || canvas.height || 0;
-    const svg = buildReferenceOverlaySvg(geometries, w, h);
 
-    // Aligner l'overlay sur le canvas dans le conteneur positionne
+    // Aligner chaque overlay sur le canvas dans le conteneur positionne
     const cRect = canvas.getBoundingClientRect();
     const wRect = container.getBoundingClientRect();
-    svg.style.left = `${Math.round(cRect.left - wRect.left)}px`;
-    svg.style.top = `${Math.round(cRect.top - wRect.top)}px`;
     if (getComputedStyle(container).position === 'static') {
       container.style.position = 'relative';
     }
-    container.appendChild(svg);
+    const place = (svg: SVGSVGElement) => {
+      svg.style.left = `${Math.round(cRect.left - wRect.left)}px`;
+      svg.style.top = `${Math.round(cRect.top - wRect.top)}px`;
+      container.appendChild(svg);
+    };
+
+    if (overlays.lines.length) {
+      place(buildReferenceOverlaySvg(computeReferenceGeometries(chart, overlays.lines), w, h));
+    }
+    if (overlays.targets.length) {
+      const layout = computeTargetGeometries(
+        chart as ChartWithDatasetsLike,
+        overlays.targets,
+        this._getDisplaySeriesNames()
+      );
+      const svg = buildTargetsOverlaySvg(layout, w, h, { zone: this.targetsZone !== 'off' });
+      place(svg);
+      this._bindTargetMarkerEvents(svg, layout);
+      this._renderTargetsLegend(layout);
+    }
     return true;
   }
 
-  /** Observe le resize du canvas pour recalculer l'overlay (debounce rAF). */
-  private _observeReferenceResize(lines: ReferenceLine[]) {
+  /** Observe le resize du canvas pour recalculer les overlays (debounce rAF). */
+  private _observeOverlayResize(overlays: { lines: ReferenceLine[]; targets: ChartTarget[] }) {
     if (typeof ResizeObserver === 'undefined') return;
-    const targets = this._resolveOverlayTargets();
-    if (!targets) return;
-    this._refOverlayResize?.disconnect();
+    const hosts = this._resolveOverlayHosts();
+    if (!hosts) return;
+    this._overlayResize?.disconnect();
     let pending = false;
-    this._refOverlayResize = new ResizeObserver(() => {
+    this._overlayResize = new ResizeObserver(() => {
       if (pending) return;
       pending = true;
       requestAnimationFrame(() => {
         pending = false;
-        if (this.isConnected) this._paintReferenceOverlay(lines);
+        if (this.isConnected) this._paintChartOverlays(overlays);
       });
     });
-    this._refOverlayResize.observe(targets.canvas);
+    this._overlayResize.observe(hosts.canvas);
   }
 
-  private _removeReferenceOverlay() {
+  private _removeChartOverlays() {
     this.querySelector('.dsfr-data-chart__reflines')?.remove();
+    this.querySelector('.dsfr-data-chart__targets')?.remove();
+    this.querySelector('.dsfr-data-chart__targets-legend')?.remove();
+    this._hideTargetTooltip();
   }
 
-  private _cleanupReferenceOverlay() {
-    if (this._refOverlayRaf !== null) {
-      cancelAnimationFrame(this._refOverlayRaf);
-      this._refOverlayRaf = null;
+  private _cleanupChartOverlays() {
+    if (this._overlayRaf !== null) {
+      cancelAnimationFrame(this._overlayRaf);
+      this._overlayRaf = null;
     }
-    this._refOverlayResize?.disconnect();
-    this._refOverlayResize = null;
-    this._removeReferenceOverlay();
+    this._overlayResize?.disconnect();
+    this._overlayResize = null;
+    this._removeChartOverlays();
+  }
+
+  // --- Cibles : interactivite (tooltip groupe par echeance, legende, #377) ----
+
+  /** Branche le tooltip sur les losanges (seuls elements pointer-events:auto). */
+  private _bindTargetMarkerEvents(svg: SVGSVGElement, layout: TargetsLayout) {
+    const polygons = svg.querySelectorAll<SVGPolygonElement>('.dsfr-data-chart__target-marker');
+    // buildTargetsOverlaySvg appose un polygon par marker, dans l'ordre du layout
+    polygons.forEach((polygon, i) => {
+      const marker = layout.markers[i];
+      if (!marker) return;
+      polygon.addEventListener('mouseenter', () => this._showTargetTooltip(marker, layout));
+      polygon.addEventListener('mouseleave', () => this._hideTargetTooltip());
+    });
+  }
+
+  /** Unite du tooltip selon la serie : bar-line → index 0 = barres. */
+  private _targetUnitForSeries(seriesIndex: number): string {
+    if (this.type === 'bar-line') {
+      return seriesIndex === 0 ? this.unitTooltipBar : this.unitTooltip;
+    }
+    return this.unitTooltip;
+  }
+
+  /**
+   * Affiche le tooltip DSFR d'une echeance : toutes les cibles de meme `x`,
+   * une ligne par serie. Positionne a droite du losange, bascule a gauche si
+   * depassement, clampe dans le conteneur.
+   */
+  private _showTargetTooltip(marker: TargetMarkerGeometry, layout: TargetsLayout) {
+    this._hideTargetTooltip();
+    const hosts = this._resolveOverlayHosts();
+    if (!hosts) return;
+    const { container } = hosts;
+
+    const key = String(marker.targetX);
+    const group = layout.markers.filter((m) => String(m.targetX) === key);
+    if (!group.length) return;
+
+    const distinctLabels = [...new Set(group.map((m) => m.label).filter(Boolean))];
+    const title = distinctLabels.length === 1 ? (distinctLabels[0] as string) : `Cible ${key}`;
+    const lines = group.map((m) => ({
+      color: m.color,
+      name: m.seriesName,
+      value: formatTargetValue(m.value, this._targetUnitForSeries(m.seriesIndex)),
+    }));
+
+    const tooltip = buildTargetTooltip(title, lines);
+    container.appendChild(tooltip);
+    this._targetTooltipEl = tooltip;
+
+    // Ancre = losange survole, dans le repere du conteneur (offset du SVG)
+    const svg = this.querySelector('.dsfr-data-chart__targets') as SVGSVGElement | null;
+    const svgLeft = svg ? parseFloat(svg.style.left) || 0 : 0;
+    const svgTop = svg ? parseFloat(svg.style.top) || 0 : 0;
+    const anchorX = svgLeft + marker.x;
+    const anchorY = svgTop + marker.y;
+
+    const tw = tooltip.offsetWidth;
+    const th = tooltip.offsetHeight;
+    const cw = container.clientWidth;
+    const ch = container.clientHeight;
+    let left = anchorX + 14;
+    if (left + tw > cw) left = anchorX - tw - 14;
+    left = Math.max(0, Math.min(left, Math.max(0, cw - tw)));
+    let top = anchorY - th / 2;
+    top = Math.max(0, Math.min(top, Math.max(0, ch - th)));
+    tooltip.style.left = `${Math.round(left)}px`;
+    tooltip.style.top = `${Math.round(top)}px`;
+  }
+
+  private _hideTargetTooltip() {
+    this._targetTooltipEl?.remove();
+    this._targetTooltipEl = null;
+  }
+
+  /**
+   * (Re)construit la legende realise/projete sous le graphe. Reconstruite a
+   * chaque paint : survit au watcher Vue `$props` deep qui reconstruit le chart.
+   */
+  private _renderTargetsLegend(layout: TargetsLayout) {
+    this.querySelector('.dsfr-data-chart__targets-legend')?.remove();
+    if (!layout.markers.length) return;
+    const { show, labels } = parseTargetsLegend(this.targetsLegend);
+    if (!show) return;
+    const wrapper = (this.querySelector('.dsfr-data-chart__wrapper') ||
+      this.querySelector('.dsfr-data-chart__databox-wrapper')) as HTMLElement | null;
+    if (!wrapper) return;
+    wrapper.appendChild(buildTargetsLegend(labels));
   }
 
   private _createRawChartElement(

--- a/packages/core/src/utils/chart-targets.ts
+++ b/packages/core/src/utils/chart-targets.ts
@@ -1,0 +1,611 @@
+/**
+ * Cibles / objectifs futurs pour dsfr-data-chart (#377) — logique PURE et testable.
+ *
+ * Représente un objectif lointain (« Cible 2030 : 26 % ») sur une courbe :
+ * trajectoire extrapolée en pointillés depuis le dernier point réel jusqu'à un
+ * losange posé à l'échéance, zone future grisée, étiquette, tooltip et légende.
+ * `@gouvfr/dsfr-chart` (Chart.js bundlé dans un canvas) ne sait tracer ni série
+ * pointillée ni marqueur losange : on décalque l'overlay SVG de #341
+ * (`chart-reference-lines.ts`, non modifié — import de types seulement).
+ *
+ * Aucune dépendance Lit / DOM-bridge : réutilisable et testable hors composant.
+ */
+
+import { DEFAULT_REF_COLOR, type ChartLike } from './chart-reference-lines.js';
+import { formatNumber, formatDecimal } from './formatters.js';
+
+// --- Types --------------------------------------------------------------------
+
+/** Une cible déclarée dans l'attribut `targets` (JSON). */
+export interface ChartTarget {
+  /** Échéance sur l'axe X (ex. `2030` ou `"2030"`). Peut être au-delà des données. */
+  x: string | number;
+  /** Valeur visée à l'échéance. */
+  value: number;
+  /** Série concernée : nom de dataset (`datasets[].label`) ou index. Défaut : 0. */
+  series?: string | number;
+  /** Libellé affiché en pastille et en titre de tooltip (ex. `"Cible 2030 : 26 %"`). */
+  label?: string;
+  /** Couleur CSS. Défaut : couleur de la série, sinon rouge DSFR. */
+  color?: string;
+}
+
+/** Sous-ensemble structurel d'un dataset Chart.js. */
+export interface ChartDatasetLike {
+  label?: string;
+  borderColor?: unknown;
+  data?: unknown[];
+  /** Id de l'échelle Y du dataset (bar-line : `y` pour les barres, `yLine` pour la ligne). */
+  yAxisID?: unknown;
+}
+
+/** ChartLike enrichi des datasets (nécessaire pour résoudre les séries). */
+export interface ChartWithDatasetsLike extends ChartLike {
+  data?: { labels?: unknown[]; datasets?: ChartDatasetLike[] };
+}
+
+/** Géométrie (pixels canvas) d'un losange de cible et de sa trajectoire. */
+export interface TargetMarkerGeometry {
+  /** Position du losange (échéance, valeur cible). */
+  x: number;
+  y: number;
+  /** Départ de la trajectoire pointillée = dernier point réel de la série (null si introuvable). */
+  fromX: number | null;
+  fromY: number | null;
+  color: string;
+  label?: string;
+  /** Position de la pastille (anti-collision verticale par échéance). */
+  labelX: number;
+  labelY: number;
+  /** Échéance brute (pour `data-target-x` et le regroupement tooltip). */
+  targetX: string | number;
+  /** Nom de la série résolue (datasets[].label, sinon `Série N+1`). */
+  seriesName: string;
+  /** Index du dataset résolu (pour choisir l'unité en bar-line). */
+  seriesIndex: number;
+  /** Valeur cible brute (pour le tooltip). */
+  value: number;
+}
+
+/** Frontière réalisé / projeté + bornes de la zone future. */
+export interface TargetsBoundaryGeometry {
+  /** Pixel X du dernier point réel (toutes séries confondues). */
+  x: number;
+  top: number;
+  bottom: number;
+  /** Bord droit de la zone traçable (fin de la bande grisée). */
+  right: number;
+}
+
+/** Sortie de {@link computeTargetGeometries}. */
+export interface TargetsLayout {
+  markers: TargetMarkerGeometry[];
+  boundary: TargetsBoundaryGeometry | null;
+}
+
+// --- Types de graphiques supportés ---------------------------------------------
+
+const TARGETS_TYPES = new Set(['line', 'bar-line']);
+
+/** Les cibles supposent une trajectoire : line et bar-line uniquement. */
+export function isTargetsChartType(type: string): boolean {
+  return TARGETS_TYPES.has(type);
+}
+
+// --- Parsing / validation -------------------------------------------------------
+
+export interface ParseTargetsResult {
+  targets: ChartTarget[];
+  error: string | null;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+/**
+ * Parse et valide l'attribut JSON `targets`. Même contrat que
+ * `parseReferenceLines` : vide → ok ; JSON cassé / pas un tableau / aucun item
+ * valide → `error` renseigné ; items invalides ignorés silencieusement.
+ */
+export function parseTargets(json: string): ParseTargetsResult {
+  const raw = (json || '').trim();
+  if (!raw) return { targets: [], error: null };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { targets: [], error: 'targets : JSON invalide' };
+  }
+  if (!Array.isArray(parsed)) {
+    return { targets: [], error: 'targets : un tableau JSON est attendu' };
+  }
+
+  const targets: ChartTarget[] = [];
+  for (const item of parsed) {
+    if (!isPlainObject(item)) continue;
+    const x = item.x;
+    const validX =
+      (typeof x === 'number' && Number.isFinite(x)) || (typeof x === 'string' && x.length > 0);
+    const value = item.value;
+    if (!validX || typeof value !== 'number' || !Number.isFinite(value)) continue;
+
+    const target: ChartTarget = { x: x as string | number, value };
+    if (typeof item.series === 'string' || typeof item.series === 'number') {
+      target.series = item.series;
+    }
+    if (typeof item.label === 'string') target.label = item.label;
+    if (typeof item.color === 'string' && item.color.trim()) target.color = item.color.trim();
+    targets.push(target);
+  }
+
+  if (targets.length === 0) {
+    return { targets: [], error: 'targets : aucune cible valide (x et value numérique requis)' };
+  }
+  return { targets, error: null };
+}
+
+// --- Extension d'axe -------------------------------------------------------------
+
+/**
+ * Reproduit l'heuristique du natif `@gouvfr/dsfr-chart` qui bascule l'axe X en
+ * échelle linéaire quand le premier label est numérique
+ * (`parseFloat(labels[0]) == labels[0]`). Exposé pour tests/documentation : sur
+ * axe catégoriel, l'écart 2025→2030 vaut UN cran (non proportionnel).
+ */
+export function isNativeLinearAxis(labels: unknown[]): boolean {
+  if (!Array.isArray(labels) || labels.length === 0) return false;
+  const first = labels[0];
+  // eslint-disable-next-line eqeqeq -- décalque volontaire de l'heuristique native (==)
+  return parseFloat(String(first)) == (first as never);
+}
+
+/**
+ * Étend les labels avec les échéances absentes et padde chaque série avec
+ * `null` (Chart.js coupe la ligne, pas d'entrée de légende parasite, le
+ * tooltip natif ignore les points null). PUR : ne mute ni `labels` ni `series`.
+ *
+ * Les échéances ajoutées sont dédupliquées (comparaison `String(x)`), triées
+ * numériquement si toutes numériques, sinon laissées en ordre de déclaration.
+ */
+export function padSeriesForTargets(
+  labels: unknown[],
+  series: number[][],
+  targetXs: Array<string | number>
+): { labels: unknown[]; series: Array<Array<number | null>>; added: Array<string | number> } {
+  const existing = new Set(labels.map((l) => String(l)));
+  const added: Array<string | number> = [];
+  for (const x of targetXs) {
+    const key = String(x);
+    if (existing.has(key)) continue;
+    existing.add(key);
+    added.push(x);
+  }
+  if (added.length > 1 && added.every((x) => Number.isFinite(Number(x)))) {
+    added.sort((a, b) => Number(a) - Number(b));
+  }
+
+  const paddedSeries: Array<Array<number | null>> = series.map((s) => [
+    ...s,
+    ...added.map(() => null),
+  ]);
+  return { labels: [...labels, ...added], series: paddedSeries, added };
+}
+
+// --- Calcul des géométries --------------------------------------------------------
+
+/**
+ * Copie durcie de `pixelForX` (chart-reference-lines.ts) : résout d'abord par
+ * label (échelle catégorielle : Chart.js attend l'index), avec repli
+ * `Number(value)` sur échelle linéaire quand le label est introuvable.
+ */
+function pixelForTargetX(chart: ChartLike, value: string | number): number {
+  const scale = chart.scales?.x;
+  if (!scale?.getPixelForValue) return NaN;
+  if (Array.isArray(chart.data?.labels)) {
+    const idx = chart.data!.labels!.findIndex((l) => String(l) === String(value));
+    if (idx >= 0) return scale.getPixelForValue(value, idx);
+  }
+  const n = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(n) ? scale.getPixelForValue(n) : NaN;
+}
+
+const LABEL_HEIGHT = 18;
+const LABEL_PAD_X = 6;
+const CHAR_WIDTH = 7; // estimation (pas de mesure de texte en logique pure)
+const LABEL_GAP = 2;
+/** Décalage vertical de la pastille au-dessus du losange. */
+const LABEL_OFFSET_Y = 16;
+
+/** Dernier index dont la valeur est non-null / non-undefined. */
+function lastNonNullIndex(data: unknown[] | undefined): number {
+  if (!Array.isArray(data)) return -1;
+  for (let i = data.length - 1; i >= 0; i--) {
+    if (data[i] !== null && data[i] !== undefined) return i;
+  }
+  return -1;
+}
+
+function resolveDataset(
+  datasets: ChartDatasetLike[],
+  series: string | number | undefined,
+  seriesNames: string[]
+): { dataset: ChartDatasetLike; index: number } | null {
+  if (typeof series === 'string') {
+    // Les datasets de @gouvfr/dsfr-chart n'ont pas de `label` : on résout
+    // aussi via les noms de séries connus du composant (même ordre).
+    let idx = datasets.findIndex((d) => d.label === series);
+    if (idx < 0) idx = seriesNames.indexOf(series);
+    return idx >= 0 && datasets[idx] ? { dataset: datasets[idx], index: idx } : null;
+  }
+  const idx = typeof series === 'number' ? series : 0;
+  return datasets[idx] ? { dataset: datasets[idx], index: idx } : null;
+}
+
+/**
+ * Échelle Y du dataset : bar-line utilise des échelles séparées (`y` pour les
+ * barres, `yLine` pour la ligne) reliées par `yAxisID`. Repli sur `y`.
+ */
+function yScaleForDataset(chart: ChartWithDatasetsLike, dataset: ChartDatasetLike) {
+  const id = typeof dataset.yAxisID === 'string' ? dataset.yAxisID : '';
+  return (id && chart.scales?.[id]) || chart.scales?.y;
+}
+
+/**
+ * Calcule la géométrie (pixels canvas) des losanges, trajectoires et de la
+ * frontière réalisé/projeté. Les cibles non résolubles (série introuvable,
+ * pixel NaN ou hors `chartArea`) sont ignorées. `seriesNames` (optionnel)
+ * fournit les noms de séries connus du composant, dans l'ordre des datasets —
+ * les datasets de `@gouvfr/dsfr-chart` n'exposent pas de `label`.
+ */
+export function computeTargetGeometries(
+  chart: ChartWithDatasetsLike,
+  targets: ChartTarget[],
+  seriesNames: string[] = []
+): TargetsLayout {
+  const area = chart.chartArea;
+  if (!area) return { markers: [], boundary: null };
+  const datasets = chart.data?.datasets ?? [];
+  const labels = chart.data?.labels ?? [];
+
+  const markers: TargetMarkerGeometry[] = [];
+
+  for (const target of targets) {
+    const resolved = resolveDataset(datasets, target.series, seriesNames);
+    if (!resolved) continue;
+    const { dataset, index } = resolved;
+    const yScale = yScaleForDataset(chart, dataset);
+
+    const px = pixelForTargetX(chart, target.x);
+    const py = yScale?.getPixelForValue ? yScale.getPixelForValue(target.value) : NaN;
+    if (!Number.isFinite(px) || !Number.isFinite(py)) continue;
+    if (px < area.left - 0.5 || px > area.right + 0.5) continue;
+    if (py < area.top - 0.5 || py > area.bottom + 0.5) continue;
+
+    // Départ de la trajectoire : dernier point réel de la série
+    let fromX: number | null = null;
+    let fromY: number | null = null;
+    const lastIdx = lastNonNullIndex(dataset.data);
+    if (lastIdx >= 0 && lastIdx < labels.length) {
+      const fx = pixelForTargetX(chart, labels[lastIdx] as string | number);
+      const fy = yScale?.getPixelForValue ? yScale.getPixelForValue(dataset.data![lastIdx]) : NaN;
+      if (Number.isFinite(fx) && Number.isFinite(fy)) {
+        fromX = fx;
+        fromY = fy;
+      }
+    }
+
+    const seriesColor =
+      typeof dataset.borderColor === 'string' && dataset.borderColor.trim()
+        ? dataset.borderColor
+        : '';
+    markers.push({
+      x: px,
+      y: py,
+      fromX,
+      fromY,
+      color: target.color || seriesColor || DEFAULT_REF_COLOR,
+      label: target.label,
+      labelX: px,
+      labelY: py - LABEL_OFFSET_Y,
+      targetX: target.x,
+      seriesName: dataset.label || seriesNames[index] || `Série ${index + 1}`,
+      seriesIndex: index,
+      value: target.value,
+    });
+  }
+
+  // Anti-collision verticale des pastilles, par échéance : les étiquettes d'une
+  // même échéance sont empilées vers le haut sans se chevaucher.
+  const byX = new Map<string, TargetMarkerGeometry[]>();
+  for (const m of markers) {
+    const key = String(m.targetX);
+    if (!byX.has(key)) byX.set(key, []);
+    byX.get(key)!.push(m);
+  }
+  for (const group of byX.values()) {
+    const sorted = [...group].sort((a, b) => b.y - a.y); // du plus bas au plus haut
+    let ceiling = Infinity;
+    for (const m of sorted) {
+      let ly = m.y - LABEL_OFFSET_Y;
+      if (ly + LABEL_HEIGHT > ceiling) ly = ceiling - LABEL_HEIGHT - LABEL_GAP;
+      m.labelY = ly;
+      ceiling = ly;
+    }
+  }
+
+  // Frontière réalisé/projeté : pixel du plus grand index où AU MOINS un
+  // dataset a une valeur réelle.
+  let boundary: TargetsBoundaryGeometry | null = null;
+  let maxIdx = -1;
+  for (const d of datasets) {
+    maxIdx = Math.max(maxIdx, lastNonNullIndex(d.data));
+  }
+  if (maxIdx >= 0 && maxIdx < labels.length) {
+    const bx = pixelForTargetX(chart, labels[maxIdx] as string | number);
+    if (Number.isFinite(bx)) {
+      boundary = { x: bx, top: area.top, bottom: area.bottom, right: area.right };
+    }
+  }
+
+  return { markers, boundary };
+}
+
+// --- Génération de l'overlay SVG ---------------------------------------------------
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+/** Demi-diagonale du losange (losange de 12px). */
+const MARKER_HALF = 6;
+/** Gris de la zone future et de la frontière. */
+const FUTURE_ZONE_COLOR = '#666666';
+
+function pastilleWidth(label: string): number {
+  return label.length * CHAR_WIDTH + LABEL_PAD_X * 2;
+}
+
+/**
+ * Construit l'overlay SVG des cibles : zone future grisée, frontière
+ * réalisé/projeté, trajectoires pointillées, losanges et pastilles.
+ * SVG racine `aria-hidden` + `pointer-events:none` ; seuls les losanges
+ * (`.dsfr-data-chart__target-marker`) captent le pointeur (tooltip, étape C).
+ * L'info est relayée dans l'aria-label du wrapper via {@link targetsAriaSummary}.
+ */
+export function buildTargetsOverlaySvg(
+  layout: TargetsLayout,
+  width: number,
+  height: number,
+  options: { zone: boolean } = { zone: true }
+): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('class', 'dsfr-data-chart__targets');
+  svg.setAttribute('width', String(width));
+  svg.setAttribute('height', String(height));
+  svg.setAttribute('aria-hidden', 'true');
+  svg.style.position = 'absolute';
+  svg.style.pointerEvents = 'none';
+  svg.style.overflow = 'visible';
+
+  const { markers, boundary } = layout;
+
+  // 1. Zone future grisée (du dernier point réel au bord droit)
+  if (options.zone && boundary && boundary.right > boundary.x) {
+    const rect = document.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('class', 'dsfr-data-chart__targets-zone');
+    rect.setAttribute('x', String(boundary.x));
+    rect.setAttribute('y', String(boundary.top));
+    rect.setAttribute('width', String(boundary.right - boundary.x));
+    rect.setAttribute('height', String(boundary.bottom - boundary.top));
+    rect.setAttribute('fill', FUTURE_ZONE_COLOR);
+    rect.setAttribute('opacity', '0.08');
+    svg.appendChild(rect);
+  }
+
+  // 2. Frontière verticale pointillée réalisé/projeté
+  if (options.zone && boundary) {
+    const line = document.createElementNS(SVG_NS, 'line');
+    line.setAttribute('class', 'dsfr-data-chart__targets-boundary');
+    line.setAttribute('x1', String(boundary.x));
+    line.setAttribute('y1', String(boundary.top));
+    line.setAttribute('x2', String(boundary.x));
+    line.setAttribute('y2', String(boundary.bottom));
+    line.setAttribute('stroke', FUTURE_ZONE_COLOR);
+    line.setAttribute('stroke-width', '1');
+    line.setAttribute('stroke-dasharray', '4,4');
+    svg.appendChild(line);
+  }
+
+  // 3. Trajectoires pointillées (dernier point réel → losange)
+  for (const m of markers) {
+    if (m.fromX === null || m.fromY === null) continue;
+    const line = document.createElementNS(SVG_NS, 'line');
+    line.setAttribute('class', 'dsfr-data-chart__target-path');
+    line.setAttribute('x1', String(m.fromX));
+    line.setAttribute('y1', String(m.fromY));
+    line.setAttribute('x2', String(m.x));
+    line.setAttribute('y2', String(m.y));
+    line.setAttribute('stroke', m.color);
+    line.setAttribute('stroke-width', '2');
+    line.setAttribute('stroke-dasharray', '5,4');
+    svg.appendChild(line);
+  }
+
+  // 4. Losanges (seuls éléments interactifs : pointer-events:auto)
+  for (const m of markers) {
+    const polygon = document.createElementNS(SVG_NS, 'polygon');
+    polygon.setAttribute('class', 'dsfr-data-chart__target-marker');
+    polygon.setAttribute(
+      'points',
+      `${m.x},${m.y - MARKER_HALF} ${m.x + MARKER_HALF},${m.y} ${m.x},${m.y + MARKER_HALF} ${m.x - MARKER_HALF},${m.y}`
+    );
+    polygon.setAttribute('fill', '#ffffff');
+    polygon.setAttribute('stroke', m.color);
+    polygon.setAttribute('stroke-width', '2');
+    polygon.setAttribute('data-target-x', String(m.targetX));
+    polygon.style.pointerEvents = 'auto';
+    svg.appendChild(polygon);
+  }
+
+  // 5. Pastilles
+  for (const m of markers) {
+    if (!m.label) continue;
+    const w = pastilleWidth(m.label);
+    const rectX = Math.max(0, Math.min(m.labelX - w / 2, width - w));
+    const rectY = m.labelY - LABEL_HEIGHT / 2;
+
+    const group = document.createElementNS(SVG_NS, 'g');
+    group.setAttribute('class', 'dsfr-data-chart__target-label');
+
+    const rect = document.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('x', String(rectX));
+    rect.setAttribute('y', String(rectY));
+    rect.setAttribute('width', String(w));
+    rect.setAttribute('height', String(LABEL_HEIGHT));
+    rect.setAttribute('rx', '2');
+    rect.setAttribute('fill', m.color);
+    group.appendChild(rect);
+
+    const text = document.createElementNS(SVG_NS, 'text');
+    text.setAttribute('x', String(rectX + w / 2));
+    text.setAttribute('y', String(rectY + LABEL_HEIGHT / 2));
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('dominant-baseline', 'central');
+    text.setAttribute('fill', '#ffffff');
+    text.setAttribute('font-size', '12');
+    text.textContent = m.label;
+    group.appendChild(text);
+
+    svg.appendChild(group);
+  }
+
+  return svg;
+}
+
+// --- Tooltip / légende (builders purs) ----------------------------------------------
+
+/** Une ligne du tooltip cible (une série à l'échéance survolée). */
+export interface TargetTooltipLine {
+  color: string;
+  name: string;
+  /** Valeur déjà formatée (via {@link formatTargetValue}). */
+  value: string;
+}
+
+/**
+ * Construit le tooltip DSFR d'une échéance (style décalqué de
+ * dsfr-data-world-map). `aria-hidden` : l'info est déjà dans l'aria-label.
+ * Le positionnement est fait par l'appelant (composant).
+ */
+export function buildTargetTooltip(title: string, lines: TargetTooltipLine[]): HTMLDivElement {
+  const tooltip = document.createElement('div');
+  tooltip.className = 'dsfr-data-chart__target-tooltip';
+  tooltip.setAttribute('aria-hidden', 'true');
+  tooltip.style.cssText =
+    'position: absolute; pointer-events: none; z-index: 10;' +
+    'background: var(--background-default-grey, #fff);' +
+    'color: var(--text-default-grey, #161616);' +
+    'border: 1px solid var(--border-default-grey, #ddd);' +
+    'border-radius: 4px; padding: 4px 8px; font-size: 0.8125rem;' +
+    'box-shadow: 0 2px 6px rgba(0,0,0,0.15); white-space: nowrap;';
+
+  const strong = document.createElement('strong');
+  strong.textContent = title;
+  tooltip.appendChild(strong);
+
+  for (const line of lines) {
+    const row = document.createElement('div');
+    row.style.cssText = 'display: flex; align-items: center; gap: 6px; margin-top: 2px;';
+    const swatch = document.createElement('span');
+    swatch.style.cssText =
+      `display: inline-block; width: 10px; height: 10px; border-radius: 2px;` +
+      `background: ${line.color}; flex: none;`;
+    row.appendChild(swatch);
+    const text = document.createElement('span');
+    text.textContent = `${line.name} : ${line.value}`;
+    row.appendChild(text);
+    tooltip.appendChild(row);
+  }
+
+  return tooltip;
+}
+
+export const DEFAULT_TARGETS_LEGEND_HISTORICAL = 'Données historiques';
+export const DEFAULT_TARGETS_LEGEND_PROJECTED = 'Trajectoire, cible extrapolée';
+
+/**
+ * Construit la légende réalisé/projeté affichée sous le graphe.
+ * `aria-hidden` : l'info est relayée par l'aria-label du wrapper.
+ */
+export function buildTargetsLegend(labels: [string, string]): HTMLDivElement {
+  const legend = document.createElement('div');
+  legend.className = 'dsfr-data-chart__targets-legend';
+  legend.setAttribute('aria-hidden', 'true');
+  legend.style.cssText =
+    'display: flex; gap: 1.5rem; justify-content: center; flex-wrap: wrap;' +
+    'margin-top: 0.25rem; font-size: 0.75rem; color: var(--text-mention-grey, #666);';
+
+  const entries: Array<{ dashed: boolean; label: string }> = [
+    { dashed: false, label: labels[0] },
+    { dashed: true, label: labels[1] },
+  ];
+  for (const entry of entries) {
+    const item = document.createElement('span');
+    item.style.cssText = 'display: inline-flex; align-items: center; gap: 6px;';
+    const sample = document.createElement('span');
+    sample.style.cssText =
+      'display: inline-block; width: 24px; border-top: 2px ' +
+      `${entry.dashed ? 'dashed' : 'solid'} currentColor;`;
+    item.appendChild(sample);
+    const text = document.createElement('span');
+    text.textContent = entry.label;
+    item.appendChild(text);
+    legend.appendChild(item);
+  }
+
+  return legend;
+}
+
+/**
+ * Interprète l'attribut `targets-legend` :
+ * - `""` → légende affichée avec les libellés par défaut ;
+ * - `"off"` → masquée ;
+ * - `'["hist","proj"]'` → libellés personnalisés (repli sur les défauts si invalide).
+ */
+export function parseTargetsLegend(attr: string): { show: boolean; labels: [string, string] } {
+  const defaults: [string, string] = [
+    DEFAULT_TARGETS_LEGEND_HISTORICAL,
+    DEFAULT_TARGETS_LEGEND_PROJECTED,
+  ];
+  const raw = (attr || '').trim();
+  if (!raw) return { show: true, labels: defaults };
+  if (raw === 'off') return { show: false, labels: defaults };
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed) && typeof parsed[0] === 'string' && typeof parsed[1] === 'string') {
+      return { show: true, labels: [parsed[0], parsed[1]] };
+    }
+  } catch {
+    /* repli sur les défauts */
+  }
+  return { show: true, labels: defaults };
+}
+
+/**
+ * Formate une valeur de cible pour le tooltip : entier → format nombre
+ * (`37849` → `37 849`), sinon décimal (`26.5` → `26,5`), unité collée par
+ * espace insécable.
+ */
+export function formatTargetValue(value: number, unit?: string): string {
+  const formatted = Number.isInteger(value) ? formatNumber(value) : formatDecimal(value);
+  const trimmed = unit?.trim();
+  return trimmed ? `${formatted}\u00a0${trimmed}` : formatted;
+}
+
+/**
+ * Résumé textuel des cibles, injecté dans l'aria-label du wrapper pour que les
+ * lecteurs d'écran connaissent les objectifs (overlay SVG aria-hidden).
+ */
+export function targetsAriaSummary(targets: ChartTarget[]): string {
+  const parts = targets.map((t) => (t.label ? `Cible : ${t.label}` : `Cible ${t.x} : ${t.value}`));
+  return parts.join('. ');
+}

--- a/specs/components/dsfr-data-chart.html
+++ b/specs/components/dsfr-data-chart.html
@@ -63,6 +63,14 @@
             Chaque item : <code>{ axis: "x"|"y", value, label?, color?, dash?, position? }</code>.
             <code>axis:"x"</code> = ligne verticale à une catégorie/date ; <code>axis:"y"</code> = ligne horizontale à un seuil.
             Ex : <code>reference-lines='[{"axis":"x","value":"2026-02","label":"Lancement","color":"#c9191e","dash":true},{"axis":"y","value":3000,"label":"Objectif"}]'</code>.</td></tr>
+          <tr><td><code>targets</code></td><td>String (JSON)</td><td>Cibles / objectifs futurs (overlay) — types <code>line</code> et <code>bar-line</code> uniquement.
+            Chaque item : <code>{ x (échéance, requis), value (requis), series?, label?, color? }</code>.
+            L'axe X est étendu automatiquement si l'échéance dépasse les données : trait plein jusqu'au dernier
+            point réel, trajectoire pointillée vers un losange à l'échéance, zone future grisée.
+            Ex : <code>targets='[{"x":2030,"value":26,"label":"Cible 2030 : 26 %"}]'</code>.</td></tr>
+          <tr><td><code>targets-zone</code></td><td>String</td><td>Bande grisée + frontière pointillée réalisé/projeté (défaut <code>"on"</code>). <code>"off"</code> désactive.</td></tr>
+          <tr><td><code>targets-legend</code></td><td>String</td><td>Légende sous le graphe : <code>""</code> = libellés par défaut
+            (« Données historiques » / « Trajectoire, cible extrapolée »), <code>"off"</code> = masquée, <code>'["a","b"]'</code> = personnalisés.</td></tr>
         </tbody>
       </table>
 
@@ -180,6 +188,42 @@
   label-field="nom"
   value-field="score_dsfr"
   reference-lines='[{"axis":"y","value":80,"label":"Objectif","color":"#c9191e"}]'&gt;
+&lt;/dsfr-data-chart&gt;</pre></div>
+      </section>
+
+      <section class="demo-section">
+        <h3>3c. Cibles / objectifs futurs (targets)</h3>
+        <p class="fr-text--sm">
+          L'attribut <code>targets</code> représente un objectif lointain : l'axe X est étendu jusqu'à
+          l'échéance, une trajectoire pointillée relie le dernier point réel à un losange, la zone future
+          est grisée et une légende « Données historiques / Trajectoire, cible extrapolée » est ajoutée.
+          Au survol du losange, un tooltip liste les cibles de toutes les séries à cette échéance.
+          Types <code>line</code> et <code>bar-line</code> uniquement — préférer des labels numériques
+          (axe linéaire : l'écart 2025&#8239;&#8594;&#8239;2030 est proportionnel).
+        </p>
+        <dsfr-data-source id="fossiles-spec" data='[
+          {"annee":"2021","part":35.1},
+          {"annee":"2022","part":34.8},
+          {"annee":"2023","part":33.9},
+          {"annee":"2024","part":32.4},
+          {"annee":"2025","part":31.6}
+        ]'></dsfr-data-source>
+        <dsfr-data-chart
+          source="fossiles-spec"
+          type="line"
+          label-field="annee"
+          value-field="part"
+          name='["Énergies fossiles"]'
+          unit-tooltip=" %"
+          targets='[{"x":"2030","value":26,"label":"Cible 2030 : 26 %"}]'>
+        </dsfr-data-chart>
+        <div class="code-block"><pre>&lt;dsfr-data-chart
+  source="fossiles"
+  type="line"
+  label-field="annee"
+  value-field="part"
+  unit-tooltip=" %"
+  targets='[{"x":"2030","value":26,"label":"Cible 2030 : 26 %"}]'&gt;
 &lt;/dsfr-data-chart&gt;</pre></div>
       </section>
 

--- a/tests/apps/playground/examples.test.ts
+++ b/tests/apps/playground/examples.test.ts
@@ -9,6 +9,7 @@ describe('playground examples', () => {
     'direct-kpi',
     'kpi-barometre',
     'chart-reference-lines',
+    'chart-targets',
     'direct-datalist',
     'direct-worldmap',
   ];
@@ -58,8 +59,8 @@ describe('playground examples', () => {
     }
   });
 
-  it('should have 34 examples', () => {
-    expect(Object.keys(examples)).toHaveLength(34);
+  it('should have 35 examples', () => {
+    expect(Object.keys(examples)).toHaveLength(35);
   });
 
   it('should have non-empty code for all examples', () => {

--- a/tests/dsfr-data-chart.test.ts
+++ b/tests/dsfr-data-chart.test.ts
@@ -643,4 +643,277 @@ describe('DsfrDataChart', () => {
       expect((chart as any)._getAriaLabel()).toContain('Lancement');
     });
   });
+
+  describe('targets (#377)', () => {
+    let el: DsfrDataChart;
+
+    afterEach(() => {
+      el?.remove();
+    });
+
+    async function mount(props: Partial<DsfrDataChart>): Promise<DsfrDataChart> {
+      el = new DsfrDataChart();
+      Object.assign(el, props);
+      document.body.appendChild(el);
+      await el.updateComplete;
+      return el;
+    }
+
+    const TARGETS = '[{"x":2030,"value":26,"label":"Cible 2030 : 26 %"}]';
+
+    it('type non supporté (bar) + targets → data-dsfr-config-error', async () => {
+      await mount({ type: 'bar', targets: TARGETS });
+      expect(el.getAttribute('data-dsfr-config-error')).toMatch(/line et bar-line uniquement/);
+    });
+
+    it('JSON invalide → data-dsfr-config-error', async () => {
+      await mount({ type: 'line', targets: '[{bad json}]' });
+      expect(el.getAttribute('data-dsfr-config-error')).toMatch(/JSON invalide/);
+    });
+
+    it('type supporté + JSON valide → pas d erreur de config', async () => {
+      await mount({ type: 'line', targets: TARGETS });
+      expect(el.hasAttribute('data-dsfr-config-error')).toBe(false);
+    });
+
+    it('retrait de targets efface l erreur', async () => {
+      await mount({ type: 'bar', targets: TARGETS });
+      expect(el.hasAttribute('data-dsfr-config-error')).toBe(true);
+      el.targets = '';
+      await el.updateComplete;
+      expect(el.hasAttribute('data-dsfr-config-error')).toBe(false);
+    });
+
+    it('erreurs reference-lines et targets combinées par « ; »', async () => {
+      await mount({
+        type: 'pie',
+        referenceLines: '[{"axis":"y","value":10}]',
+        targets: TARGETS,
+      });
+      const error = el.getAttribute('data-dsfr-config-error') ?? '';
+      expect(error).toMatch(/reference-lines/);
+      expect(error).toMatch(/targets/);
+      expect(error).toContain(' ; ');
+    });
+
+    it('aria-label inclut le libellé de la cible', () => {
+      (chart as any)._data = [{ m: '2025', v: 30 }];
+      chart.type = 'line';
+      chart.labelField = 'm';
+      chart.valueField = 'v';
+      chart.targets = TARGETS;
+      expect((chart as any)._getAriaLabel()).toContain('Cible 2030 : 26 %');
+    });
+
+    describe('extension d axe X (padding des séries)', () => {
+      beforeEach(() => {
+        (chart as any)._data = [
+          { annee: '2024', conso: 30, prod: 12 },
+          { annee: '2025', conso: 27, prod: 14 },
+        ];
+        chart.labelField = 'annee';
+        chart.valueField = 'conso';
+        chart.targets = TARGETS;
+      });
+
+      it('line : x se termine par l échéance, séries paddées par null', () => {
+        chart.type = 'line';
+        chart.valueFields = 'prod';
+        const { attrs } = (chart as any)._getTypeSpecificAttributes();
+        const labels = JSON.parse(attrs['x'])[0];
+        expect(String(labels[labels.length - 1])).toBe('2030');
+        const series = JSON.parse(attrs['y']);
+        expect(series).toHaveLength(2);
+        expect(series[0][series[0].length - 1]).toBeNull();
+        expect(series[1][series[1].length - 1]).toBeNull();
+      });
+
+      it('bar-line : x/y-bar/y-line paddés', () => {
+        chart.type = 'bar-line';
+        chart.valueField2 = 'prod';
+        const { attrs } = (chart as any)._getTypeSpecificAttributes();
+        const labels = JSON.parse(attrs['x']);
+        expect(String(labels[labels.length - 1])).toBe('2030');
+        const yBar = JSON.parse(attrs['y-bar']);
+        const yLine = JSON.parse(attrs['y-line']);
+        expect(yBar[yBar.length - 1]).toBeNull();
+        expect(yLine[yLine.length - 1]).toBeNull();
+        expect(yBar.slice(0, 2)).toEqual([30, 27]);
+        expect(yLine.slice(0, 2)).toEqual([12, 14]);
+      });
+
+      it('pas de padding si l échéance existe déjà dans les labels', () => {
+        chart.type = 'line';
+        (chart as any)._data = [
+          { annee: '2025', conso: 27 },
+          { annee: '2030', conso: 20 },
+        ];
+        const { attrs } = (chart as any)._getTypeSpecificAttributes();
+        expect(JSON.parse(attrs['x'])[0]).toEqual(['2025', '2030']);
+        expect(JSON.parse(attrs['y'])).toEqual([[27, 20]]);
+      });
+
+      it('type non supporté : pas de padding', () => {
+        chart.type = 'bar';
+        const { attrs } = (chart as any)._getTypeSpecificAttributes();
+        expect(JSON.parse(attrs['x'])[0]).toEqual(['2024', '2025']);
+      });
+    });
+
+    describe('bornes Y automatiques', () => {
+      beforeEach(() => {
+        (chart as any)._data = [
+          { annee: '2024', conso: 10 },
+          { annee: '2025', conso: 12 },
+        ];
+        chart.type = 'line';
+        chart.labelField = 'annee';
+        chart.valueField = 'conso';
+      });
+
+      it('y-max posé si la cible dépasse le max des données et yMax vide', () => {
+        chart.targets = '[{"x":2030,"value":26}]';
+        const { attrs } = (chart as any)._getTypeSpecificAttributes();
+        expect(attrs['y-max']).toBe('26');
+      });
+
+      it('y-max non posé si l utilisateur a fixé le sien', () => {
+        chart.targets = '[{"x":2030,"value":26}]';
+        chart.yMax = '40';
+        const { attrs } = (chart as any)._getTypeSpecificAttributes();
+        expect(attrs['y-max']).toBeUndefined();
+      });
+
+      it('y-min posé si la cible est sous le min des données', () => {
+        chart.targets = '[{"x":2030,"value":2}]';
+        const { attrs } = (chart as any)._getTypeSpecificAttributes();
+        expect(attrs['y-min']).toBe('2');
+      });
+
+      it('cible dans la plage : aucune borne posée', () => {
+        chart.targets = '[{"x":2030,"value":11}]';
+        const { attrs } = (chart as any)._getTypeSpecificAttributes();
+        expect(attrs['y-max']).toBeUndefined();
+        expect(attrs['y-min']).toBeUndefined();
+      });
+
+      it('bar-line : bornes par axe (y-bar-max / y-line-max)', () => {
+        chart.type = 'bar-line';
+        (chart as any)._data = [
+          { annee: '2024', conso: 10, prod: 20 },
+          { annee: '2025', conso: 12, prod: 24 },
+        ];
+        chart.valueField2 = 'prod';
+        chart.targets = '[{"x":2030,"value":18,"series":0},{"x":2030,"value":30,"series":1}]';
+        const { attrs } = (chart as any)._getTypeSpecificAttributes();
+        expect(attrs['y-bar-max']).toBe('18');
+        expect(attrs['y-line-max']).toBe('30');
+        expect(attrs['y-max']).toBeUndefined();
+      });
+    });
+
+    describe('_processData expose allSeries', () => {
+      it('mode wide : une entrée par value field', () => {
+        (chart as any)._data = [
+          { cat: 'A', v1: 1, v2: 3 },
+          { cat: 'B', v1: 2, v2: 4 },
+        ];
+        chart.labelField = 'cat';
+        chart.valueFields = 'v1,v2';
+        const { allSeries } = (chart as any)._processData();
+        expect(allSeries).toEqual([
+          [1, 2],
+          [3, 4],
+        ]);
+      });
+
+      it('mode tidy : une entrée par valeur distincte de series-field', () => {
+        (chart as any)._data = [
+          { mois: 'Jan', groupe: 'A', v: 1 },
+          { mois: 'Jan', groupe: 'B', v: 3 },
+          { mois: 'Fev', groupe: 'A', v: 2 },
+        ];
+        chart.labelField = 'mois';
+        chart.seriesField = 'groupe';
+        chart.valueField = 'v';
+        const { allSeries } = (chart as any)._processData();
+        expect(allSeries).toEqual([
+          [1, 2],
+          [3, 0],
+        ]);
+      });
+
+      it('mono-série : allSeries = [values]', () => {
+        (chart as any)._data = [{ cat: 'A', v: 5 }];
+        chart.labelField = 'cat';
+        chart.valueField = 'v';
+        const { allSeries, values } = (chart as any)._processData();
+        expect(allSeries).toEqual([values]);
+      });
+    });
+
+    describe('légende réalisé/projeté (étape C)', () => {
+      const layout = {
+        markers: [
+          {
+            x: 100,
+            y: 50,
+            fromX: 10,
+            fromY: 40,
+            color: '#000091',
+            labelX: 100,
+            labelY: 34,
+            targetX: 2030,
+            seriesName: 'S',
+            seriesIndex: 0,
+            value: 26,
+          },
+        ],
+        boundary: null,
+      };
+
+      async function mountWithWrapper(props: Partial<DsfrDataChart>): Promise<DsfrDataChart> {
+        await mount({ ...props, labelField: 'a', valueField: 'v' });
+        (el as any)._data = [{ a: '2025', v: 1 }];
+        await el.requestUpdate();
+        await el.updateComplete;
+        return el;
+      }
+
+      it('présente sous le wrapper quand des cibles existent', async () => {
+        await mountWithWrapper({ type: 'line', targets: TARGETS });
+        (el as any)._renderTargetsLegend(layout);
+        const legend = el.querySelector(
+          '.dsfr-data-chart__wrapper .dsfr-data-chart__targets-legend'
+        );
+        expect(legend).not.toBeNull();
+        expect(legend!.textContent).toContain('Données historiques');
+        expect(legend!.textContent).toContain('Trajectoire, cible extrapolée');
+      });
+
+      it('targets-legend="off" → absente', async () => {
+        await mountWithWrapper({ type: 'line', targets: TARGETS, targetsLegend: 'off' });
+        (el as any)._renderTargetsLegend(layout);
+        expect(el.querySelector('.dsfr-data-chart__targets-legend')).toBeNull();
+      });
+
+      it('libellés custom via un tableau JSON', async () => {
+        await mountWithWrapper({
+          type: 'line',
+          targets: TARGETS,
+          targetsLegend: '["Réalisé","À venir"]',
+        });
+        (el as any)._renderTargetsLegend(layout);
+        const legend = el.querySelector('.dsfr-data-chart__targets-legend');
+        expect(legend!.textContent).toContain('Réalisé');
+        expect(legend!.textContent).toContain('À venir');
+      });
+
+      it('aucun marker → pas de légende', async () => {
+        await mountWithWrapper({ type: 'line', targets: TARGETS });
+        (el as any)._renderTargetsLegend({ markers: [], boundary: null });
+        expect(el.querySelector('.dsfr-data-chart__targets-legend')).toBeNull();
+      });
+    });
+  });
 });

--- a/tests/utils/chart-targets.test.ts
+++ b/tests/utils/chart-targets.test.ts
@@ -1,0 +1,525 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTargets,
+  isTargetsChartType,
+  isNativeLinearAxis,
+  padSeriesForTargets,
+  computeTargetGeometries,
+  buildTargetsOverlaySvg,
+  buildTargetTooltip,
+  buildTargetsLegend,
+  parseTargetsLegend,
+  formatTargetValue,
+  targetsAriaSummary,
+  DEFAULT_TARGETS_LEGEND_HISTORICAL,
+  DEFAULT_TARGETS_LEGEND_PROJECTED,
+  type ChartWithDatasetsLike,
+  type TargetsLayout,
+} from '@/utils/chart-targets.js';
+import { DEFAULT_REF_COLOR } from '@/utils/chart-reference-lines.js';
+
+// --- Chart.js mock (duck-typé), repris de chart-reference-lines.test.ts et
+// étendu avec `datasets` (une série finissant par null) ------------------------
+
+function mockChart(
+  canvas: HTMLCanvasElement,
+  overrides: Partial<ChartWithDatasetsLike> = {}
+): ChartWithDatasetsLike {
+  return {
+    canvas,
+    chartArea: { left: 50, right: 450, top: 20, bottom: 320, width: 400, height: 300 },
+    data: {
+      labels: ['2023', '2024', '2025', '2030'],
+      datasets: [
+        { label: 'Pétrole', borderColor: '#000091', data: [30, 28, 27, null] },
+        { label: 'Gaz naturel', borderColor: '#e1000f', data: [22, 21, null, null] },
+      ],
+    },
+    scales: {
+      // catégorielle : pixel par index réparti sur [left, right]
+      x: {
+        getPixelForValue: (_v: unknown, i?: number) => {
+          if (typeof i !== 'number' || !Number.isFinite(i)) return NaN;
+          return 50 + (i / 3) * 400; // 4 labels → i ∈ 0..3
+        },
+      },
+      // linéaire : 0..40 → bottom(320)..top(20)
+      y: {
+        getPixelForValue: (v: unknown) => {
+          const n = Number(v);
+          if (!Number.isFinite(n)) return NaN;
+          return 320 - (n / 40) * 300;
+        },
+      },
+    },
+    ...overrides,
+  };
+}
+
+const canvas = () => document.createElement('canvas');
+
+// --- parseTargets ---------------------------------------------------------------
+
+describe('parseTargets', () => {
+  it('vide → pas d erreur, pas de cibles', () => {
+    expect(parseTargets('')).toEqual({ targets: [], error: null });
+    expect(parseTargets('   ')).toEqual({ targets: [], error: null });
+  });
+
+  it('parse un tableau valide avec defaults', () => {
+    const { targets, error } = parseTargets(
+      '[{"x":"2030","value":26,"label":"Cible 2030 : 26 %"},{"x":2035,"value":10,"series":1,"color":"#123456"}]'
+    );
+    expect(error).toBeNull();
+    expect(targets).toHaveLength(2);
+    expect(targets[0]).toMatchObject({ x: '2030', value: 26, label: 'Cible 2030 : 26 %' });
+    expect(targets[1]).toMatchObject({ x: 2035, value: 10, series: 1, color: '#123456' });
+  });
+
+  it('JSON invalide → erreur', () => {
+    const r = parseTargets('[{x:2030}]');
+    expect(r.targets).toEqual([]);
+    expect(r.error).toMatch(/JSON invalide/);
+  });
+
+  it('pas un tableau → erreur', () => {
+    const r = parseTargets('{"x":2030,"value":26}');
+    expect(r.targets).toEqual([]);
+    expect(r.error).toMatch(/tableau JSON/);
+  });
+
+  it('items invalides ignorés, cibles valides conservées', () => {
+    const { targets, error } = parseTargets(
+      '[{"x":"","value":26},{"value":26},{"x":2030},{"x":2030,"value":"26"},{"x":2030,"value":26},42,null]'
+    );
+    expect(error).toBeNull();
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({ x: 2030, value: 26 });
+  });
+
+  it('aucun item valide dans un tableau non vide → erreur', () => {
+    const r = parseTargets('[{"x":2030},{"value":26}]');
+    expect(r.targets).toEqual([]);
+    expect(r.error).toMatch(/aucune cible valide/);
+  });
+});
+
+// --- isTargetsChartType ----------------------------------------------------------
+
+describe('isTargetsChartType', () => {
+  it('line et bar-line uniquement', () => {
+    expect(isTargetsChartType('line')).toBe(true);
+    expect(isTargetsChartType('bar-line')).toBe(true);
+    expect(isTargetsChartType('bar')).toBe(false);
+    expect(isTargetsChartType('scatter')).toBe(false);
+    expect(isTargetsChartType('pie')).toBe(false);
+    expect(isTargetsChartType('gauge')).toBe(false);
+  });
+});
+
+// --- isNativeLinearAxis ------------------------------------------------------------
+
+describe('isNativeLinearAxis', () => {
+  it('labels numériques → linéaire (heuristique native)', () => {
+    expect(isNativeLinearAxis(['2023', '2024'])).toBe(true);
+    expect(isNativeLinearAxis([2023, 2024])).toBe(true);
+  });
+
+  it('labels catégoriels → non linéaire', () => {
+    expect(isNativeLinearAxis(['Jan', 'Fev'])).toBe(false);
+    expect(isNativeLinearAxis([])).toBe(false);
+  });
+});
+
+// --- padSeriesForTargets --------------------------------------------------------------
+
+describe('padSeriesForTargets', () => {
+  it('ajoute les échéances absentes et padde chaque série avec null', () => {
+    const { labels, series, added } = padSeriesForTargets(
+      ['2023', '2024', '2025'],
+      [
+        [30, 28, 27],
+        [22, 21, 20],
+      ],
+      [2030]
+    );
+    expect(labels).toEqual(['2023', '2024', '2025', 2030]);
+    expect(series).toEqual([
+      [30, 28, 27, null],
+      [22, 21, 20, null],
+    ]);
+    expect(added).toEqual([2030]);
+  });
+
+  it('pas de doublon si l échéance existe déjà (comparaison String)', () => {
+    const { labels, series, added } = padSeriesForTargets(['2023', '2030'], [[1, 2]], [2030]);
+    expect(labels).toEqual(['2023', '2030']);
+    expect(series).toEqual([[1, 2]]);
+    expect(added).toEqual([]);
+  });
+
+  it('déduplique et trie numériquement les échéances ajoutées', () => {
+    const { labels, added } = padSeriesForTargets(['2023'], [[1]], [2035, 2030, '2035', 2030]);
+    expect(added).toEqual([2030, 2035]);
+    expect(labels).toEqual(['2023', 2030, 2035]);
+  });
+
+  it('échéances non numériques laissées en ordre de déclaration', () => {
+    const { added } = padSeriesForTargets(['Jan'], [[1]], ['Zeta', 'Alpha']);
+    expect(added).toEqual(['Zeta', 'Alpha']);
+  });
+
+  it('est pur : ne mute pas les entrées', () => {
+    const labels = ['2023'];
+    const series = [[1]];
+    padSeriesForTargets(labels, series, [2030]);
+    expect(labels).toEqual(['2023']);
+    expect(series).toEqual([[1]]);
+  });
+});
+
+// --- computeTargetGeometries -------------------------------------------------------------
+
+describe('computeTargetGeometries', () => {
+  it('place le losange au pixel de l échéance et de la valeur', () => {
+    const chart = mockChart(canvas());
+    const { markers } = computeTargetGeometries(chart, [{ x: '2030', value: 26 }]);
+    expect(markers).toHaveLength(1);
+    expect(markers[0].x).toBeCloseTo(450); // index 3 → right
+    expect(markers[0].y).toBeCloseTo(320 - (26 / 40) * 300);
+  });
+
+  it('trajectoire depuis le dernier point non-null de la série', () => {
+    const chart = mockChart(canvas());
+    const { markers } = computeTargetGeometries(chart, [{ x: '2030', value: 26 }]);
+    // Pétrole (défaut) : dernier non-null à l'index 2 (2025, 27)
+    expect(markers[0].fromX).toBeCloseTo(50 + (2 / 3) * 400);
+    expect(markers[0].fromY).toBeCloseTo(320 - (27 / 40) * 300);
+  });
+
+  it('hérite la couleur de la série, override par la cible', () => {
+    const chart = mockChart(canvas());
+    const { markers } = computeTargetGeometries(chart, [
+      { x: '2030', value: 26 },
+      { x: '2030', value: 12, series: 1, color: '#00ff00' },
+    ]);
+    expect(markers[0].color).toBe('#000091');
+    expect(markers[1].color).toBe('#00ff00');
+  });
+
+  it('résout la série par nom et par index', () => {
+    const chart = mockChart(canvas());
+    const { markers } = computeTargetGeometries(chart, [
+      { x: '2030', value: 12, series: 'Gaz naturel' },
+      { x: '2030', value: 26, series: 0 },
+    ]);
+    expect(markers[0].seriesName).toBe('Gaz naturel');
+    expect(markers[0].seriesIndex).toBe(1);
+    // Gaz naturel : dernier non-null à l'index 1 (2024, 21)
+    expect(markers[0].fromX).toBeCloseTo(50 + (1 / 3) * 400);
+    expect(markers[1].seriesName).toBe('Pétrole');
+  });
+
+  it('série introuvable → cible ignorée', () => {
+    const chart = mockChart(canvas());
+    const { markers } = computeTargetGeometries(chart, [
+      { x: '2030', value: 26, series: 'Charbon' },
+      { x: '2030', value: 26, series: 99 },
+    ]);
+    expect(markers).toEqual([]);
+  });
+
+  it('fallback Number(value) sur échelle linéaire quand le label est absent', () => {
+    const chart = mockChart(canvas(), {
+      data: {
+        labels: ['2023', '2024', '2025'],
+        datasets: [{ label: 'Pétrole', borderColor: '#000091', data: [30, 28, 27] }],
+      },
+      scales: {
+        // linéaire en x : 2020..2032 → left..right
+        x: {
+          getPixelForValue: (v: unknown, i?: number) => {
+            if (typeof i === 'number') return 50 + (i / 2) * 400;
+            const n = Number(v);
+            if (!Number.isFinite(n)) return NaN;
+            return 50 + ((n - 2020) / 12) * 400;
+          },
+        },
+        y: {
+          getPixelForValue: (v: unknown) => 320 - (Number(v) / 40) * 300,
+        },
+      },
+    });
+    const { markers } = computeTargetGeometries(chart, [{ x: 2030, value: 26 }]);
+    expect(markers).toHaveLength(1);
+    expect(markers[0].x).toBeCloseTo(50 + (10 / 12) * 400);
+  });
+
+  it('boundary = pixel du dernier index réel toutes séries confondues', () => {
+    const chart = mockChart(canvas());
+    const { boundary } = computeTargetGeometries(chart, [{ x: '2030', value: 26 }]);
+    // Pétrole va jusqu'à l'index 2, Gaz jusqu'à 1 → max = 2 (2025)
+    expect(boundary).not.toBeNull();
+    expect(boundary!.x).toBeCloseTo(50 + (2 / 3) * 400);
+    expect(boundary!.top).toBe(20);
+    expect(boundary!.bottom).toBe(320);
+    expect(boundary!.right).toBe(450);
+  });
+
+  it('cible hors chartArea ignorée', () => {
+    const chart = mockChart(canvas());
+    const { markers } = computeTargetGeometries(chart, [{ x: '2030', value: 999 }]);
+    expect(markers).toEqual([]);
+  });
+
+  it('résout la série par nom via seriesNames quand les datasets n ont pas de label (dsfr-chart)', () => {
+    const chart = mockChart(canvas(), {
+      data: {
+        labels: ['2023', '2024', '2025', '2030'],
+        datasets: [
+          { borderColor: '#000091', data: [30, 28, 27, null] },
+          { borderColor: '#e1000f', data: [22, 21, null, null] },
+        ],
+      },
+    });
+    const { markers } = computeTargetGeometries(
+      chart,
+      [{ x: '2030', value: 12, series: 'Gaz naturel' }],
+      ['Pétrole', 'Gaz naturel']
+    );
+    expect(markers).toHaveLength(1);
+    expect(markers[0].seriesIndex).toBe(1);
+    expect(markers[0].seriesName).toBe('Gaz naturel');
+  });
+
+  it('utilise l échelle du dataset via yAxisID (bar-line : yLine)', () => {
+    const chart = mockChart(canvas(), {
+      data: {
+        labels: ['2023', '2024', '2025', '2030'],
+        datasets: [
+          { borderColor: '#000091', data: [10, 12, 14, null] }, // barres → y
+          { borderColor: '#e1000f', data: [20, 22, 24, null], yAxisID: 'yLine' },
+        ],
+      },
+      scales: {
+        x: {
+          getPixelForValue: (_v: unknown, i?: number) =>
+            typeof i === 'number' ? 50 + (i / 3) * 400 : NaN,
+        },
+        // y (barres) : 0..15 → bottom..top — 30 serait TRÈS au-dessus
+        y: { getPixelForValue: (v: unknown) => 320 - (Number(v) / 15) * 300 },
+        // yLine : 0..30 → bottom..top
+        yLine: { getPixelForValue: (v: unknown) => 320 - (Number(v) / 30) * 300 },
+      },
+    });
+    const { markers } = computeTargetGeometries(chart, [{ x: '2030', value: 30, series: 1 }]);
+    expect(markers).toHaveLength(1);
+    // 30 sur yLine → top (20) ; sur y il serait à -280 (hors zone, ignoré)
+    expect(markers[0].y).toBeCloseTo(20);
+  });
+
+  it('sans chartArea → layout vide', () => {
+    const chart = mockChart(canvas(), { chartArea: undefined });
+    expect(computeTargetGeometries(chart, [{ x: '2030', value: 26 }])).toEqual({
+      markers: [],
+      boundary: null,
+    });
+  });
+
+  it('anti-collision : deux étiquettes de la même échéance ne se chevauchent pas', () => {
+    const chart = mockChart(canvas());
+    const { markers } = computeTargetGeometries(chart, [
+      { x: '2030', value: 26, label: 'A' },
+      { x: '2030', value: 25, label: 'B' }, // valeurs proches → pastilles en conflit
+    ]);
+    expect(markers).toHaveLength(2);
+    const ys = markers.map((m) => m.labelY).sort((a, b) => a - b);
+    expect(ys[1] - ys[0]).toBeGreaterThanOrEqual(18); // LABEL_HEIGHT
+  });
+});
+
+// --- buildTargetsOverlaySvg ------------------------------------------------------------------
+
+function sampleLayout(): TargetsLayout {
+  return {
+    markers: [
+      {
+        x: 450,
+        y: 125,
+        fromX: 316,
+        fromY: 117.5,
+        color: '#000091',
+        label: 'Cible 2030 : 26 %',
+        labelX: 450,
+        labelY: 109,
+        targetX: '2030',
+        seriesName: 'Pétrole',
+        seriesIndex: 0,
+        value: 26,
+      },
+    ],
+    boundary: { x: 316, top: 20, bottom: 320, right: 450 },
+  };
+}
+
+describe('buildTargetsOverlaySvg', () => {
+  it('SVG racine aria-hidden et pointer-events none', () => {
+    const svg = buildTargetsOverlaySvg(sampleLayout(), 500, 340);
+    expect(svg.getAttribute('aria-hidden')).toBe('true');
+    expect(svg.style.pointerEvents).toBe('none');
+    expect(svg.getAttribute('class')).toBe('dsfr-data-chart__targets');
+  });
+
+  it('losange : pointer-events auto + data-target-x, un polygon par marker', () => {
+    const svg = buildTargetsOverlaySvg(sampleLayout(), 500, 340);
+    const polygons = svg.querySelectorAll('polygon.dsfr-data-chart__target-marker');
+    expect(polygons).toHaveLength(1);
+    const marker = polygons[0] as SVGPolygonElement;
+    expect(marker.style.pointerEvents).toBe('auto');
+    expect(marker.getAttribute('data-target-x')).toBe('2030');
+    expect(marker.getAttribute('fill')).toBe('#ffffff');
+    expect(marker.getAttribute('stroke')).toBe('#000091');
+  });
+
+  it('trajectoire pointillée avec la couleur de la série', () => {
+    const svg = buildTargetsOverlaySvg(sampleLayout(), 500, 340);
+    const path = svg.querySelector('line.dsfr-data-chart__target-path');
+    expect(path).not.toBeNull();
+    expect(path!.getAttribute('stroke-dasharray')).toBe('5,4');
+    expect(path!.getAttribute('stroke')).toBe('#000091');
+  });
+
+  it('pas de trajectoire quand fromX/fromY sont null', () => {
+    const layout = sampleLayout();
+    layout.markers[0].fromX = null;
+    layout.markers[0].fromY = null;
+    const svg = buildTargetsOverlaySvg(layout, 500, 340);
+    expect(svg.querySelector('.dsfr-data-chart__target-path')).toBeNull();
+  });
+
+  it('zone on : rect translucide + frontière pointillée', () => {
+    const svg = buildTargetsOverlaySvg(sampleLayout(), 500, 340, { zone: true });
+    const zone = svg.querySelector('rect.dsfr-data-chart__targets-zone');
+    expect(zone).not.toBeNull();
+    expect(zone!.getAttribute('opacity')).toBe('0.08');
+    expect(Number(zone!.getAttribute('x'))).toBeCloseTo(316);
+    expect(Number(zone!.getAttribute('width'))).toBeCloseTo(450 - 316);
+    const boundary = svg.querySelector('line.dsfr-data-chart__targets-boundary');
+    expect(boundary).not.toBeNull();
+    expect(boundary!.getAttribute('stroke-dasharray')).toBe('4,4');
+  });
+
+  it('zone off : ni rect ni frontière', () => {
+    const svg = buildTargetsOverlaySvg(sampleLayout(), 500, 340, { zone: false });
+    expect(svg.querySelector('.dsfr-data-chart__targets-zone')).toBeNull();
+    expect(svg.querySelector('.dsfr-data-chart__targets-boundary')).toBeNull();
+  });
+
+  it('pastille conditionnelle au label', () => {
+    const withLabel = buildTargetsOverlaySvg(sampleLayout(), 500, 340);
+    expect(withLabel.querySelector('.dsfr-data-chart__target-label')).not.toBeNull();
+    expect(withLabel.querySelector('.dsfr-data-chart__target-label text')!.textContent).toBe(
+      'Cible 2030 : 26 %'
+    );
+
+    const layout = sampleLayout();
+    delete layout.markers[0].label;
+    const withoutLabel = buildTargetsOverlaySvg(layout, 500, 340);
+    expect(withoutLabel.querySelector('.dsfr-data-chart__target-label')).toBeNull();
+  });
+});
+
+// --- Builders tooltip / légende ------------------------------------------------------------------
+
+describe('buildTargetTooltip', () => {
+  it('titre + une ligne par série avec pastille de couleur', () => {
+    const tooltip = buildTargetTooltip('Cible 2030', [
+      { color: '#000091', name: 'Pétrole', value: '26 %' },
+      { color: '#e1000f', name: 'Gaz naturel', value: '12 %' },
+    ]);
+    expect(tooltip.className).toBe('dsfr-data-chart__target-tooltip');
+    expect(tooltip.getAttribute('aria-hidden')).toBe('true');
+    expect(tooltip.querySelector('strong')!.textContent).toBe('Cible 2030');
+    const rows = tooltip.querySelectorAll('div');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].textContent).toContain('Pétrole : 26 %');
+    expect(rows[1].textContent).toContain('Gaz naturel : 12 %');
+  });
+});
+
+describe('buildTargetsLegend', () => {
+  it('deux entrées aria-hidden avec les libellés fournis', () => {
+    const legend = buildTargetsLegend(['Historique', 'Projeté']);
+    expect(legend.className).toBe('dsfr-data-chart__targets-legend');
+    expect(legend.getAttribute('aria-hidden')).toBe('true');
+    expect(legend.textContent).toContain('Historique');
+    expect(legend.textContent).toContain('Projeté');
+  });
+});
+
+describe('parseTargetsLegend', () => {
+  it('vide → visible avec libellés par défaut', () => {
+    expect(parseTargetsLegend('')).toEqual({
+      show: true,
+      labels: [DEFAULT_TARGETS_LEGEND_HISTORICAL, DEFAULT_TARGETS_LEGEND_PROJECTED],
+    });
+  });
+
+  it('off → masquée', () => {
+    expect(parseTargetsLegend('off').show).toBe(false);
+  });
+
+  it('tableau JSON de deux strings → libellés custom', () => {
+    expect(parseTargetsLegend('["Réalisé","À venir"]')).toEqual({
+      show: true,
+      labels: ['Réalisé', 'À venir'],
+    });
+  });
+
+  it('JSON invalide → repli sur les défauts', () => {
+    expect(parseTargetsLegend('[nope')).toEqual({
+      show: true,
+      labels: [DEFAULT_TARGETS_LEGEND_HISTORICAL, DEFAULT_TARGETS_LEGEND_PROJECTED],
+    });
+  });
+});
+
+describe('formatTargetValue', () => {
+  it('entier → format nombre français', () => {
+    // Intl fr-FR utilise l'espace fine insécable comme séparateur de milliers
+    expect(formatTargetValue(37849).replace(/[\u202f\u00a0]/g, ' ')).toBe('37 849');
+  });
+
+  it('décimal → virgule française', () => {
+    expect(formatTargetValue(26.5)).toBe('26,5');
+  });
+
+  it('unité collée par espace insécable', () => {
+    expect(formatTargetValue(26, '%')).toBe('26\u00a0%');
+  });
+});
+
+describe('targetsAriaSummary', () => {
+  it('label prioritaire, sinon x et valeur', () => {
+    const summary = targetsAriaSummary([
+      { x: '2030', value: 26, label: 'Cible 2030 : 26 %' },
+      { x: 2035, value: 10 },
+    ]);
+    expect(summary).toBe('Cible : Cible 2030 : 26 %. Cible 2035 : 10');
+  });
+});
+
+// --- Non-régression : la couleur par défaut vient bien de chart-reference-lines ----
+
+describe('couleur par défaut', () => {
+  it('sans couleur de cible ni de série → rouge DSFR', () => {
+    const chart = mockChart(canvas(), {
+      data: {
+        labels: ['2023', '2030'],
+        datasets: [{ label: 'S', data: [1, null] }],
+      },
+    });
+    const { markers } = computeTargetGeometries(chart, [{ x: '2030', value: 26 }]);
+    expect(markers[0].color).toBe(DEFAULT_REF_COLOR);
+  });
+});


### PR DESCRIPTION
## Epic #377 — réalisée en entier (A + B + C + D)

Closes #377. Closes #378. Closes #379. Closes #380.

Représente un **objectif lointain** (« Cible 2030 : 26 % ») sur une courbe : trait plein jusqu'au dernier point réel, **trajectoire pointillée** vers un **losange** à l'échéance, **zone future grisée** + frontière, **étiquette**, **tooltip groupé** par échéance et **légende** réalisé/projeté — le tout par-dessus le canvas `@gouvfr/dsfr-chart` via l'infrastructure d'overlay SVG de #341 (`chart-reference-lines.ts` **non modifié**, diff vide).

### A — module pur `chart-targets.ts` (#378)
`parseTargets`, `isTargetsChartType`, `isNativeLinearAxis`, `padSeriesForTargets` (extension d'axe pure, séries paddées `null`), `computeTargetGeometries`, `buildTargetsOverlaySvg`, builders tooltip/légende, `formatTargetValue`, `targetsAriaSummary`. **44 tests unitaires.**

### B — intégration `dsfr-data-chart` (#379)
3 attributs (`targets`, `targets-zone`, `targets-legend`), `allSeries` exposé par `_processData`, extension d'axe avant sérialisation (default + bar-line), **bornes Y auto par axe** (bar-line : `y-bar-*` / `y-line-*` en `suggested*`), pipeline d'overlay #341 **généralisé** (un seul rAF/ResizeObserver/cleanup pour les deux familles, erreurs jointes par « ; », chaque famille valide peinte indépendamment), aria-label enrichi, gardes de type.

### C — interactivité (#380)
Tooltip DSFR **groupé par échéance** au survol des losanges (seuls éléments `pointer-events:auto`), unité par série en bar-line, bascule gauche/droite + clamp ; légende sous le graphe (défauts / `off` / libellés custom) ; zone pilotée par `targets-zone`.

### D — écosystème
Skill builder-IA (garde CI `skills.test.ts` verte), exemple playground « Ligne + cibles 2030 — Énergies fossiles », specs, guide a11y, **changeset minor**.

## Découvertes E2E (corrigées)
La validation Playwright sur le playground dev a révélé deux réalités du dsfr-chart absentes des specs :
1. les datasets réels n'ont **pas de `label`** → résolution/affichage des séries via les noms connus du composant (attribut `name`, sinon champs) ;
2. le bar-line a **des axes Y séparés** (`y` barres / `yLine` ligne, reliés par `yAxisID`) → échelle par dataset + bornes auto par axe.

## Validation
- **3590 tests verts** (148 fichiers) dont 44 module + 31 composant nouveaux ; non-régression #341/#305/skills/examples
- `npm run build` + lint (0 erreur) + `format:check` + `check:accents` OK
- **E2E Playwright 18/18 PASS** sur le playground dev : overlay, losanges, trajectoires, zone+frontière, pastille, légende, aria-label, tooltip groupé (affiché/masqué), non-régression reference-lines, **GATE bar-line** (instance Chart.js résolue, ordre datasets `[bar, line]` confirmé, axe étendu à 2030, losange sur `yLine`)
- Rendu conforme à la maquette de l'epic (screenshot vérifié)

⚠️ La branche part du main incluant #367 (`color-token`), comme demandé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)