### PR TITLE
feat(map): nouveaux fonds de carte (carto, opentopomap, osm) + fix ign-topo

### DIFF
--- a/.changeset/four-tile-presets.md
+++ b/.changeset/four-tile-presets.md
@@ -1,0 +1,9 @@
+---
+'dsfr-data': minor
+---
+
+dsfr-data-map : nouveaux fonds de carte et correction d'ign-topo (#429)
+
+- Nouveaux presets `tiles` sans clé API : `carto-positron` et `carto-dark` (CARTO, fonds sobres idéaux pour la dataviz), `opentopomap` (carte topographique communautaire) et `osm-standard` (tuiles OpenStreetMap.org), chacun avec l'attribution requise.
+- `ign-topo` est déprécié : la couche Géoplateforme `GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1` rendait un fond quasi vide et les couches topographiques SCAN exigent une clé API. Le preset redirige désormais vers `ign-plan` avec un `console.warn` explicite — les pages existantes ne cassent pas.
+- La frontière `sovereign-only` reste inchangée (presets IGN uniquement, fallback `ign-plan`) ; les nouveaux presets y sont refusés avec avertissement.

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -2424,8 +2424,8 @@ Leaflet est charge dynamiquement (pas inclus dans le bundle).
 | min-zoom | Number | \`2\` | Zoom minimum |
 | max-zoom | Number | \`18\` | Zoom maximum |
 | height | String | \`"500px"\` | Hauteur CSS (px, vh, rem). Un \`%\` est un ratio de la largeur (ex: \`"60%"\` = 60% de la largeur) |
-| tiles | String | \`"ign-plan"\` | Fond de carte : \`ign-plan\`, \`ign-ortho\`, \`ign-topo\`, \`ign-cadastre\`, \`osm-fr\` (alias : \`osm\`), ou URL template |
-| sovereign-only | Boolean | \`false\` | Restreint \`tiles\` aux presets IGN souverains. Tout autre preset (\`osm-fr\`) ou URL custom est refuse avec \`console.warn\` et remplace par \`ign-plan\`. |
+| tiles | String | \`"ign-plan"\` | Fond de carte : \`ign-plan\`, \`ign-ortho\`, \`ign-cadastre\`, \`osm-fr\` (alias : \`osm\`), \`osm-standard\`, \`carto-positron\`, \`carto-dark\`, \`opentopomap\`, ou URL template. \`ign-topo\` est deprecie (redirige vers \`ign-plan\` avec warning) |
+| sovereign-only | Boolean | \`false\` | Restreint \`tiles\` aux presets IGN souverains. Tout autre preset (\`osm-fr\`, \`carto-*\`, \`opentopomap\`...) ou URL custom est refuse avec \`console.warn\` et remplace par \`ign-plan\`. |
 | no-controls | Boolean | \`false\` | Masque les controles de zoom |
 | fit-bounds | Boolean | \`false\` | Ajuste le viewport aux données |
 | max-bounds | String | \`""\` | Limites \`"latSW,lonSW,latNE,lonNE"\` |
@@ -2478,11 +2478,15 @@ Leaflet est charge dynamiquement (pas inclus dans le bundle).
 
 ### Fonds de carte predefinis (sans clé API)
 
-- \`ign-plan\` : Plan IGN (Geoplateforme)
+- \`ign-plan\` : Plan IGN (Geoplateforme) — defaut
 - \`ign-ortho\` : Vue aerienne IGN
-- \`ign-topo\` : Carte topographique IGN (SCAN 25/100)
 - \`ign-cadastre\` : Parcelles cadastrales IGN
-- \`osm\` : OpenStreetMap France
+- \`osm\` / \`osm-fr\` : OpenStreetMap France
+- \`osm-standard\` : OpenStreetMap (tuiles osm.org)
+- \`carto-positron\` : CARTO Positron (fond clair sobre, ideal dataviz)
+- \`carto-dark\` : CARTO Dark Matter (fond sombre)
+- \`opentopomap\` : OpenTopoMap (carte topographique communautaire)
+- \`ign-topo\` : deprecie — redirige vers \`ign-plan\` (couche BDUNI quasi vide, couches SCAN topo soumises a clé API)
 
 ### Exemple : POI avec clustering
 

--- a/docs/THIRD-PARTY-LICENSES.md
+++ b/docs/THIRD-PARTY-LICENSES.md
@@ -25,8 +25,12 @@ Les presets de tuiles fournis par `dsfr-data-map` ne redistribuent aucun contenu
 
 | Preset | Service | Souverainete | Conditions d'usage |
 |---|---|---|---|
-| `ign-plan`, `ign-ortho`, `ign-topo`, `ign-cadastre` | [Géoplateforme nationale IGN](https://geoservices.ign.fr/services-geoplateforme) | Oui (IGN, hébergée en France) | Accès sans clé API, mention de la source IGN requise (gérée automatiquement par l'attribution Leaflet) |
+| `ign-plan`, `ign-ortho`, `ign-cadastre` | [Géoplateforme nationale IGN](https://geoservices.ign.fr/services-geoplateforme) | Oui (IGN, hébergée en France) | Accès sans clé API, mention de la source IGN requise (gérée automatiquement par l'attribution Leaflet) |
+| `ign-topo` (déprécié) | — | — | Redirigé vers `ign-plan` avec avertissement console : la couche BDUNI.J1 rendait un fond quasi vide et les couches topographiques SCAN de la Géoplateforme exigent une clé API |
 | `osm-fr` (alias : `osm`) | [OpenStreetMap France](https://www.openstreetmap.fr/) (association) | Non (associatif hors État) | Accès sans clé API, respect de la [Tile Usage Policy OSM France](https://www.openstreetmap.fr/). Distinct de l'OpenStreetMap Foundation. |
+| `osm-standard` | [OpenStreetMap Foundation](https://www.openstreetmap.org/) | Non | Accès sans clé API, respect de la [Tile Usage Policy OSMF](https://operations.osmfoundation.org/policies/tiles/). Données © contributeurs OpenStreetMap (ODbL). |
+| `carto-positron`, `carto-dark` | [CARTO basemaps](https://carto.com/basemaps) | Non (CDN CARTO) | Gratuit pour usage non commercial avec [attribution CARTO](https://carto.com/attributions) + OpenStreetMap. |
+| `opentopomap` | [OpenTopoMap](https://opentopomap.org/) (communautaire) | Non | Accès sans clé API, rendu sous licence CC-BY-SA, données © contributeurs OpenStreetMap + SRTM. |
 
 L'attribut `sovereign-only` du composant `<dsfr-data-map>` restreint les presets acceptés aux seules tuiles IGN.
 

--- a/guide/guide-exemples-map.html
+++ b/guide/guide-exemples-map.html
@@ -265,16 +265,21 @@
         <!-- ============================================================ -->
         <h2>Fonds de carte</h2>
         <p>
-          Quatre presets souverains sont disponibles. Vous pouvez aussi passer une URL template personnalisee.
+          Huit presets sont disponibles sans clé API (trois souverains IGN, utilisables avec
+          <code>sovereign-only</code>). Vous pouvez aussi passer une URL template personnalisée.
         </p>
         <table class="fr-table fr-table--sm fr-mt-1w">
           <thead><tr><th>Preset</th><th>Source</th><th>Usage</th></tr></thead>
           <tbody>
-            <tr><td><code>ign-plan</code></td><td>IGN Geoplateforme</td><td>Plan de base (defaut)</td></tr>
-            <tr><td><code>ign-ortho</code></td><td>IGN Geoplateforme</td><td>Vue aerienne</td></tr>
-            <tr><td><code>ign-topo</code></td><td>IGN Geoplateforme</td><td>Carte topographique (SCAN 25/100)</td></tr>
-            <tr><td><code>ign-cadastre</code></td><td>IGN Geoplateforme</td><td>Parcelles cadastrales</td></tr>
-            <tr><td><code>osm</code></td><td>OpenStreetMap France</td><td>Carte communautaire</td></tr>
+            <tr><td><code>ign-plan</code></td><td>IGN Geoplateforme</td><td>Plan de base (défaut, souverain)</td></tr>
+            <tr><td><code>ign-ortho</code></td><td>IGN Geoplateforme</td><td>Vue aérienne (souverain)</td></tr>
+            <tr><td><code>ign-cadastre</code></td><td>IGN Geoplateforme</td><td>Parcelles cadastrales (souverain)</td></tr>
+            <tr><td><code>osm</code> / <code>osm-fr</code></td><td>OpenStreetMap France</td><td>Carte communautaire</td></tr>
+            <tr><td><code>osm-standard</code></td><td>OpenStreetMap</td><td>Carte communautaire (tuiles osm.org)</td></tr>
+            <tr><td><code>carto-positron</code></td><td>CARTO</td><td>Fond clair sobre, idéal dataviz</td></tr>
+            <tr><td><code>carto-dark</code></td><td>CARTO</td><td>Fond sombre</td></tr>
+            <tr><td><code>opentopomap</code></td><td>OpenTopoMap</td><td>Carte topographique communautaire</td></tr>
+            <tr><td><code>ign-topo</code></td><td>—</td><td>Déprécié : redirige vers <code>ign-plan</code> avec un avertissement console</td></tr>
           </tbody>
         </table>
 

--- a/packages/core/src/components/dsfr-data-map.ts
+++ b/packages/core/src/components/dsfr-data-map.ts
@@ -15,7 +15,7 @@ type LeafletMap = import('leaflet').Map;
 type LeafletTileLayer = import('leaflet').TileLayer;
 type LatLngBoundsExpression = import('leaflet').LatLngBoundsExpression;
 
-/** Tile presets — souverains (IGN) ou europeens (OSM France), sans clé API */
+/** Tile presets — souverains (IGN), europeens (OSM) ou dataviz (CARTO), sans clé API */
 const TILE_PRESETS: Record<
   string,
   { url: string; attribution: string; options?: Record<string, unknown> }
@@ -28,10 +28,6 @@ const TILE_PRESETS: Record<
     url: 'https://data.geopf.fr/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=ORTHOIMAGERY.ORTHOPHOTOS&STYLE=normal&FORMAT=image/jpeg&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
     attribution: '&copy; <a href="https://www.ign.fr/">IGN</a>',
   },
-  'ign-topo': {
-    url: 'https://data.geopf.fr/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1&STYLE=normal&FORMAT=image/png&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
-    attribution: '&copy; <a href="https://www.ign.fr/">IGN</a>',
-  },
   'ign-cadastre': {
     url: 'https://data.geopf.fr/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=CADASTRALPARCELS.PARCELLAIRE_EXPRESS&STYLE=normal&FORMAT=image/png&TILEMATRIXSET=PM&TILEMATRIX={z}&TILEROW={y}&TILECOL={x}',
     attribution: '&copy; <a href="https://www.ign.fr/">IGN</a>',
@@ -41,11 +37,50 @@ const TILE_PRESETS: Record<
     attribution:
       '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> — serveurs <a href="https://www.openstreetmap.fr/">OSM France</a>',
   },
+  'osm-standard': {
+    url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+    options: { maxZoom: 19 },
+  },
+  'carto-positron': {
+    url: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png',
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+    options: { subdomains: 'abcd', maxZoom: 20 },
+  },
+  'carto-dark': {
+    url: 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png',
+    attribution:
+      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+    options: { subdomains: 'abcd', maxZoom: 20 },
+  },
+  opentopomap: {
+    url: 'https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png',
+    attribution:
+      'Données : &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, SRTM — Rendu : &copy; <a href="https://opentopomap.org">OpenTopoMap</a> (CC-BY-SA)',
+    options: { maxZoom: 17 },
+  },
 };
 
 /** Alias de presets pour retrocompatibilite. */
 const TILE_ALIASES: Record<string, string> = {
   osm: 'osm-fr',
+};
+
+/**
+ * Presets deprecies — resolus vers un preset de remplacement, avec warning (#429).
+ * `ign-topo` pointait sur la couche Geoplateforme GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1
+ * (couche de travail BD Uni, rendu quasi vide) ; les vraies couches topographiques SCAN
+ * (GEOGRAPHICALGRIDSYSTEMS.MAPS*) ne sont pas servies par l'endpoint libre data.geopf.fr
+ * (clé API requise). On redirige vers `ign-plan` pour ne pas casser les pages existantes.
+ */
+const DEPRECATED_PRESETS: Record<string, { replacement: string; reason: string }> = {
+  'ign-topo': {
+    replacement: 'ign-plan',
+    reason:
+      'la couche IGN BDUNI.J1 rend un fond quasi vide et les couches topographiques SCAN exigent une clé API',
+  },
 };
 
 /** Presets consideres comme souverains (tuiles IGN Geoplateforme, hebergees en France). */
@@ -62,7 +97,18 @@ export function resolveTilePreset(
   requested: string,
   sovereignOnly = false
 ): { key: string | null; warning?: string } {
-  const canonical = TILE_ALIASES[requested] ?? requested;
+  let name = requested;
+  let deprecationWarning: string | undefined;
+
+  const deprecated = DEPRECATED_PRESETS[name];
+  if (deprecated) {
+    deprecationWarning =
+      `tiles="${name}" est deprecie : ${deprecated.reason}. ` +
+      `Fallback sur "${deprecated.replacement}".`;
+    name = deprecated.replacement;
+  }
+
+  const canonical = TILE_ALIASES[name] ?? name;
   const isKnownPreset = canonical in TILE_PRESETS;
 
   if (sovereignOnly && (!isKnownPreset || !SOVEREIGN_PRESETS.has(canonical))) {
@@ -74,13 +120,14 @@ export function resolveTilePreset(
     };
   }
 
-  return { key: isKnownPreset ? canonical : null };
+  return { key: isKnownPreset ? canonical : null, warning: deprecationWarning };
 }
 
 /** Expose pour les tests (valeurs read-only). */
 export const __tilePresetsForTests = {
   presets: TILE_PRESETS,
   aliases: TILE_ALIASES,
+  deprecated: DEPRECATED_PRESETS,
   sovereign: SOVEREIGN_PRESETS,
 } as const;
 

--- a/tests/dsfr-data-map.test.ts
+++ b/tests/dsfr-data-map.test.ts
@@ -90,8 +90,17 @@ describe('DsfrDataMap', () => {
 });
 
 describe('resolveTilePreset', () => {
-  it('resout les 5 presets canoniques sans warning', () => {
-    for (const preset of ['ign-plan', 'ign-ortho', 'ign-topo', 'ign-cadastre', 'osm-fr']) {
+  it('resout les 8 presets canoniques sans warning', () => {
+    for (const preset of [
+      'ign-plan',
+      'ign-ortho',
+      'ign-cadastre',
+      'osm-fr',
+      'osm-standard',
+      'carto-positron',
+      'carto-dark',
+      'opentopomap',
+    ]) {
       const { key, warning } = resolveTilePreset(preset, false);
       expect(key).toBe(preset);
       expect(warning).toBeUndefined();
@@ -104,6 +113,14 @@ describe('resolveTilePreset', () => {
     expect(warning).toBeUndefined();
   });
 
+  it('deprecie "ign-topo" vers "ign-plan" avec warning (#429)', () => {
+    const { key, warning } = resolveTilePreset('ign-topo', false);
+    expect(key).toBe('ign-plan');
+    expect(warning).toMatch(/ign-topo/);
+    expect(warning).toMatch(/deprecie/);
+    expect(warning).toMatch(/ign-plan/);
+  });
+
   it('retourne null sur une URL custom (pas de warning)', () => {
     const custom = 'https://tiles.example.com/{z}/{x}/{y}.png';
     const { key, warning } = resolveTilePreset(custom, false);
@@ -112,12 +129,18 @@ describe('resolveTilePreset', () => {
   });
 
   describe('sovereign-only', () => {
-    it('accepte les 4 presets IGN', () => {
-      for (const preset of ['ign-plan', 'ign-ortho', 'ign-topo', 'ign-cadastre']) {
+    it('accepte les 3 presets IGN actifs', () => {
+      for (const preset of ['ign-plan', 'ign-ortho', 'ign-cadastre']) {
         const { key, warning } = resolveTilePreset(preset, true);
         expect(key).toBe(preset);
         expect(warning).toBeUndefined();
       }
+    });
+
+    it('resout ign-topo deprecie vers ign-plan (souverain) avec warning de depreciation', () => {
+      const { key, warning } = resolveTilePreset('ign-topo', true);
+      expect(key).toBe('ign-plan');
+      expect(warning).toMatch(/deprecie/);
     });
 
     it('refuse osm-fr et force ign-plan avec warning', () => {
@@ -125,6 +148,14 @@ describe('resolveTilePreset', () => {
       expect(key).toBe('ign-plan');
       expect(warning).toMatch(/osm-fr/);
       expect(warning).toMatch(/sovereign-only/);
+    });
+
+    it('refuse les nouveaux presets non souverains et force ign-plan avec warning', () => {
+      for (const preset of ['osm-standard', 'carto-positron', 'carto-dark', 'opentopomap']) {
+        const { key, warning } = resolveTilePreset(preset, true);
+        expect(key).toBe('ign-plan');
+        expect(warning).toMatch(/sovereign-only/);
+      }
     });
 
     it("refuse l'alias osm et force ign-plan avec warning", () => {
@@ -142,9 +173,20 @@ describe('resolveTilePreset', () => {
 });
 
 describe('TILE_PRESETS', () => {
-  it('contient les 5 presets documentes (4 IGN + osm-fr)', () => {
+  it('contient les 8 presets documentes (3 IGN + OSM + CARTO + OpenTopoMap)', () => {
     const keys = Object.keys(__tilePresetsForTests.presets).sort();
-    expect(keys).toEqual(['ign-cadastre', 'ign-ortho', 'ign-plan', 'ign-topo', 'osm-fr'].sort());
+    expect(keys).toEqual(
+      [
+        'ign-cadastre',
+        'ign-ortho',
+        'ign-plan',
+        'osm-fr',
+        'osm-standard',
+        'carto-positron',
+        'carto-dark',
+        'opentopomap',
+      ].sort()
+    );
   });
 
   it('expose 4 presets souverains (tuiles IGN)', () => {
@@ -156,14 +198,33 @@ describe('TILE_PRESETS', () => {
     expect(__tilePresetsForTests.aliases).toEqual({ osm: 'osm-fr' });
   });
 
-  it('toutes les URLs pointent vers data.geopf.fr ou openstreetmap.fr (sans clé API)', () => {
+  it('expose ign-topo comme preset deprecie vers ign-plan (#429)', () => {
+    expect(Object.keys(__tilePresetsForTests.deprecated)).toEqual(['ign-topo']);
+    expect(__tilePresetsForTests.deprecated['ign-topo'].replacement).toBe('ign-plan');
+  });
+
+  it('toutes les URLs pointent vers un hote autorise (sans clé API)', () => {
+    const allowedHosts = [
+      'data.geopf.fr',
+      'openstreetmap.fr',
+      'openstreetmap.org',
+      'basemaps.cartocdn.com',
+      'opentopomap.org',
+    ];
     for (const [key, preset] of Object.entries(__tilePresetsForTests.presets)) {
-      const allowedHosts = ['data.geopf.fr', 'openstreetmap.fr'];
       expect(
         allowedHosts.some((host) => preset.url.includes(host)),
         `preset ${key} doit pointer vers ${allowedHosts.join(' ou ')}`
       ).toBe(true);
       expect(preset.url).not.toMatch(/[?&](key|api_key|apikey)=/);
+    }
+  });
+
+  it('chaque preset declare une attribution non vide', () => {
+    for (const [key, preset] of Object.entries(__tilePresetsForTests.presets)) {
+      expect(preset.attribution.length, `preset ${key} doit avoir une attribution`).toBeGreaterThan(
+        0
+      );
     }
   });
 });


### PR DESCRIPTION
## Résumé

- **`ign-topo` déprécié → redirige vers `ign-plan`** avec un `console.warn` explicite (pas de rupture des pages existantes). La couche Géoplateforme `GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1` rend un fond quasi vide, et aucune couche topographique SCAN n'est servie par l'endpoint libre `data.geopf.fr` (clé API requise).
- **4 nouveaux presets `tiles`** (hors sovereign-only), avec attribution conforme :
  - `carto-positron` / `carto-dark` — CARTO (light_all / dark_all, `{r}` retina, subdomains `abcd`, maxZoom 20), attribution OSM + CARTO
  - `opentopomap` — topo communautaire (maxZoom 17), attribution OSM + SRTM + OpenTopoMap CC-BY-SA
  - `osm-standard` — tuiles OSM.org (maxZoom 19), attribution OSM
- **Frontière `sovereign-only` inchangée** : `SOVEREIGN_PRESETS` non modifié, fallback `ign-plan` + warning conservés ; les nouveaux presets y sont refusés. `ign-topo` en mode sovereign-only résout vers `ign-plan` (souverain) avec le warning de dépréciation.

## Vérifications empiriques (curl, tuile z=6 x=32 y=22, TILEMATRIXSET PM)

| Couche / URL | Résultat |
|---|---|
| `GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1` (ancien ign-topo) | HTTP 200 `image/png` mais **rendu quasi vide** (tuile blanche, quelques traces — inspectée visuellement) |
| `GEOGRAPHICALGRIDSYSTEMS.MAPS` (SCAN) | **HTTP 400** — `Layer GEOGRAPHICALGRIDSYSTEMS.MAPS unknown` sur l'endpoint libre |
| `GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN25TOUR` / `SCAN-EXPRESS.STANDARD` | **HTTP 400** — couches inconnues (clé API requise) |
| `GEOGRAPHICALGRIDSYSTEMS.MAPS.OVERVIEW` | HTTP 200 mais **404 dès z≥9** (aperçu mondial, inutilisable en topo) |
| `a.basemaps.cartocdn.com/light_all/6/32/22.png` | **HTTP 200** `image/png` (15 Ko) — `@2x` retina OK (200, 37 Ko) |
| `b.basemaps.cartocdn.com/dark_all/6/32/22.png` | **HTTP 200** `image/png` (11 Ko) |
| `a.tile.opentopomap.org/6/32/22.png` | **HTTP 200** `image/png` (45 Ko) |
| `tile.openstreetmap.org/6/32/22.png` | **HTTP 200** `image/png` (55 Ko) |

Vérification bundles après `npm run build` : les 4 nouvelles URLs sont présentes dans `dsfr-data.map.esm.js` / `dsfr-data.esm.js` ; **plus aucune URL BDUNI** (seule subsiste la chaîne du message de dépréciation).

## Fichiers modifiés

- `packages/core/src/components/dsfr-data-map.ts` — zone TILE_PRESETS uniquement (nouveaux presets, `DEPRECATED_PRESETS`, résolution dans `resolveTilePreset`) pour minimiser les conflits avec `feat/map-insets`
- `tests/dsfr-data-map.test.ts` — résolution des 8 presets, dépréciation ign-topo, sovereign-only, hôtes autorisés, attributions
- `apps/builder-ia/src/skills.ts` — doc attribut `tiles` + liste des fonds prédéfinis (test-garde skills vert)
- `guide/guide-exemples-map.html` — tableau des fonds de carte
- `docs/THIRD-PARTY-LICENSES.md` — conditions d'usage CARTO / OSMF / OpenTopoMap
- `.changeset/four-tile-presets.md` — minor `dsfr-data`

## Tests

- `npm run build` : OK
- Vitest : **152 fichiers / 3651 tests verts** (dont `tests/apps/builder-ia/skills.test.ts`)
- `npm run check:accents` : OK

## Suivi (hors périmètre)

`specs/components/dsfr-data-map.html` et le sélecteur de fonds d'`apps/builder-carto` mentionnent encore `ign-topo` (fonctionnel via la redirection, mais à rafraîchir dans une PR dédiée).

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)