### PR TITLE
feat(core): intégration DSFR Chart 2.1.x — API cartes unifiée level (#402)

### DIFF
--- a/.changeset/databox-name-map-level.md
+++ b/.changeset/databox-name-map-level.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': patch
+---
+
+Alignement DSFR Chart 2.1.x (correctifs) : la DataBox pose désormais `name` (renommage upstream de `title` en 2.1.0 — les titres de DataBox étaient invisibles en preview/prod) tout en conservant `title` pour les hôtes 2.0.x ; les types `map` et `map-reg` routent vers `<map-chart level="dep|reg">` (API cartes unifiée), ce qui corrige la limitation connue de la carte régionale nationale (`<map-chart-reg>` sans `region`).

--- a/.changeset/map-aca-monde.md
+++ b/.changeset/map-aca-monde.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': minor
+---
+
+Nouveaux types de cartes `map-aca` (académies, clés = noms en majuscules) et `map-monde` (mondiale, clés ISO 3166-1 — les codes alpha-3 et numériques sont convertis automatiquement en alpha-2 via `toIsoA2`) sur `dsfr-data-chart`, apportés par l'API cartes unifiée `<map-chart level>` de DSFR Chart 2.1. `dsfr-data-world-map` est déprécié au profit de `type="map-monde"` (warn console ; retrait prévu à la prochaine version majeure, #402).

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@
 
 ```html
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css">
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css">
-<script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css">
+<script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js"></script>
 <script src="https://unpkg.com/dsfr-data/dist/dsfr-data.core.umd.js"></script>
 ```
 
@@ -103,6 +103,12 @@ Pour le detail du monorepo, des conventions, du workflow de release Changesets e
 - [Contribuer](docs/CONTRIBUTING.md) — monorepo, conventions, release Changesets
 - [Fiche produit](docs/DATASHEET.md) — positionnement, comparatif, cibles
 - [Politique de securite](docs/SECURITY.md) + [baseline](docs/security-baseline.md) — signalement, pipeline CI/CD, defenses
+
+## Credits
+
+- Les graphiques et cartes sont rendus par **[DSFR Chart](https://github.com/GouvernementFR/dsfr-chart)** (`@gouvfr/dsfr-chart`), la bibliotheque officielle de datavisualisation de l'Etat — merci a ses mainteneurs. `dsfr-data` se concentre sur la couche **donnees** (sources, requetes, transformations) et delegue le rendu graphique a DSFR Chart, dont il suit les evolutions (API cartes unifiee `level` depuis la 2.1).
+- Le design et les composants d'interface suivent le **[Systeme de design de l'Etat (DSFR)](https://www.systeme-de-design.gouv.fr/)**.
+- Dependances tierces detaillees : [THIRD-PARTY-LICENSES](docs/THIRD-PARTY-LICENSES.md).
 
 ## Licence
 

--- a/apps/builder-ia/index.html
+++ b/apps/builder-ia/index.html
@@ -15,8 +15,8 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
 
   <!-- DSFR Chart (pour les cartes) -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
 
   <!-- Composants dsfr-data -->
   <script type="module" src="../../packages/core/dist/dsfr-data.esm.js"></script>

--- a/apps/builder-ia/src/chat/chat.ts
+++ b/apps/builder-ia/src/chat/chat.ts
@@ -738,6 +738,10 @@ function repairAction(parsed: Record<string, unknown>): Record<string, unknown> 
     map: 'map',
     carte: 'map',
     'map-reg': 'map-reg',
+    'map-aca': 'map-aca',
+    'map-monde': 'map-monde',
+    monde: 'map-monde',
+    world: 'map-monde',
     'bar-line': 'bar-line',
     barline: 'bar-line',
   };

--- a/apps/builder-ia/src/ia/action-schema.ts
+++ b/apps/builder-ia/src/ia/action-schema.ts
@@ -33,6 +33,8 @@ export const CHART_TYPES = [
   'map',
   'bar-line',
   'map-reg',
+  'map-aca',
+  'map-monde',
   'datalist',
   'podium',
 ] as const;

--- a/apps/builder-ia/src/ia/data-tools.ts
+++ b/apps/builder-ia/src/ia/data-tools.ts
@@ -300,8 +300,14 @@ export function diagnoseConfig(config: Partial<ChartConfig>, data: Row[]): Diagn
   if (type === 'datalist' && !config.colonnes) {
     warnings.push('datalist sans "colonnes" : toutes les colonnes seront affichees.');
   }
-  if ((type === 'map' || type === 'map-reg') && !config.codeField && !config.labelField) {
-    errors.push('Carte sans codeField : un champ code INSEE (departement/region) est requis.');
+  if (
+    (type === 'map' || type === 'map-reg' || type === 'map-aca' || type === 'map-monde') &&
+    !config.codeField &&
+    !config.labelField
+  ) {
+    errors.push(
+      'Carte sans codeField : un champ code est requis (INSEE departement/region, nom d academie ou code pays ISO).'
+    );
   }
 
   // 3) Filtre WHERE.

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -65,7 +65,7 @@ Elle est distincte du code embarquable HTML (voir skills composants dsfr-data).
 | labelField | String | selon type | Champ pour les labels / axe X |
 | valueField | String | oui | Champ pour les valeurs / axe Y |
 | valueField2 | String | non | 2e série (bar-line, comparaisons) |
-| codeField | String | non | Champ code departement/region (map, map-reg) |
+| codeField | String | non | Champ code : departement/region (map, map-reg), nom d'academie (map-aca), code pays ISO (map-monde) |
 | aggregation | String | non | Fonction : sum, avg, count, min, max |
 | where | String | non | Filtre pre-agrégation (voir syntaxe ci-dessous) |
 | limit | Number | non | Nombre max de resultats |
@@ -94,13 +94,15 @@ Elle est distincte du code embarquable HTML (voir skills composants dsfr-data).
 | kpi | non | oui | Indicateur chiffre clé unique |
 | map | non (codeField) | oui | Données par departement francais |
 | map-reg | non (codeField) | oui | Données par region francaise |
+| map-aca | non (codeField) | oui | Données par academie (noms en majuscules : PARIS, LYON...) |
+| map-monde | non (codeField) | oui | Données par pays (ISO 3166-1 : FR, US... — a3/num convertis) |
 | datalist | non | non (colonnes) | Tableau de données filtrable |
 
 IMPORTANT :
 - \`doughnut\` = \`pie\` (le composant pie est un anneau par défaut)
 - \`horizontalBar\` = \`bar\` (le renderer le convertit automatiquement)
 - Pour KPI et gauge : PAS de labelField
-- Pour map/map-reg : utiliser codeField (pas labelField)
+- Pour map/map-reg/map-aca/map-monde : utiliser codeField (pas labelField)
 
 ### Syntaxe du filtre (config.where)
 Format : \`"champ:operateur:valeur"\`
@@ -1069,6 +1071,9 @@ Conteneur qui dispose plusieurs \`<dsfr-data-kpi>\` dans une grille CSS 12 colon
       'gauge',
       'departement',
       'region',
+      'academie',
+      'monde',
+      'pays',
       'databox',
       'habillage',
       'encadrer',
@@ -1105,8 +1110,10 @@ ce tableau en format DSFR Chart (tableaux imbriques x/y).
 | scatter | scatter-chart | Nuage de points |
 | gauge | gauge-chart | Jauge circulaire 0-100% |
 | bar-line | bar-chart + line-chart | Combine barres et ligne (2 séries) |
-| map | map-chart | Carte par departement francais |
-| map-reg | map-chart-reg | Carte par region francaise |
+| map | map-chart (level="dep") | Carte par departement francais |
+| map-reg | map-chart (level="reg") | Carte par region francaise |
+| map-aca | map-chart (level="aca") | Carte par academie |
+| map-monde | map-chart (level="monde") | Carte mondiale par pays |
 
 ### Attributs
 | Attribut | Type | Défaut | Requis | Description |
@@ -1131,7 +1138,7 @@ ce tableau en format DSFR Chart (tableaux imbriques x/y).
 | y-min | String | \`""\` | non | Limite min axe Y |
 | y-max | String | \`""\` | non | Limite max axe Y |
 | gauge-value | Number | \`null\` | type gauge | Valeur de la jauge (0-100) |
-| code-field | String | \`""\` | type map/map-reg | Champ contenant le code departement ou region (prioritaire sur label-field) |
+| code-field | String | \`""\` | types map* | Champ contenant le code : departement/region (map, map-reg), nom d'academie en majuscules (map-aca), code pays ISO 3166-1 alpha-2/alpha-3/numerique (map-monde, converti en alpha-2) — prioritaire sur label-field |
 | map-highlight | String | \`""\` | non | Departements/regions a surligner |
 | reference-lines | String | \`""\` | non | Lignes de reference (overlay) en JSON. Cartesiens uniquement (line, bar, bar-line, scatter). Chaque item : \`{ axis: "x" ou "y", value (string ou number), label?, color?, dash?, position? }\`. \`axis:"x"\` → ligne verticale a une categorie/date ; \`axis:"y"\` → ligne horizontale a un seuil. Ex : \`reference-lines='[{"axis":"x","value":"2026-02","label":"Lancement","color":"#c9191e","dash":true},{"axis":"y","value":3000,"label":"Objectif"}]'\`. |
 | targets | String | \`""\` | non | Cibles / objectifs futurs (overlay) en JSON. Types line et bar-line uniquement. Chaque item : \`{ x (echeance, string ou number, requis), value (number, requis), series? (nom de dataset ou index, defaut 0), label?, color? }\`. L'axe X est etendu automatiquement si l'echeance depasse les donnees : trait plein jusqu'au dernier point reel, trajectoire pointillee vers un losange a l'echeance, zone future grisee. Ex : \`targets='[{"x":2030,"value":26,"label":"Cible 2030 : 26 %"}]'\`. |
@@ -1150,6 +1157,8 @@ ce tableau en format DSFR Chart (tableaux imbriques x/y).
 | bar-line | source, type, label-field, value-field, value-field-2 | name, unit-tooltip, unit-tooltip-bar |
 | map | source, type, code-field, value-field | selected-palette, map-highlight |
 | map-reg | source, type, code-field, value-field | selected-palette, map-highlight |
+| map-aca | source, type, code-field, value-field | selected-palette, map-highlight |
+| map-monde | source, type, code-field, value-field | selected-palette, map-highlight |
 
 ### Exemples
 \`\`\`html
@@ -1192,6 +1201,17 @@ ce tableau en format DSFR Chart (tableaux imbriques x/y).
 <!-- Carte par region -->
 <dsfr-data-chart source="reg-data" type="map-reg"
   code-field="code_reg" value-field="valeur">
+</dsfr-data-chart>
+
+<!-- Carte par academie (noms en majuscules : PARIS, LYON...) -->
+<dsfr-data-chart source="aca-data" type="map-aca"
+  code-field="academie" value-field="valeur">
+</dsfr-data-chart>
+
+<!-- Carte mondiale (codes pays ISO : FR, US ou FRA, USA ou 250, 840) -->
+<dsfr-data-chart source="pays-data" type="map-monde"
+  code-field="code_pays" value-field="valeur"
+  selected-palette="sequentialAscending">
 </dsfr-data-chart>
 
 <!-- Jauge -->
@@ -1502,15 +1522,20 @@ name='["Série A","Série B"]'
 ### <radar-chart>
 - Multi-séries pour comparer des profils
 
-### <map-chart> (carte par departement)
-- data='{"75": 95, "69": 78, "2A": 60}' : JSON code_dept -> valeur
-- Codes departements valides : 01-95, 2A, 2B, 971-976
+### <map-chart> (cartes choroplethes — API unifiee DSFR Chart 2.1)
+- level : decoupage — "dep" (défaut), "reg", "aca", "monde"
+- data : JSON code -> valeur, selon le level :
+  - level="dep" : data='{"75": 95, "69": 78, "2A": 60}' (codes 01-95, 2A, 2B, 971-976)
+  - level="reg" : data='{"11": 95, "84": 78}' (codes region INSEE)
+  - level="aca" : data='{"PARIS": 95, "LYON": 78}' (noms d'academie majuscules)
+  - level="monde" : data='{"FR": 95, "US": 78}' (ISO 3166-1 alpha-2)
 - name : nom de l'indicateur
 - value-nat : valeur nationale de reference
 - selected-palette : palette de couleurs
 
-### <map-chart-reg> (carte par region)
-- Même format que map-chart avec codes region
+### <map-chart-reg region="..."> (zoom sur UNE region)
+- Zoome sur une region donnee, data par departement de cette region
+- Ex : region="11" data='{"75": 95, "92": 78}'
 
 ### Attributs communs
 - selected-palette : categorical, sequentialAscending, sequentialDescending, divergentAscending, divergentDescending, neutral, default
@@ -1929,6 +1954,15 @@ Guide pour choisir le type de visualisation adapte aux données.
 - **Quand** : données geographiques par region francaise
 - **Champs** : code-field (code region), value-field
 
+### Carte academies (map-aca)
+- **Quand** : données education par academie
+- **Champs** : code-field (nom d'academie en majuscules : PARIS, LYON, STRASBOURG...), value-field
+
+### Carte mondiale (map-monde)
+- **Quand** : données internationales par pays
+- **Champs** : code-field (code pays ISO 3166-1 : alpha-2 "FR", alpha-3 "FRA" ou numerique "250" — convertis automatiquement en alpha-2), value-field
+- **Palette recommandee** : sequentialAscending
+
 ### Séries multiples (bar, line, bar-line, radar)
 Utiliser \`value-field-2\` pour une seconde série, ou \`value-fields\` pour plusieurs séries supplementaires (separees par virgules).
 Definir les noms avec \`name='["Série 1","Série 2","Série 3"]'\`.
@@ -1964,7 +1998,7 @@ Exemple multi-séries : \`value-field="ca" value-fields="budget,objectif" name='
 
 ### Bonnes pratiques
 - Utiliser \`categorical\` pour pie, radar et comparaisons multi-catégories
-- Utiliser \`sequentialAscending\` pour les cartes (map, map-reg)
+- Utiliser \`sequentialAscending\` pour les cartes (map, map-reg, map-aca, map-monde)
 - Utiliser \`neutral\` + \`highlight-index\` pour mettre en avant une valeur
 - Assurer un contraste suffisant (conformite RGAA)
 - Eviter le rouge/vert seuls (daltonisme) - les palettes DSFR sont concues pour ca`,
@@ -2262,7 +2296,12 @@ rendu : switch chart/tableau integre, CSV natif). Conserver uniquement :
       'planisphere',
       'carte pays',
     ],
