### PR TITLE
chore(ci): e2e — corrige testDir Playwright (0 test découvert) (#352)

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './e2e',
+  // testDir est résolu relativement à CE fichier (qui vit déjà dans e2e/) :
+  // './e2e' pointait sur e2e/e2e/ (inexistant) → 0 test découvert (#352)
+  testDir: '.',
   timeout: 30_000,
   retries: 0,
   use: {


### PR DESCRIPTION
Closes #352.

`testDir: './e2e'` est résolu **relativement au fichier de config**, qui vit déjà dans `e2e/` → Playwright cherchait `e2e/e2e/` (inexistant) → `Total: 0 tests`.

Fix : `testDir: '.'` (+ commentaire pour éviter la régression).

## Validation
- `--list` : **156 tests découverts dans 12 fichiers** (avant : 0)
- `smoke.spec.ts` (projet chromium) : **12/12 verts** en local (17 s, webServer dev)

NB : aucun workflow CI n'invoque `test:e2e` aujourd'hui — brancher les e2e en CI (browsers, DB pour les `.db.spec`) serait un chantier distinct, non couvert ici.

🤖 Generated with [Claude Code](https://claude.com/claude-code)