### PR TITLE
feat(server): SSO silencieux OIDC via prompt=none (#365)

### DIFF
--- a/.changeset/silent-sso.md
+++ b/.changeset/silent-sso.md
@@ -1,0 +1,10 @@
+---
+'dsfr-data': patch
+---
+
+SSO silencieux OIDC (`prompt=none`, #365) : si un provider OIDC est configuré
+et que la session IdP est active, l'utilisateur est loggué sans clic au
+chargement de l'app (une tentative max par session navigateur, aucun message
+en l'absence de session IdP). Le callback revient sur la page d'origine via
+un `return_to` strictement validé (chemin relatif uniquement). Désactivable
+côté app via `initAuth({ silentSso: false })`.

--- a/packages/shared/src/auth/auth-service.ts
+++ b/packages/shared/src/auth/auth-service.ts
@@ -505,3 +505,41 @@ export async function fetchAuthProviders(): Promise<AuthProvidersResponse> {
     return EMPTY_PROVIDERS;
   }
 }
+
+/** Garde anti-boucle du SSO silencieux : une tentative par session navigateur (#365). */
+const SILENT_SSO_ATTEMPTED_KEY = 'dsfr-data-silent-sso-attempted';
+
+/**
+ * SSO silencieux OIDC (#365) : si un provider OIDC est configuré et que
+ * l'utilisateur n'est pas loggué localement, tente le flux `prompt=none`
+ * via une redirection pleine page.
+ * - Session IdP active → callback → loggué, zéro clic.
+ * - Pas de session → l'IdP renvoie `login_required`, le callback redirige
+ *   vers la page d'origine sans erreur visible.
+ * Garde-fou : UNE tentative par session navigateur (sessionStorage, posé
+ * AVANT la redirection pour couper toute boucle login_required → retry).
+ *
+ * Retourne true si une redirection a été déclenchée (l'appelant peut
+ * s'arrêter là : la page va se décharger).
+ */
+export async function attemptSilentSso(): Promise<boolean> {
+  try {
+    if (sessionStorage.getItem(SILENT_SSO_ATTEMPTED_KEY)) return false;
+  } catch {
+    return false; // sessionStorage indisponible → pas de tentative (aucune garde possible)
+  }
+
+  const { providers } = await fetchAuthProviders();
+  const oidcProvider = providers.find((p) => p.id === 'oidc');
+  if (!oidcProvider) return false;
+
+  try {
+    sessionStorage.setItem(SILENT_SSO_ATTEMPTED_KEY, '1');
+  } catch {
+    return false;
+  }
+
+  const returnTo = window.location.pathname + window.location.search;
+  window.location.href = `${oidcProvider.loginUrl}?silent=1&return_to=${encodeURIComponent(returnTo)}`;
+  return true;
+}

--- a/packages/shared/src/auth/init-auth.ts
+++ b/packages/shared/src/auth/init-auth.ts
@@ -7,7 +7,7 @@
  * so all existing sync writes also sync to the server in background.
  */
 
-import { checkAuth } from './auth-service.js';
+import { checkAuth, attemptSilentSso } from './auth-service.js';
 import { setSaveHook, STORAGE_KEYS } from '../storage/local-storage.js';
 import { ApiStorageAdapter } from '../storage/api-storage-adapter.js';
 import { setStorageAdapter, loadData } from '../storage/storage-provider.js';
@@ -27,10 +27,18 @@ export function getApiAdapter(): ApiStorageAdapter | null {
  * - Hooks saveToStorage for background API sync
  * - Prefetches data from server to update localStorage cache
  */
-export async function initAuth(): Promise<void> {
+export async function initAuth(options: { silentSso?: boolean } = {}): Promise<void> {
   const authState = await checkAuth();
 
-  if (!authState.isAuthenticated) return;
+  if (!authState.isAuthenticated) {
+    // SSO silencieux (#365) : si un provider OIDC est configuré et que la
+    // session IdP est active, loggue sans clic (une tentative max par
+    // session navigateur). Désactivable via initAuth({ silentSso: false }).
+    if (options.silentSso !== false) {
+      await attemptSilentSso();
+    }
+    return;
+  }
 
   _apiAdapter = new ApiStorageAdapter();
   setStorageAdapter(_apiAdapter);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -132,6 +132,7 @@ export {
   getUser,
   isAuthenticated,
   fetchAuthProviders,
+  attemptSilentSso,
   type AuthProvider,
   type AuthProvidersResponse,
 } from './auth/auth-service.js';

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -32,6 +32,8 @@ import {
   OIDC_STATE_COOKIE,
   OIDC_STATE_MAX_AGE_MS,
   OIDC_COOKIE_PATH,
+  OIDC_NO_SESSION_ERRORS,
+  sanitizeReturnTo,
   type OidcStatePayload,
 } from '../utils/oidc.js';
 
@@ -61,6 +63,11 @@ router.get('/providers', (_req, res) => {
  * Kick off the OIDC authorization-code flow with PKCE.
  * Generates state + nonce + code_verifier, stores them in a single signed
  * cookie scoped to /api/auth/oidc, and 302-redirects to the IdP /authorize.
+ *
+ * SSO silencieux (#365) : `?silent=1` ajoute `prompt=none` — l'IdP répond
+ * sans interaction (code si session active, `error=login_required` sinon).
+ * `?return_to=/chemin` (chemin relatif validé) est porté par le cookie
+ * d'état pour revenir sur la page d'origine après le callback.
  */
 router.get('/oidc/login', authLimiter, async (req, res) => {
   if (!isOidcEnabled()) {
@@ -74,8 +81,10 @@ router.get('/oidc/login', authLimiter, async (req, res) => {
     const nonce = oidc.randomNonce();
     const codeVerifier = oidc.randomPKCECodeVerifier();
     const codeChallenge = await oidc.calculatePKCECodeChallenge(codeVerifier);
+    const silent = req.query.silent === '1';
+    const returnTo = sanitizeReturnTo(req.query.return_to);
 
-    const payload: OidcStatePayload = { state, nonce, codeVerifier };
+    const payload: OidcStatePayload = { state, nonce, codeVerifier, returnTo };
     res.cookie(OIDC_STATE_COOKIE, JSON.stringify(payload), {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
@@ -91,6 +100,7 @@ router.get('/oidc/login', authLimiter, async (req, res) => {
       nonce,
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
+      ...(silent ? { prompt: 'none' } : {}),
     });
 
     res.redirect(authUrl.toString());
@@ -123,6 +133,24 @@ router.get('/oidc/callback', authLimiter, async (req, res) => {
 
   const rawCookie = req.cookies?.[OIDC_STATE_COOKIE];
   res.clearCookie(OIDC_STATE_COOKIE, { path: OIDC_COOKIE_PATH });
+
+  // SSO silencieux (#365) : « pas de session IdP » n'est pas une erreur.
+  // L'IdP redirige avec error=login_required & co lors d'un prompt=none sans
+  // session active → retour à l'app sans rien afficher (le front garde son
+  // flag sessionStorage, pas de boucle). Testé AVANT la validation du cookie :
+  // même un cookie absent/expiré ne doit pas transformer ce cas en 400.
+  const idpError = typeof req.query.error === 'string' ? req.query.error : '';
+  if (idpError && OIDC_NO_SESSION_ERRORS.has(idpError)) {
+    await logAudit(req, 'oidc.silent.no_session', undefined, undefined, { error: idpError });
+    let returnTo = '/';
+    try {
+      returnTo = sanitizeReturnTo((JSON.parse(rawCookie ?? '{}') as OidcStatePayload).returnTo);
+    } catch {
+      /* cookie absent ou illisible → '/' */
+    }
+    res.redirect(returnTo);
+    return;
+  }
 
   if (!rawCookie) {
     res.status(400).json({ error: 'Missing OIDC state cookie (expired or third-party blocked)' });
@@ -265,7 +293,8 @@ router.get('/oidc/callback', authLimiter, async (req, res) => {
     await createSession(user.id, token, 'oidc', req);
     await logAudit(req, 'oidc.login.success', 'user', user.id, { issuer });
 
-    res.redirect('/');
+    // Retour sur la page d'origine (SSO silencieux #365) — '/' sinon
+    res.redirect(sanitizeReturnTo(stored.returnTo));
   } catch (err) {
     console.error('[oidc] /callback failed:', err);
     await logAudit(req, 'oidc.callback.error', undefined, undefined, {

--- a/server/src/utils/oidc.ts
+++ b/server/src/utils/oidc.ts
@@ -82,4 +82,29 @@ export interface OidcStatePayload {
   state: string;
   nonce: string;
   codeVerifier: string;
+  /** Chemin relatif où revenir après le callback (SSO silencieux #365). Défaut '/'. */
+  returnTo?: string;
 }
+
+/**
+ * Valide le `return_to` fourni par le front (SSO silencieux #365) : chemin
+ * relatif same-origin uniquement — tout ce qui pourrait produire un open
+ * redirect (URL absolue, protocol-relative `//`, backslash) retombe sur '/'.
+ */
+export function sanitizeReturnTo(value: unknown): string {
+  if (typeof value !== 'string' || !value.startsWith('/')) return '/';
+  if (value.startsWith('//') || value.includes('\\')) return '/';
+  return value;
+}
+
+/**
+ * Erreurs OIDC renvoyées par l'IdP qui signifient « pas de session SSO
+ * active » lors d'une tentative `prompt=none` — à traiter comme un non-login
+ * silencieux, pas comme une erreur (#365).
+ */
+export const OIDC_NO_SESSION_ERRORS = new Set([
+  'login_required',
+  'interaction_required',
+  'consent_required',
+  'account_selection_required',
+]);

--- a/tests/server/oidc.test.ts
+++ b/tests/server/oidc.test.ts
@@ -114,6 +114,52 @@ describe('GET /api/auth/oidc/login', () => {
     const res = await request(app).get('/api/auth/oidc/login');
     expect(res.status).toBe(500);
   });
+
+  // --- SSO silencieux (#365) -------------------------------------------------
+
+  it('?silent=1 ajoute prompt=none à l URL /authorize', async () => {
+    enableOidc();
+    const res = await request(app).get('/api/auth/oidc/login?silent=1');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain('prompt=none');
+  });
+
+  it('sans silent, pas de prompt dans l URL /authorize', async () => {
+    enableOidc();
+    const res = await request(app).get('/api/auth/oidc/login');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).not.toContain('prompt=');
+  });
+
+  it('?return_to relatif est porté par le cookie d état', async () => {
+    enableOidc();
+    const res = await request(app).get(
+      '/api/auth/oidc/login?return_to=%2Fapps%2Fdashboard%2F%3Ftab%3D2'
+    );
+    const setCookie = res.headers['set-cookie'];
+    const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+    const stateCookie = cookies.find((c) => c && c.startsWith(OIDC_STATE_COOKIE)) ?? '';
+    const payload = JSON.parse(
+      decodeURIComponent(stateCookie.split(';')[0].slice(OIDC_STATE_COOKIE.length + 1))
+    );
+    expect(payload.returnTo).toBe('/apps/dashboard/?tab=2');
+  });
+
+  it('return_to non relatif (open redirect) retombe sur /', async () => {
+    enableOidc();
+    for (const evil of ['https://evil.example', '//evil.example', '/valid\\..\\evil']) {
+      const res = await request(app).get(
+        `/api/auth/oidc/login?return_to=${encodeURIComponent(evil)}`
+      );
+      const setCookie = res.headers['set-cookie'];
+      const cookies = Array.isArray(setCookie) ? setCookie : [setCookie];
+      const stateCookie = cookies.find((c) => c && c.startsWith(OIDC_STATE_COOKIE)) ?? '';
+      const payload = JSON.parse(
+        decodeURIComponent(stateCookie.split(';')[0].slice(OIDC_STATE_COOKIE.length + 1))
+      );
+      expect(payload.returnTo).toBe('/');
+    }
+  });
 });
 
 describe('GET /api/auth/oidc/callback', () => {
@@ -129,6 +175,68 @@ describe('GET /api/auth/oidc/callback', () => {
   it('returns 404 when OIDC is not enabled', async () => {
     const res = await request(app).get('/api/auth/oidc/callback?code=x&state=y');
     expect(res.status).toBe(404);
+  });
+
+  // --- SSO silencieux (#365) : erreurs « pas de session IdP » ----------------
+
+  it.each([
+    'login_required',
+    'interaction_required',
+    'consent_required',
+    'account_selection_required',
+  ])('error=%s → redirect / silencieux (pas de 400), même sans cookie', async (idpError) => {
+    enableOidc();
+    const res = await request(app).get(`/api/auth/oidc/callback?error=${idpError}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/');
+  });
+
+  it('error=login_required avec cookie → redirect vers le returnTo stocké', async () => {
+    enableOidc();
+    const cookie = `${OIDC_STATE_COOKIE}=${encodeURIComponent(
+      JSON.stringify({
+        state: 'test-state-xxxxxxxxxxxxxxxx',
+        nonce: 'test-nonce-yyyyyyyyyyyyyyyy',
+        codeVerifier: 'test-pkce-verifier-zzzzzzzzzz',
+        returnTo: '/apps/dashboard/',
+      })
+    )}`;
+    const res = await request(app)
+      .get('/api/auth/oidc/callback?error=login_required')
+      .set('Cookie', cookie);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/apps/dashboard/');
+  });
+
+  it('une vraie erreur OAuth (access_denied) reste une erreur', async () => {
+    enableOidc();
+    const res = await request(app)
+      .get('/api/auth/oidc/callback?error=access_denied')
+      .set('Cookie', VALID_STATE_COOKIE);
+    expect(res.status).toBe(400);
+  });
+
+  it('login réussi → redirect vers le returnTo stocké dans le cookie', async () => {
+    enableOidc();
+    idTokenClaims.mockReturnValue({
+      sub: 'idp-sub-returnto',
+      email: 'return.to@example.com',
+      email_verified: true,
+      name: 'Return To',
+    });
+    const cookie = `${OIDC_STATE_COOKIE}=${encodeURIComponent(
+      JSON.stringify({
+        state: 'test-state-xxxxxxxxxxxxxxxx',
+        nonce: 'test-nonce-yyyyyyyyyyyyyyyy',
+        codeVerifier: 'test-pkce-verifier-zzzzzzzzzz',
+        returnTo: '/apps/sources/',
+      })
+    )}`;
+    const res = await request(app)
+      .get('/api/auth/oidc/callback?code=x&state=test-state-xxxxxxxxxxxxxxxx')
+      .set('Cookie', cookie);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/apps/sources/');
   });
 
   it('returns 400 when the state cookie is missing', async () => {
@@ -266,8 +374,10 @@ describe('GET /api/auth/oidc/callback', () => {
     );
     expect(user?.auth_provider).toBe('local');
 
+    // logAudit range le requérant (non authentifié → NULL) dans user_id et la
+    // cible dans target_id — c'est donc target_id qu'il faut interroger.
     const audit = await queryOne<{ action: string }>(
-      'SELECT action FROM audit_log WHERE user_id = ? ORDER BY id DESC LIMIT 1',
+      'SELECT action FROM audit_log WHERE target_id = ? ORDER BY id DESC LIMIT 1',
       ['user-existing-2']
     );
     expect(audit?.action).toBe('oidc.callback.denied_unverified_email');

--- a/tests/shared/auth-service.test.ts
+++ b/tests/shared/auth-service.test.ts
@@ -10,6 +10,7 @@ import {
   isAuthenticated,
   getAuthState,
   onAuthChange,
+  attemptSilentSso,
 } from '../../packages/shared/src/auth/auth-service';
 
 describe('AuthService', () => {
@@ -326,6 +327,47 @@ describe('AuthService', () => {
       expect(state.isLoading).toBe(true);
       expect(state.user).toBeNull();
       expect(state.isAuthenticated).toBe(false);
+    });
+  });
+
+  describe('attemptSilentSso (#365)', () => {
+    const OIDC_PROVIDERS = {
+      ok: true,
+      json: async () => ({
+        providers: [{ id: 'oidc', label: 'SSO', loginUrl: '/api/auth/oidc/login' }],
+        oidcOnly: false,
+      }),
+    };
+
+    beforeEach(() => {
+      sessionStorage.clear();
+    });
+
+    it('aucun provider OIDC → false, pas de flag posé', async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue({ ok: true, json: async () => ({ providers: [], oidcOnly: false }) });
+      expect(await attemptSilentSso()).toBe(false);
+      expect(sessionStorage.getItem('dsfr-data-silent-sso-attempted')).toBeNull();
+    });
+
+    it('provider OIDC présent → pose le flag AVANT la redirection et retourne true', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(OIDC_PROVIDERS);
+      expect(await attemptSilentSso()).toBe(true);
+      expect(sessionStorage.getItem('dsfr-data-silent-sso-attempted')).toBe('1');
+    });
+
+    it('garde anti-boucle : une seule tentative par session navigateur', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue(OIDC_PROVIDERS);
+      expect(await attemptSilentSso()).toBe(true);
+      expect(await attemptSilentSso()).toBe(false);
+      // le second appel ne refait même pas l'appel réseau
+      expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('backend injoignable → false, silencieux', async () => {
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+      expect(await attemptSilentSso()).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Closes #365.

Si l'utilisateur a une session active sur l'IdP (Authentik), il est loggué **sans clic** au chargement de l'app ; sinon, retour silencieux à la page (aucune erreur visible), le flux interactif restant le défaut.

## Backend (`server/`)
- `/oidc/login?silent=1` → `prompt=none` dans l'URL `/authorize`
- `/oidc/callback` : `error ∈ {login_required, interaction_required, consent_required, account_selection_required}` = « pas de session IdP » → **redirect silencieux** (testé avant la validation du cookie d'état, pour qu'un cookie expiré ne transforme pas ce cas en 400) ; `access_denied` et les vraies erreurs OAuth restent des erreurs
- **`return_to`** (ajout par rapport à l'issue) : sans lui, tout login silencieux téléportait l'utilisateur sur le hub `/`. Chemin relatif **strictement validé** (`sanitizeReturnTo` : refuse URL absolue, `//`, backslash → pas d'open redirect), porté par le cookie d'état, utilisé au succès comme en cas d'absence de session. Bénéficie aussi au flux interactif.

## Front (`packages/shared`)
- `attemptSilentSso()` : une tentative **max par session navigateur** (flag `sessionStorage` posé *avant* la redirection — coupe toute boucle `login_required` → retry), déclenchée par `initAuth()` quand non authentifié. Opt-out par app : `initAuth({ silentSso: false })`. Aucun effet si pas de provider OIDC ou backend injoignable (statique).

## Tests
- **+11 server** (`tests/server/oidc.test.ts`, 30/30 sur MariaDB locale) : `prompt=none`, `return_to` porté par le cookie, tentatives d'open redirect → `/`, les 4 erreurs no-session → 302 silencieux (avec et sans cookie), `access_denied` → 400, succès → `return_to`
- **+4 front** (`tests/shared/auth-service.test.ts`) : garde anti-boucle, flag, provider absent, réseau KO
- Fix au passage d'un test préexistant cassé (`anti-takeover` interrogeait `audit_log.user_id` — NULL pour un requérant non authentifié — au lieu de `target_id`)
- Suite complète racine : **3594 tests verts** ; typecheck/lint/format OK ; changeset patch

## Limite connue
La validation bout-en-bout réelle (session Authentik active → login zéro clic) ne peut se faire qu'en déployé — à vérifier sur `chartsbuilder.miweb.run` après release. NB : les tests server ne tournent pas en CI (pas de service MariaDB dans ci.yml) — validés en local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)