-    content: `## dsfr-data-world-map — Carte choroplèthe mondiale
+    content: `## dsfr-data-world-map — Carte choroplèthe mondiale (DEPRECIE)
+
+⚠️ DEPRECIE : preferer \`<dsfr-data-chart type="map-monde">\` (carte mondiale
+DSFR Chart native, aucun bundle supplementaire). Ce composant sera retire
+dans une prochaine version majeure. Il reste pertinent uniquement si le zoom
+continent interactif est requis.
 
 Composant qui affiche une carte du monde SVG (projection Natural Earth)
 où chaque pays est colorié selon une valeur numérique.

--- a/apps/builder-ia/src/state.ts
+++ b/apps/builder-ia/src/state.ts
@@ -29,6 +29,8 @@ export interface ChartConfig {
     | 'map'
     | 'bar-line'
     | 'map-reg'
+    | 'map-aca'
+    | 'map-monde'
     | 'datalist'
     | 'podium';
   labelField?: string;

--- a/apps/builder-ia/src/ui/chart-renderer.ts
+++ b/apps/builder-ia/src/ui/chart-renderer.ts
@@ -2,7 +2,13 @@
  * Chart rendering - applies chart configuration to generate visual output
  */
 
-import { escapeHtml, DSFR_COLORS, PALETTE_COLORS, isValidDeptCode } from '@dsfr-data/shared';
+import {
+  escapeHtml,
+  DSFR_COLORS,
+  PALETTE_COLORS,
+  isValidDeptCode,
+  MAP_LEVEL_MAP,
+} from '@dsfr-data/shared';
 import { state } from '../state.js';
 import type { ChartConfig, AggregatedResult } from '../state.js';
 import { addMessage } from '../chat/chat.js';
@@ -197,7 +203,7 @@ export function applyChartConfig(config: ChartConfig): void {
 
   // Aggregate data for charts
   const aggregated: Record<string, { values: number[]; count: number; code: string | null }> = {};
-  const isMap = config.type === 'map' || config.type === 'map-reg';
+  const isMap = config.type in MAP_LEVEL_MAP;
   const codeField = config.codeField || config.labelField;
 
   workingData.forEach((record) => {
@@ -333,8 +339,8 @@ function renderChart(config: ChartConfig, data: AggregatedResult[]): void {
     return;
   }
 
-  // Handle map type (uses DSFR map-chart / map-chart-reg)
-  if (config.type === 'map' || config.type === 'map-reg') {
+  // Handle map types (uses DSFR <map-chart level="…">, API unifiee 2.1.0)
+  if (config.type in MAP_LEVEL_MAP) {
     canvas.style.display = 'none';
     emptyState.style.display = 'none';
 
@@ -342,24 +348,28 @@ function renderChart(config: ChartConfig, data: AggregatedResult[]): void {
     const mapData: Record<string, number> = {};
     data.forEach((d) => {
       let code = String(d.code || d.label || '').trim();
-      if (/^\d+$/.test(code) && code.length < 3) {
+      if (config.type === 'map-aca' || config.type === 'map-monde') {
+        // aca : noms d'academie majuscules ; monde : ISO alpha-2
+        // (la conversion a3/num est faite par dsfr-data-chart, pas ici)
+        code = code.toUpperCase();
+      } else if (/^\d+$/.test(code) && code.length < 3) {
         code = code.padStart(2, '0');
       }
       const value = d.value || 0;
-      if (isValidDeptCode(code)) {
+      if (config.type === 'map' ? isValidDeptCode(code) : code !== '') {
         mapData[code] = Math.round(value * 100) / 100;
       }
     });
 
-    const mapTag = config.type === 'map-reg' ? 'map-chart-reg' : 'map-chart';
     const mapCard = document.createElement('div');
     mapCard.className = 'map-card';
     mapCard.innerHTML = `
-      <${mapTag}
+      <map-chart
+        level="${MAP_LEVEL_MAP[config.type]}"
         data='${JSON.stringify(mapData)}'
         name="${escapeHtml(config.title || 'Carte')}"
         selected-palette="${config.palette || 'sequentialAscending'}"
-      ></${mapTag}>
+      ></map-chart>
     `;
     chartWrapper.appendChild(mapCard);
     return;

--- a/apps/builder-ia/src/ui/code-generator.ts
+++ b/apps/builder-ia/src/ui/code-generator.ts
@@ -12,6 +12,7 @@ import {
   extractResourceIds,
   filterToOdsql,
   formatKPIValue,
+  MAP_LEVEL_MAP,
 } from '@dsfr-data/shared';
 import { state } from '../state.js';
 import type { ChartConfig, AggregatedResult } from '../state.js';
@@ -99,8 +100,8 @@ export function generateCode(config: ChartConfig, data: AggregatedResult[]): voi
     return;
   }
 
-  // Handle map type (department or region)
-  if (config.type === 'map' || config.type === 'map-reg') {
+  // Handle map types (departments, regions, academies, world)
+  if (config.type in MAP_LEVEL_MAP) {
     codeEl.textContent = generateMapCode(config, data);
     return;
   }
@@ -322,11 +323,15 @@ function generateMapCode(config: ChartConfig, data: AggregatedResult[]): string 
   const mapData: Record<string, number> = {};
   data.forEach((d) => {
     let code = String(d.code || d.label || '').trim();
-    if (/^\d+$/.test(code) && code.length < 3) {
+    if (config.type === 'map-aca' || config.type === 'map-monde') {
+      // aca : noms d'academie majuscules ; monde : ISO alpha-2
+      // (la conversion a3/num est faite par dsfr-data-chart, pas ici)
+      code = code.toUpperCase();
+    } else if (/^\d+$/.test(code) && code.length < 3) {
       code = code.padStart(2, '0');
     }
     const value = d.value || 0;
-    if (isValidDeptCode(code)) {
+    if (config.type === 'map' ? isValidDeptCode(code) : code !== '') {
       mapData[code] = Math.round(value * 100) / 100;
     }
   });
@@ -479,7 +484,6 @@ function generateMapCode(config: ChartConfig, data: AggregatedResult[]): string 
   }
 
   // Embedded-data variant
-  const mapTagEmbed = config.type === 'map-reg' ? 'map-chart-reg' : 'map-chart';
   return `<!-- Carte generee avec dsfr-data Builder IA -->
 <!-- Source : ${state.source?.name || 'Données locales'} -->
 
@@ -492,11 +496,12 @@ function generateMapCode(config: ChartConfig, data: AggregatedResult[]): string 
 <div class="fr-container fr-my-4w">
   <h2>${escapeHtml(config.title || 'Carte de France')}</h2>
   ${config.subtitle ? `<p class="fr-text--sm fr-text--light">${escapeHtml(config.subtitle)}</p>` : ''}
-  <${mapTagEmbed}
+  <map-chart
+    level="${MAP_LEVEL_MAP[config.type]}"
     data='${JSON.stringify(mapData)}'
     name="${escapeHtml(config.title || 'Carte')}"
     selected-palette="${config.palette || 'sequentialAscending'}"
-  ></${mapTagEmbed}>
+  ></map-chart>
 </div>`;
 }
 

--- a/apps/builder/index.html
+++ b/apps/builder/index.html
@@ -19,8 +19,8 @@
   <script type="module" src="../../packages/app-ui/dist/app-ui.esm.js"></script>
 
   <!-- DSFR Chart (pour les cartes et jauges) -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
 
   <!-- App entry point -->
   <script type="module" src="src/main.ts"></script>

--- a/apps/builder/src/ui/code-generator.ts
+++ b/apps/builder/src/ui/code-generator.ts
@@ -114,9 +114,10 @@ function a11yDep(): string {
 function wrapWithDatabox(chartHtml: string, chartId: string): string {
   if (!state.databoxEnabled) return chartHtml;
   const dbId = `databox-${chartId}`;
-  // DataBox attributes — title, source, date are required
+  // DataBox attributes — name, source, date are required
+  // (DSFR Chart 2.1.0 renamed `title` to `name`)
   const dbAttrs: string[] = [`id="${dbId}"`];
-  dbAttrs.push(`title="${escapeHtml(state.databoxTitle || ' ')}"`);
+  dbAttrs.push(`name="${escapeHtml(state.databoxTitle || ' ')}"`);
   dbAttrs.push(`source="${escapeHtml(state.databoxSource || ' ')}"`);
   dbAttrs.push(`date="${escapeHtml(state.databoxDate || new Date().toISOString().split('T')[0])}"`);
   if (state.databoxDownload) dbAttrs.push('download');

--- a/apps/dashboard/index.html
+++ b/apps/dashboard/index.html
@@ -12,8 +12,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
 
   <!-- DSFR Chart -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
 
   <!-- dsfr-data -->
   <script type="module" src="../../packages/core/dist/dsfr-data.esm.js"></script>

--- a/apps/favorites/index.html
+++ b/apps/favorites/index.html
@@ -15,8 +15,8 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
 
   <!-- DSFR Chart -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
 
   <!-- Composants dsfr-data -->
   <script type="module" src="../../packages/core/dist/dsfr-data.esm.js"></script>

--- a/apps/grist-widgets/chart/index.html
+++ b/apps/grist-widgets/chart/index.html
@@ -11,8 +11,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
 
   <!-- DSFR Chart (composants Vue : bar-chart, line-chart, pie-chart...) -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
 
   <!-- dsfr-data (UMD : enregistre les custom elements + expose DsfrData global) -->
   <script src="../lib/dsfr-data.umd.js"></script>

--- a/apps/grist-widgets/src/chart.ts
+++ b/apps/grist-widgets/src/chart.ts
@@ -13,7 +13,7 @@
 import './styles/grist-widgets.css';
 import { initGristBridge, onGristOptions, getGristApiInfo } from './shared/grist-bridge.js';
 import { createOptionsPanel, type OptionDef } from './shared/grist-options-panel.js';
-import { PROXY_BASE_URL } from '@dsfr-data/shared';
+import { PROXY_BASE_URL, CDN_URLS } from '@dsfr-data/shared';
 
 const ALL_OPTIONS: OptionDef[] = [
   {
@@ -31,6 +31,8 @@ const ALL_OPTIONS: OptionDef[] = [
       { value: 'bar-line', label: 'Barres + Lignes' },
       { value: 'map', label: 'Carte departements' },
       { value: 'map-reg', label: 'Carte regions' },
+      { value: 'map-aca', label: 'Carte academies' },
+      { value: 'map-monde', label: 'Carte monde' },
       { value: 'kpi', label: 'KPI' },
     ],
   },
@@ -149,7 +151,7 @@ function renderWidget(type: string) {
     chart.setAttribute('type', type);
     chart.setAttribute('label-field', 'Label');
     chart.setAttribute('value-field', 'Value');
-    if (type === 'map' || type === 'map-reg') {
+    if (type.startsWith('map')) {
       chart.setAttribute('code-field', 'Code');
     }
     container.appendChild(chart);
@@ -246,12 +248,8 @@ function generateFixedHtml(): string {
   }
 
   // Chart types: bar, line, pie, radar, scatter, gauge, bar-line, map, map-reg
-  deps.push(
-    '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css">'
-  );
-  deps.push(
-    '<script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js"></script>'
-  );
+  deps.push(`<link rel="stylesheet" href="${CDN_URLS.dsfrChartCss}">`);
+  deps.push(`<script type="module" src="${CDN_URLS.dsfrChartJs}"></script>`);
   deps.push(
     '<script src="https://cdn.jsdelivr.net/gh/bmatge/dsfr-data@main/dist/dsfr-data.umd.js"></script>'
   );
@@ -260,7 +258,7 @@ function generateFixedHtml(): string {
   const horizontal = opts.horizontal === true ? ' horizontal' : '';
   const stacked = opts.stacked === true ? ' stacked' : '';
   const unitTooltip = opts.unitTooltip ? ` unit-tooltip="${opts.unitTooltip}"` : '';
-  const codeField = type === 'map' || type === 'map-reg' ? ' code-field="Code"' : '';
+  const codeField = type.startsWith('map') ? ' code-field="Code"' : '';
   const hasValue2 = data.length > 0 && 'Value2' in data[0];
   const valueField2 = hasValue2 ? ' value-field-2="Value2"' : '';
 
@@ -325,12 +323,8 @@ function generateDynamicHtml(): string {
 <dsfr-data-kpi source="grist-data" value="fields.${valueCol}:${agg}" format="${format}" label="${label}"${icone}${couleur}></dsfr-data-kpi>`;
   }
 
-  deps.push(
-    '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css">'
-  );
-  deps.push(
-    '<script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js"></script>'
-  );
+  deps.push(`<link rel="stylesheet" href="${CDN_URLS.dsfrChartCss}">`);
+  deps.push(`<script type="module" src="${CDN_URLS.dsfrChartJs}"></script>`);
   deps.push(
     '<script src="https://cdn.jsdelivr.net/gh/bmatge/dsfr-data@main/dist/dsfr-data.umd.js"></script>'
   );
@@ -339,8 +333,7 @@ function generateDynamicHtml(): string {
   const horizontal = opts.horizontal === true ? ' horizontal' : '';
   const stacked = opts.stacked === true ? ' stacked' : '';
   const unitTooltip = opts.unitTooltip ? ` unit-tooltip="${opts.unitTooltip}"` : '';
-  const codeFieldAttr =
-    (type === 'map' || type === 'map-reg') && codeCol ? ` code-field="fields.${codeCol}"` : '';
+  const codeFieldAttr = type.startsWith('map') && codeCol ? ` code-field="fields.${codeCol}"` : '';
   const valueField2 = value2Col ? ` value-field-2="fields.${value2Col}"` : '';
 
   return `${deps.join('\n')}

--- a/apps/grist-widgets/test-local.html
+++ b/apps/grist-widgets/test-local.html
@@ -11,8 +11,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
 
   <!-- DSFR Chart -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
 
   <!-- dsfr-data UMD -->
   <script src="/lib/dsfr-data.umd.js"></script>

--- a/apps/playground/index.html
+++ b/apps/playground/index.html
@@ -12,8 +12,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
 
   <!-- DSFR Chart -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
 
   <!-- CodeMirror -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.min.css" integrity="sha384-phfEUVAmRZV1Pzn/Xgxc3NH6zPMDuer0wHU9jRQKhNBBLyV4MP1gaBY1sxfxxPRT" crossorigin="anonymous">

--- a/docs/THIRD-PARTY-LICENSES.md
+++ b/docs/THIRD-PARTY-LICENSES.md
@@ -9,7 +9,7 @@ Le projet `dsfr-data` lui-même est distribué sous licence **MIT** (voir [`LICE
 | Paquet | Version | Licence | Usage |
 |---|---|---|---|
 | [`lit`](https://lit.dev/) | ^3.1.0 | BSD-3-Clause | Framework des Web Components |
-| [`@gouvfr/dsfr-chart`](https://www.npmjs.com/package/@gouvfr/dsfr-chart) | ^2.0.4 | MIT | Composants Vue DSFR (bar/line/pie chart, map-chart) |
+| [`@gouvfr/dsfr-chart`](https://github.com/GouvernementFR/dsfr-chart) | ^2.1.1 | MIT | Composants Vue DSFR (bar/line/pie chart, map-chart avec API cartes unifiee `level`) |
 | [`leaflet`](https://leafletjs.com/) | ^1.9.4 | BSD-2-Clause | Moteur de carte (chargé dynamiquement) |
 | [`leaflet.markercluster`](https://github.com/Leaflet/Leaflet.markercluster) | ^1.5.3 | MIT | Plugin clustering de markers (chargé dynamiquement) |
 | [`leaflet.heat`](https://github.com/Leaflet/Leaflet.heat) | ^0.2.0 | BSD-2-Clause | Plugin heatmap (chargé dynamiquement) |

--- a/e2e/industrie-du-futur.html
+++ b/e2e/industrie-du-futur.html
@@ -10,8 +10,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
 
   <!-- DSFR Chart (pour tous les graphiques) -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
 
   <!-- dsfr-data composants -->
   <script type="module" src="/dist/dsfr-data.esm.js"></script>

--- a/guide/examples/education-gouv-1.html
+++ b/guide/examples/education-gouv-1.html
@@ -13,9 +13,9 @@
 
   <!-- DSFR Chart -->
 
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
 
   <!-- dsfr-data (web components) -->
 

--- a/guide/examples/exemple-electrifions.html
+++ b/guide/examples/exemple-electrifions.html
@@ -11,9 +11,9 @@
     <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
     <script nomodule src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.nomodule.min.js" integrity="sha384-Z4DUpohlJ2Fb0B8Lg02tWZXbOSM2tn+L1hEWTt5sf3gNXplIW00IoMarWgHBUffK" crossorigin="anonymous"></script>
     <!-- DSFR Chart -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
     <!-- dsfr-data : dernière version 0.x (@0, non figée) — requis pour KPI heading/lines (#342) et chart reference-lines (#341). Major flottant : pas de SRI (cf. check:sri). -->
     <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0/dist/dsfr-data.core.umd.js"></script>
   </head>

--- a/guide/examples/exemple-france-num.html
+++ b/guide/examples/exemple-france-num.html
@@ -8,9 +8,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
     <!-- DSFR Chart -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
     <!--
     Leaflet préchargé AVANT dsfr-data pour éviter l'échec du dynamic import
     dans certains contextes (iframe, CSP stricte) — pattern identique

--- a/guide/examples/exemple-masa-v1.html
+++ b/guide/examples/exemple-masa-v1.html
@@ -6,10 +6,10 @@
   <title>DNC - Suivi epidemiologique</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <!-- Leaflet : charge dynamiquement par dsfr-data.umd.js - NE PAS inclure manuellement -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <!-- dsfr-data : derniere version 0.x (@0, non figee) — evite le fallback proxy chartsbuilder.matge.com bake dans 0.7.1. Bundle complet (core + map). Major flottant : pas de SRI (cf. check:sri). -->
   <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0/dist/dsfr-data.umd.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>

--- a/guide/examples/exemple-masa-v2.html
+++ b/guide/examples/exemple-masa-v2.html
@@ -9,13 +9,13 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <!-- DSFR Chart CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
 
   <!-- Leaflet est chargé dynamiquement par dsfr-data.umd.js depuis cdn.jsdelivr.net -->
 
   <!-- Chart.js — AVANT DSFRChart.js -->
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <!-- dsfr-data core + map -->
 <!-- dsfr-data : derniere version 0.x (@0, non figee) — evite le fallback proxy chartsbuilder.matge.com bake dans 0.7.1. Bundle complet (core + map). Major flottant : pas de SRI (cf. check:sri). -->
 <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0/dist/dsfr-data.umd.js"></script>

--- a/guide/examples/observatoire-afa-v1.html
+++ b/guide/examples/observatoire-afa-v1.html
@@ -6,9 +6,9 @@
   <title>AFA – Chroniques jurisprudentielles 2021 / 2022</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/dsfr-data@0/dist/dsfr-data.css">
   <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0/dist/dsfr-data.core.umd.js"></script>
 </head>

--- a/guide/guide-demo-complete.html
+++ b/guide/guide-demo-complete.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>
@@ -362,15 +362,17 @@
 
         <div class="fr-grid-row fr-grid-row--gutters fr-mb-4w">
           <div class="fr-col-12 fr-col-md-6">
-            <p class="fr-text--sm">Entrées simulées par région (milliers) — tableau de données :</p>
-            <!-- map-chart-reg requiert un attribut `region` et zoome sur une région spécifique ;
-                 il n'est pas adapté à une carte choroplèthe nationale. On affiche les données sous forme de liste. -->
-            <dsfr-data-list
+            <p class="fr-text--sm">Entrées simulées par région (milliers) :</p>
+            <dsfr-data-chart id="chart-map-reg"
               source="region-data"
-              columns="code:Région INSEE,n:Entrées (k)"
-              sort="n:desc"
-              pagination="13">
-            </dsfr-data-list>
+              type="map-reg"
+              code-field="code"
+              value-field="n"
+              name="Entrées (k)"
+              selected-palette="sequentialAscending"
+              unit-tooltip=" k entrées">
+            </dsfr-data-chart>
+            <dsfr-data-a11y for="chart-map-reg" source="region-data" table download></dsfr-data-a11y>
           </div>
           <div class="fr-col-12 fr-col-md-6">
             <p class="fr-text--sm">Entrées simulées par département (milliers) :</p>

--- a/guide/guide-exemple-ODS.html
+++ b/guide/guide-exemple-ODS.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-chart-a11y.html
+++ b/guide/guide-exemples-chart-a11y.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-context.html
+++ b/guide/guide-exemples-context.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-display.html
+++ b/guide/guide-exemples-display.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-facets.html
+++ b/guide/guide-exemples-facets.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-ghibli.html
+++ b/guide/guide-exemples-ghibli.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-insee-erfs.html
+++ b/guide/guide-exemples-insee-erfs.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-join.html
+++ b/guide/guide-exemples-join.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-maires.html
+++ b/guide/guide-exemples-maires.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-normalize.html
+++ b/guide/guide-exemples-normalize.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-query.html
+++ b/guide/guide-exemples-query.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-search.html
+++ b/guide/guide-exemples-search.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-source.html
+++ b/guide/guide-exemples-source.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/guide/guide-exemples-world-map.html
+++ b/guide/guide-exemples-world-map.html
@@ -8,8 +8,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <script src="guide-menu.js"></script>

--- a/packages/app-ui/src/app-footer.ts
+++ b/packages/app-ui/src/app-footer.ts
@@ -65,22 +65,26 @@ export class AppFooter extends LitElement {
                 Charts builder est un projet open-source permettant de créer des visualisations de
                 données conformes au Design System de l'État (DSFR).
               </p>
-              ${this._version
-                ? html`<p class="fr-footer__content-desc fr-text--xs" style="opacity: 0.7;">
-                    Composants dsfr-data
-                    v${this._version}${this._commit
-                      ? html` ·
-                          <a
-                            class="fr-footer__content-link"
-                            href="https://github.com/bmatge/dsfr-data/commit/${this._commit}"
-                            target="_blank"
-                            rel="noopener"
-                            title="Voir le commit sur GitHub"
-                            >commit ${this._commit}</a
-                          >`
-                      : ''}
-                  </p>`
-                : ''}
+              ${
+                this._version
+                  ? html`<p class="fr-footer__content-desc fr-text--xs" style="opacity: 0.7;">
+                      Composants dsfr-data
+                      v${this._version}${
+                      this._commit
+                        ? html` ·
+                            <a
+                              class="fr-footer__content-link"
+                              href="https://github.com/bmatge/dsfr-data/commit/${this._commit}"
+                              target="_blank"
+                              rel="noopener"
+                              title="Voir le commit sur GitHub"
+                              >commit ${this._commit}</a
+                            >`
+                        : ''
+                    }
+                    </p>`
+                  : ''
+              }
               <ul class="fr-footer__content-list">
                 <li class="fr-footer__content-item">
                   <a
@@ -90,6 +94,16 @@ export class AppFooter extends LitElement {
                     href="https://www.systeme-de-design.gouv.fr/"
                   >
                     systeme-de-design.gouv.fr
+                  </a>
+                </li>
+                <li class="fr-footer__content-item">
+                  <a
+                    class="fr-footer__content-link"
+                    target="_blank"
+                    rel="noopener"
+                    href="https://github.com/GouvernementFR/dsfr-chart"
+                  >
+                    DSFR Chart
                   </a>
                 </li>
                 <li class="fr-footer__content-item">

--- a/packages/core/src/components/dsfr-data-chart.ts
+++ b/packages/core/src/components/dsfr-data-chart.ts
@@ -31,11 +31,35 @@ import {
   type TargetMarkerGeometry,
 } from '../utils/chart-targets.js';
 import { escapeHtml, toNumber, isValidDeptCode } from '@dsfr-data/shared/lib';
+import { toIsoA2 } from '../data/continent-lookup.js';
 
 type DSFRChartType =
-  'line' | 'bar' | 'pie' | 'radar' | 'gauge' | 'scatter' | 'bar-line' | 'map' | 'map-reg';
+  | 'line'
+  | 'bar'
+  | 'pie'
+  | 'radar'
+  | 'gauge'
+  | 'scatter'
+  | 'bar-line'
+  | 'map'
+  | 'map-reg'
+  | 'map-aca'
+  | 'map-monde';
 
 let databoxAutoId = 0;
+
+/**
+ * Map chart types -> attribut `level` de <map-chart> (API cartes unifiée
+ * DSFR Chart >= 2.1.0). `map-chart-reg` upstream subsiste mais zoome sur UNE
+ * région (clés départementales) : la carte nationale des régions passe par
+ * level="reg".
+ */
+const MAP_LEVEL: Record<string, string> = {
+  map: 'dep',
+  'map-reg': 'reg',
+  'map-aca': 'aca',
+  'map-monde': 'monde',
+};
 
 /** Maps chart type -> DSFR custom element tag name */
 const CHART_TAG_MAP: Record<string, string> = {
@@ -47,7 +71,9 @@ const CHART_TAG_MAP: Record<string, string> = {
   gauge: 'gauge-chart',
   'bar-line': 'bar-line-chart',
   map: 'map-chart',
-  'map-reg': 'map-chart-reg',
+  'map-reg': 'map-chart',
+  'map-aca': 'map-chart',
+  'map-monde': 'map-chart',
 };
 
 /**
@@ -79,7 +105,10 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
   @property({ type: String, attribute: 'label-field' })
   labelField = '';
 
-  /** Chemin vers le champ code departement/region (map/map-reg, prioritaire sur label-field) */
+  /**
+   * Chemin vers le champ code (prioritaire sur label-field) : departement/region
+   * (map/map-reg), nom d'academie (map-aca), code pays ISO a2/a3/num (map-monde)
+   */
   @property({ type: String, attribute: 'code-field' })
   codeField = '';
 
@@ -456,14 +485,24 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
     const mapData: Record<string, number> = {};
     for (const record of this._data) {
       let code = String(getByPath(record, field) ?? '').trim();
-      // Pad numeric codes to 2 digits (e.g. "1" -> "01")
-      if (/^\d+$/.test(code) && code.length < 3) {
-        code = code.padStart(2, '0');
+      if (this.type === 'map-monde') {
+        // <map-chart level="monde"> n'accepte que l'alpha-2 : convertit
+        // iso-a3 / iso-num a la volee, ignore les codes inconnus
+        code = toIsoA2(code);
+        if (!code) continue;
+      } else if (this.type === 'map-aca') {
+        // Cles = nom d'academie en majuscules ("PARIS", "LYON"...)
+        code = code.toUpperCase();
+        if (!code) continue;
+      } else {
+        // Pad numeric codes to 2 digits (e.g. "1" -> "01")
+        if (/^\d+$/.test(code) && code.length < 3) {
+          code = code.padStart(2, '0');
+        }
+        if (this.type === 'map' ? !isValidDeptCode(code) : code === '') continue;
       }
       const value = toNumber(getByPath(record, this.valueField));
-      if (this.type === 'map' ? isValidDeptCode(code) : code !== '') {
-        mapData[code] = Math.round(value * 100) / 100;
-      }
+      mapData[code] = Math.round(value * 100) / 100;
     }
     return JSON.stringify(mapData);
   }
@@ -484,14 +523,14 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
       // DSFR Chart attend un tableau JSON pour name (ex: '["Série 1"]')
       // Si l'utilisateur passe une string simple, on l'enveloppe automatiquement
       const trimmed = this.name.trim();
-      const isMap = this.type === 'map' || this.type === 'map-reg';
+      const isMap = this.type in MAP_LEVEL;
       attrs['name'] = isMap
         ? trimmed
         : trimmed.startsWith('[')
           ? trimmed
           : JSON.stringify([trimmed]);
     } else if (this.valueField) {
-      const isMap = this.type === 'map' || this.type === 'map-reg';
+      const isMap = this.type in MAP_LEVEL;
       if (isMap) {
         attrs['name'] = this.valueField;
       } else {
@@ -608,7 +647,12 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
         break;
       }
       case 'map':
-      case 'map-reg': {
+      case 'map-reg':
+      case 'map-aca':
+      case 'map-monde': {
+        // Le decoupage est choisi par l'attribut level (API unifiee 2.1.0) —
+        // statique : Vue le lit au montage et ne l'ecrase pas
+        attrs['level'] = MAP_LEVEL[this.type];
         // All map attributes go in `deferred` because the DSFR Chart Vue component
         // overwrites props set before mount with their default values.
         // Deferred attrs are applied via setTimeout(500ms) after Vue has mounted,
@@ -705,7 +749,7 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
     if (this.type === 'pie' && this.fill) {
       attrs['fill'] = 'true';
     }
-    if ((this.type === 'map' || this.type === 'map-reg') && this.mapHighlight) {
+    if (this.type in MAP_LEVEL && this.mapHighlight) {
       attrs['highlight'] = this.mapHighlight;
     }
 
@@ -726,6 +770,8 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
       'bar-line': 'barres et lignes',
       map: 'carte departements',
       'map-reg': 'carte regions',
+      'map-aca': 'carte academies',
+      'map-monde': 'carte monde',
     };
     const typeName = typeLabels[this.type] || this.type;
     const count = this._data.length;
@@ -1117,7 +1163,10 @@ export class DsfrDataChart extends SourceSubscriberMixin(LitElement) {
     // creates the Teleport target containers when segmented-control is set.
     // Without it, the chart's Vue <Teleport> has no target and renders outside.
     databoxEl.setAttribute('segmented-control', '');
-    // title, source, date are REQUIRED props for DataBox — always set them.
+    // name, source, date are REQUIRED props for DataBox — always set them.
+    // DSFR Chart 2.1.0 renamed `title` to `name` (conflict with the native
+    // HTML title attribute); keep setting `title` too for 2.0.x hosts.
+    databoxEl.setAttribute('name', this.databoxTitle || ' ');
     databoxEl.setAttribute('title', this.databoxTitle || ' ');
     databoxEl.setAttribute('source', this.databoxSource || ' ');
     databoxEl.setAttribute('date', this.databoxDate || new Date().toISOString().split('T')[0]);

--- a/packages/core/src/components/dsfr-data-world-map.ts
+++ b/packages/core/src/components/dsfr-data-world-map.ts
@@ -92,6 +92,9 @@ const CONTINENT_LABELS: Record<string, string> = {
  * Composant Lit natif (pas DSFR Chart) pour afficher une carte du monde
  * coloree par valeur, avec zoom interactif par continent.
  *
+ * @deprecated Depuis DSFR Chart 2.1, utiliser <dsfr-data-chart type="map-monde">
+ * (carte mondiale native, sans bundle world-map). Retrait prevu au prochain major (#402).
+ *
  * @example
  * <dsfr-data-world-map
  *   source="data"
@@ -148,6 +151,11 @@ export class DsfrDataWorldMap extends SourceSubscriberMixin(LitElement) {
   connectedCallback() {
     super.connectedCallback();
     sendWidgetBeacon('dsfr-data-world-map');
+    // Deprecie (#402, cycle en 2 releases) : la carte mondiale est desormais
+    // fournie par DSFR Chart 2.1 — retrait prevu a la prochaine version majeure
+    console.warn(
+      'dsfr-data-world-map est déprécié et sera retiré dans une prochaine version majeure — utilisez <dsfr-data-chart type="map-monde"> (carte mondiale DSFR Chart native)'
+    );
     // Alias deprecie (#299) : zoom="continent|none" -> zoom-mode
     if (this.hasAttribute('zoom') && !this.hasAttribute('zoom-mode')) {
       const legacy = this.getAttribute('zoom');

--- a/packages/core/src/data/continent-lookup.ts
+++ b/packages/core/src/data/continent-lookup.ts
@@ -565,6 +565,35 @@ export function toIsoNumeric(code: string, format: 'iso-a2' | 'iso-a3' | 'iso-nu
   }
 }
 
+let NUM_TO_ISO_A2: Record<string, string> | null = null;
+
+/**
+ * Normalize any ISO code format (alpha-2, alpha-3 or numeric) to alpha-2,
+ * auto-detecting the input format. Returns '' when the code is unknown.
+ * Needed by <map-chart level="monde"> (DSFR Chart >= 2.1.0), which only
+ * accepts alpha-2 keys.
+ */
+export function toIsoA2(code: string): string {
+  const upper = code.trim().toUpperCase();
+  if (/^[A-Z]{2}$/.test(upper)) {
+    return ISO_A2_TO_NUM[upper] ? upper : '';
+  }
+  let num = '';
+  if (/^[A-Z]{3}$/.test(upper)) {
+    num = ISO_A3_TO_NUM[upper] || '';
+  } else if (/^\d{1,3}$/.test(upper)) {
+    num = upper.padStart(3, '0');
+  }
+  if (!num) return '';
+  if (!NUM_TO_ISO_A2) {
+    NUM_TO_ISO_A2 = {};
+    for (const [a2, n] of Object.entries(ISO_A2_TO_NUM)) {
+      NUM_TO_ISO_A2[n] = a2;
+    }
+  }
+  return NUM_TO_ISO_A2[num] || '';
+}
+
 /** All continent names used in the lookup */
 export const CONTINENTS = [
   'Africa',

--- a/packages/shared/src/charts/chart-types.ts
+++ b/packages/shared/src/charts/chart-types.ts
@@ -15,9 +15,32 @@ export const DSFR_TAG_MAP: Record<string, string> = {
   gauge: 'gauge-chart',
   'bar-line': 'bar-line-chart',
   map: 'map-chart',
-  'map-reg': 'map-chart-reg',
+  'map-reg': 'map-chart',
+  'map-aca': 'map-chart',
+  'map-monde': 'map-chart',
+};
+
+/**
+ * Maps map chart types to the <map-chart> `level` attribute
+ * (unified map API, DSFR Chart >= 2.1.0).
+ */
+export const MAP_LEVEL_MAP: Record<string, string> = {
+  map: 'dep',
+  'map-reg': 'reg',
+  'map-aca': 'aca',
+  'map-monde': 'monde',
 };
 
 /** Canonical chart types (without aliases) */
 export type DSFRChartType =
-  'bar' | 'line' | 'pie' | 'radar' | 'gauge' | 'scatter' | 'bar-line' | 'map' | 'map-reg';
+  | 'bar'
+  | 'line'
+  | 'pie'
+  | 'radar'
+  | 'gauge'
+  | 'scatter'
+  | 'bar-line'
+  | 'map'
+  | 'map-reg'
+  | 'map-aca'
+  | 'map-monde';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -40,7 +40,7 @@ export type { PaletteType } from './constants/dsfr-palettes.js';
 export { CDN_URLS, getPreviewHTML } from './templates/cdn-versions.js';
 
 // Charts
-export { DSFR_TAG_MAP } from './charts/chart-types.js';
+export { DSFR_TAG_MAP, MAP_LEVEL_MAP } from './charts/chart-types.js';
 export type { DSFRChartType } from './charts/chart-types.js';
 
 // Query / Filters

--- a/packages/shared/src/lib.ts
+++ b/packages/shared/src/lib.ts
@@ -57,7 +57,7 @@ export {
 export type { PaletteType } from './constants/dsfr-palettes.js';
 
 // Charts
-export { DSFR_TAG_MAP } from './charts/chart-types.js';
+export { DSFR_TAG_MAP, MAP_LEVEL_MAP } from './charts/chart-types.js';
 export type { DSFRChartType } from './charts/chart-types.js';
 
 // API / Proxy (config runtime injectable, cf. #319)

--- a/specs/charts/bar-chart.html
+++ b/specs/charts/bar-chart.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
   </style>

--- a/specs/charts/gauge-chart.html
+++ b/specs/charts/gauge-chart.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
     .gauge-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1.5rem; }

--- a/specs/charts/index.html
+++ b/specs/charts/index.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
     .chart-card { background: var(--background-default-grey); border: 1px solid var(--border-default-grey); border-radius: 8px; padding: 1.5rem; margin-bottom: 1.5rem; }

--- a/specs/charts/line-chart.html
+++ b/specs/charts/line-chart.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
   </style>

--- a/specs/charts/map-chart.html
+++ b/specs/charts/map-chart.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
   </style>
@@ -20,11 +20,11 @@
 
   <app-layout-demo title="Carte de France" icon="ri-map-line" active-path="charts/map-chart" base-path="../">
     <div slot="content">
-      <p class="fr-text--lead">Les composants <code>&lt;map-chart&gt;</code> et <code>&lt;map-chart-reg&gt;</code> visualisent des données geographiques.</p>
+      <p class="fr-text--lead">Le composant <code>&lt;map-chart&gt;</code> visualise des données geographiques : departements, regions, academies ou monde selon l'attribut <code>level</code> (API cartes unifiee de <a href="https://github.com/GouvernementFR/dsfr-chart" target="_blank" rel="noopener">DSFR Chart</a> 2.1).</p>
 
       <section class="demo-section">
-        <h3>Carte departementale</h3>
-        <p>Le composant <code>&lt;map-chart&gt;</code> affiche une carte de France avec données par departement.</p>
+        <h3>Carte departementale (level="dep", défaut)</h3>
+        <p>Sans attribut <code>level</code> (ou avec <code>level="dep"</code>), <code>&lt;map-chart&gt;</code> affiche une carte de France avec données par departement.</p>
         <map-chart
           data='{"75": 95, "13": 82, "69": 78, "33": 71, "31": 68, "59": 88, "67": 75, "44": 80, "34": 72, "06": 91}'
           date="2024-01-15"
@@ -42,15 +42,65 @@
       </section>
 
       <section class="demo-section">
-        <h3>Carte regionale</h3>
-        <div class="fr-callout fr-callout--brown-caramel fr-my-2w">
-          <p class="fr-callout__text">
-            <strong>Limitation connue :</strong> Le composant <code>&lt;map-chart-reg&gt;</code>
-            presente des bugs dans DSFR Chart v2.0.4 (affiche un decoupage departemental au lieu de regional).
-            Consultez la <a href="https://github.com/GouvernementFR/dsfr-chart/issues" target="_blank">page des issues GitHub</a> pour suivre les corrections.
-          </p>
-        </div>
-        <p>Syntaxe attendue pour <code>&lt;map-chart-reg&gt;</code> :</p>
+        <h3>Carte regionale nationale (level="reg")</h3>
+        <p>Avec <code>level="reg"</code>, la carte affiche le decoupage regional national. Les clés de <code>data</code> sont les codes region INSEE.</p>
+        <map-chart
+          level="reg"
+          data='{"11": 95, "84": 82, "76": 78, "75": 71, "44": 68, "32": 88}'
+          date="2024-01-15"
+          name="Score RGAA"
+          selected-palette="sequentialAscending">
+        </map-chart>
+        <div class="code-block"><pre>&lt;map-chart
+  level="reg"
+  data='{"11": 95, "84": 82, "76": 78, "75": 71}'
+  date="2024-01-15"
+  name="Score RGAA"
+  selected-palette="sequentialAscending"&gt;
+&lt;/map-chart&gt;</pre></div>
+      </section>
+
+      <section class="demo-section">
+        <h3>Carte des academies (level="aca")</h3>
+        <p>Avec <code>level="aca"</code>, les clés de <code>data</code> sont les noms d'academie en majuscules.</p>
+        <map-chart
+          level="aca"
+          data='{"PARIS": 95, "LYON": 82, "STRASBOURG": 78, "BORDEAUX": 71, "LILLE": 88}'
+          date="2024-01-15"
+          name="Score RGAA"
+          selected-palette="sequentialAscending">
+        </map-chart>
+        <div class="code-block"><pre>&lt;map-chart
+  level="aca"
+  data='{"PARIS": 95, "LYON": 82, "STRASBOURG": 78}'
+  date="2024-01-15"
+  name="Score RGAA"
+  selected-palette="sequentialAscending"&gt;
+&lt;/map-chart&gt;</pre></div>
+      </section>
+
+      <section class="demo-section">
+        <h3>Carte mondiale (level="monde")</h3>
+        <p>Avec <code>level="monde"</code>, les clés de <code>data</code> sont les codes pays ISO 3166-1 alpha-2. Via <code>&lt;dsfr-data-chart type="map-monde"&gt;</code>, les codes alpha-3 et numériques sont convertis automatiquement.</p>
+        <map-chart
+          level="monde"
+          data='{"FR": 95, "DE": 82, "IT": 78, "ES": 71, "US": 60, "JP": 55}'
+          date="2024-01-15"
+          name="Indicateur"
+          selected-palette="sequentialAscending">
+        </map-chart>
+        <div class="code-block"><pre>&lt;map-chart
+  level="monde"
+  data='{"FR": 95, "DE": 82, "US": 60}'
+  date="2024-01-15"
+  name="Indicateur"
+  selected-palette="sequentialAscending"&gt;
+&lt;/map-chart&gt;</pre></div>
+      </section>
+
+      <section class="demo-section">
+        <h3>Zoom sur une region (&lt;map-chart-reg&gt;)</h3>
+        <p>Le composant <code>&lt;map-chart-reg region="…"&gt;</code> zoome sur <strong>une</strong> region donnee : les clés de <code>data</code> sont alors les departements de cette region. Pour la carte nationale des regions, utiliser <code>level="reg"</code> ci-dessus.</p>
         <div class="code-block"><pre>&lt;map-chart-reg
   data='{"75": 95, "77": 82, "78": 85, "91": 78, "92": 90}'
   date="2024-01-15"
@@ -71,9 +121,14 @@
         </thead>
         <tbody>
           <tr>
+            <td><code>level</code></td>
+            <td>String</td>
+            <td>Decoupage : <code>dep</code> (défaut), <code>reg</code>, <code>aca</code>, <code>monde</code> — DSFR Chart &ge; 2.1</td>
+          </tr>
+          <tr>
             <td><code>data</code></td>
             <td>String (JSON)</td>
-            <td>Dictionnaire JSON avec codes departement/region comme clés et valeurs numériques</td>
+            <td>Dictionnaire JSON : clés selon le <code>level</code> (code departement, code region, nom d'academie en majuscules, code pays ISO alpha-2), valeurs numériques</td>
           </tr>
           <tr>
             <td><code>date</code></td>

--- a/specs/charts/pie-chart.html
+++ b/specs/charts/pie-chart.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
   </style>

--- a/specs/charts/radar-chart.html
+++ b/specs/charts/radar-chart.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
   </style>

--- a/specs/charts/scatter-chart.html
+++ b/specs/charts/scatter-chart.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
   </style>

--- a/specs/components/dsfr-data-a11y.html
+++ b/specs/components/dsfr-data-a11y.html
@@ -7,8 +7,8 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
   <style>

--- a/specs/components/dsfr-data-chart.html
+++ b/specs/components/dsfr-data-chart.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
   </style>
@@ -40,7 +40,7 @@
         <thead><tr><th>Attribut</th><th>Type</th><th>Description</th></tr></thead>
         <tbody>
           <tr><td><code>source</code></td><td>String</td><td>ID du <code>&lt;dsfr-data-source&gt;</code> (requis)</td></tr>
-          <tr><td><code>type</code></td><td>String</td><td>Type de chart : <code>bar</code>, <code>line</code>, <code>pie</code>, <code>radar</code>, <code>gauge</code>, <code>scatter</code></td></tr>
+          <tr><td><code>type</code></td><td>String</td><td>Type de chart : <code>bar</code>, <code>line</code>, <code>pie</code>, <code>radar</code>, <code>gauge</code>, <code>scatter</code>, <code>bar-line</code>, <code>map</code>, <code>map-reg</code>, <code>map-aca</code>, <code>map-monde</code></td></tr>
           <tr><td><code>label-field</code></td><td>String</td><td>Chemin vers le champ label dans les données</td></tr>
           <tr><td><code>value-field</code></td><td>String</td><td>Chemin vers le champ valeur dans les données</td></tr>
           <tr><td><code>selected-palette</code></td><td>String</td><td>Palette : <code>default</code>, <code>categorical</code>, <code>sequential*</code>, <code>divergent*</code></td></tr>
@@ -48,7 +48,7 @@
           <tr><td><code>horizontal</code></td><td>Boolean</td><td>Barres horizontales (bar chart)</td></tr>
           <tr><td><code>stacked</code></td><td>Boolean</td><td>Barres empilees (bar chart)</td></tr>
           <tr><td><code>fill</code></td><td>Boolean</td><td>Remplissage plein (pie chart)</td></tr>
-          <tr><td><code>code-field</code></td><td>String</td><td>Champ code departement/region (map, map-reg)</td></tr>
+          <tr><td><code>code-field</code></td><td>String</td><td>Champ code : departement/region (map, map-reg), nom d'academie (map-aca), code pays ISO a2/a3/num (map-monde)</td></tr>
           <tr><td><code>map-highlight</code></td><td>String</td><td>Departements/regions a surligner</td></tr>
           <tr><td><code>gauge-value</code></td><td>Number</td><td>Valeur de la jauge 0-100 (type gauge)</td></tr>
           <tr><td><code>value-field-2</code></td><td>String</td><td>2e série de valeurs (bar-line)</td></tr>

--- a/specs/components/dsfr-data-facets.html
+++ b/specs/components/dsfr-data-facets.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
     .attr-table { width: 100%; border-collapse: collapse; }

--- a/specs/components/dsfr-data-normalize.html
+++ b/specs/components/dsfr-data-normalize.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
     .attr-table { width: 100%; border-collapse: collapse; }

--- a/specs/components/dsfr-data-search.html
+++ b/specs/components/dsfr-data-search.html
@@ -7,10 +7,10 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }
     .attr-table { width: 100%; border-collapse: collapse; }

--- a/specs/index.html
+++ b/specs/index.html
@@ -11,14 +11,14 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
 
   <!-- DSFR Chart CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
 
   <!-- dsfr-data - Production bundle -->
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
 
   <!-- DSFR Chart JS -->
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
 
   <style>
     body {
@@ -46,6 +46,8 @@
         <p class="fr-text--lead">
           dsfr-data est une bibliotheque de Web Components pour creer des tableaux de bord
           et visualisations de données conformes au Design System de l'État (DSFR).
+          Le rendu des graphiques s'appuie sur la bibliotheque officielle
+          <a href="https://github.com/GouvernementFR/dsfr-chart" target="_blank" rel="noopener">DSFR Chart</a>.
         </p>
 
         <!-- Architecture et principe -->

--- a/specs/roadmap.html
+++ b/specs/roadmap.html
@@ -11,14 +11,14 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
 
   <!-- DSFR Chart CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css" integrity="sha384-987+TUcyVaQAI/PaEqYIGNqku/bHSkNVAqOfNxyS1eE9SxeeH2Ue4FQZ3kKtnWfM" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css" integrity="sha384-5m9vgfA+uOR3qcY14HhRzWDK17cwEVXO75RSwv2KJXignSdIrOvz1xNaaDpWXCeu" crossorigin="anonymous">
 
   <!-- dsfr-data - Production bundle -->
   <script type="module" src="/dist/dsfr-data.esm.js"></script>
   <script type="module" src="/dist/app-ui.esm.js"></script>
 
   <!-- DSFR Chart JS -->
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js" integrity="sha384-xYrR55uYb2Y55H6eELrLA9ARM8YsjB1ksG6QHJZrhL49lzax9l7rHuQPjsZGiTYk" crossorigin="anonymous"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js" integrity="sha384-OJTIJmv0zL1Ym2Bd6hA0oHB25gTqveSogoyVtnN3cEJcm4qE28qzTEp56vJeeKIS" crossorigin="anonymous"></script>
 
   <style>
     body { min-height: 100vh; display: flex; flex-direction: column; }

--- a/tests/apps/builder-ia/action-schema.test.ts
+++ b/tests/apps/builder-ia/action-schema.test.ts
@@ -27,6 +27,8 @@ describe('builder-ia action-schema', () => {
         'map',
         'bar-line',
         'map-reg',
+        'map-aca',
+        'map-monde',
         'datalist',
         'podium',
       ];

--- a/tests/apps/dashboard/dashboards.test.ts
+++ b/tests/apps/dashboard/dashboards.test.ts
@@ -18,9 +18,9 @@ vi.mock('@dsfr-data/shared', () => ({
     dsfrUtilityCss: 'https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css',
     dsfrModuleJs: 'https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js',
     dsfrChartCss:
-      'https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.css',
+      'https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.css',
     dsfrChartJs:
-      'https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.0.4/dist/DSFRChart/DSFRChart.js',
+      'https://cdn.jsdelivr.net/npm/@gouvfr/dsfr-chart@2.1.1/dist/DSFRChart/DSFRChart.js',
     chartJs: 'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js',
   },
 }));


### PR DESCRIPTION
Implémente les phases P0→P3 de #402 + la partie « release N » du P4 (dépréciation), et ajoute les crédits vers le projet upstream.

## Changements

### 🔴 P0 — DataBox `title` → `name` (bug actif en prod)
- `dsfr-data-chart` pose `name` (renommage DSFR Chart 2.1.0) **et** `title` en compat hôtes 2.0.x
- L'embed du builder génère `name="…"`
- builder-ia non concerné (passe par notre attribut `databox-title`)

### 🟠 P1 — `map`/`map-reg` → `<map-chart level="dep|reg">`
- Corrige la limitation connue de la carte régionale nationale (`<map-chart-reg>` sans `region`)
- Callout « limitation connue » retiré des specs ; la démo Ghibli affiche une vraie carte régionale
- `<map-chart-reg region>` documenté dans son nouveau rôle (zoom sur UNE région)

### 🟢 P2 — Nouveaux types `map-aca` et `map-monde`
- `DSFRChartType` + `CHART_TAG_MAP` + `_processMapData()` + `_getAriaLabel()`
- `map-monde` : conversion automatique ISO alpha-3 / numérique → alpha-2 (`toIsoA2` dans `continent-lookup.ts`)
- `map-aca` : clés = noms d'académie en majuscules
- Cascade : `MAP_LEVEL_MAP` exporté dans les **deux** barrels du shared, builder-ia (state, action-schema, chat, data-tools, chart-renderer, code-generator, **skills.ts**), grist-widgets (dropdown), specs

### 🎯 P4 (release N) — dépréciation `dsfr-data-world-map`
- `console.warn` + `@deprecated` + note dans le skill — retrait effectif au prochain major (cycle en 2 releases documenté dans #402)

### 🔵 P3 — Doc statique CDN 2.0.4 → 2.1.1
- 44 fichiers HTML + README + `dashboards.test.ts` bumpés, SRI régénérés (`check:sri` vert)
- grist-widgets branché sur `CDN_URLS` au lieu d'URLs en dur (cf #322)

### 🤝 Crédits DSFR Chart
- Section « Credits » dans le README, lien DSFR Chart dans le footer des apps/specs/guide, mention sur la home des specs et la page map-chart, THIRD-PARTY-LICENSES → repo GitHub upstream

## Changesets
- `patch` : correctifs DataBox `name` + routage `level`
- `minor` : nouveaux types `map-aca`/`map-monde` + dépréciation world-map

## Validation
- Unitaires : **3594/3594** ✅ (alignement `action-schema.test.ts`)
- E2E smoke (playground + map + guide) : **17/17** ✅ dont `facets-map`, `direct-worldmap`, DataBox
- Navigateur (dev server réel) : les 4 `level` rendent ; conversions vérifiées (`FRA/USA/276` → `FR/US/DE`, `paris` → `PARIS`, `3` → `03`) ; titre DataBox visible
- `map-chart-reg` absent des bundles produits ; lint 0 erreur (3 warnings préexistants)

NB : des échecs E2E préexistants sur `main` (pages doc-only `specs-live`, overlay du tour dans playground) ont été observés à l'identique hors de cette branche — hors périmètre, issue à ouvrir.

Closes rien — #402 reste ouverte pour le P4 final (retrait world-map au prochain major).

🤖 Generated with [Claude Code](https://claude.com/claude-code)