### PR TITLE
feat(map): encarts territoriaux dsfr-data-map-inset (DROM/COM/Corse) + attribut locked

### DIFF
--- a/.changeset/brave-atolls-gather.md
+++ b/.changeset/brave-atolls-gather.md
@@ -1,0 +1,7 @@
+---
+'dsfr-data': minor
+---
+
+Nouveau composant `dsfr-data-map-inset` : encarts territoriaux (DROM, COM, Corse...) pour `dsfr-data-map`. Chaque encart rend une mini-carte verrouillée qui réutilise automatiquement les couches ET le popup de la carte hôte — un clic dans l'encart ouvre le volet/la modale de la carte principale (template unique). 12 territoires prédéfinis (`territory="guadeloupe"`, `"nouvelle-caledonie"`...) surchargeables par `center`/`zoom`/`label`, et raccourci `insets="drom"` / `insets="drom,corse"` sur `dsfr-data-map` qui génère les encarts.
+
+`dsfr-data-map` : nouvel attribut `locked` (carte sans aucune interaction — encarts, vignettes). La hauteur fixe s'applique désormais au conteneur Leaflet plutôt qu'au host (le host s'étend pour accueillir les compagnons hors-carte) et le panel de `dsfr-data-map-popup` s'ancre sur ce conteneur — rendu identique pour les pages existantes.

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -2427,6 +2427,8 @@ Leaflet est charge dynamiquement (pas inclus dans le bundle).
 | tiles | String | \`"ign-plan"\` | Fond de carte : \`ign-plan\`, \`ign-ortho\`, \`ign-topo\`, \`ign-cadastre\`, \`osm-fr\` (alias : \`osm\`), ou URL template |
 | sovereign-only | Boolean | \`false\` | Restreint \`tiles\` aux presets IGN souverains. Tout autre preset (\`osm-fr\`) ou URL custom est refuse avec \`console.warn\` et remplace par \`ign-plan\`. |
 | no-controls | Boolean | \`false\` | Masque les controles de zoom |
+| locked | Boolean | \`false\` | Carte verrouillee : aucune interaction (pan/zoom/clavier) — encarts, vignettes |
+| insets | String | \`""\` | Raccourci encarts territoriaux : groupe et/ou territoires nommes (\`"drom"\`, \`"drom,corse"\`) |
 | fit-bounds | Boolean | \`false\` | Ajuste le viewport aux données |
 | max-bounds | String | \`""\` | Limites \`"latSW,lonSW,latNE,lonNE"\` |
 | name | String | \`""\` | Titre (aria-label) |
@@ -2587,6 +2589,31 @@ Sans template, tableau auto.
     min-zoom="10" bbox>
   </dsfr-data-map-layer>
 </dsfr-data-map>
+\`\`\`
+
+### dsfr-data-map-inset — Encarts territoriaux (DROM, Corse...)
+
+Composant compagnon place comme enfant de \`dsfr-data-map\`. Rend une mini-carte verrouillee centree
+sur un territoire, qui reutilise automatiquement les couches ET le popup de la carte hote : un clic
+sur un element de l'encart ouvre le volet/la modale de la carte principale (un seul template).
+
+| Attribut | Type | Défaut | Description |
+|----------|------|--------|-------------|
+| territory | String | \`""\` | Territoire predefini : \`guadeloupe\`, \`martinique\`, \`guyane\`, \`la-reunion\`, \`mayotte\`, \`saint-pierre-et-miquelon\`, \`saint-martin\`, \`saint-barthelemy\`, \`nouvelle-caledonie\`, \`polynesie-francaise\`, \`wallis-et-futuna\`, \`corse\` |
+| center | String | \`""\` | Centre \`"lat,lon"\` (requis sans territory ; prioritaire sur le preset) |
+| zoom | Number | \`8\` | Zoom fixe (prioritaire sur le preset) |
+| label | String | \`""\` | Libelle affiche au-dessus (et nom accessible) |
+| height | String | \`"160px"\` | Hauteur de la mini-carte |
+
+\`\`\`html
+<dsfr-data-map center="46.5,2.6" zoom="6" tiles="ign-plan">
+  <dsfr-data-map-layer source="territoires" type="geoshape" geo-field="geojson"></dsfr-data-map-layer>
+  <dsfr-data-map-popup mode="panel-right" title-field="nom"><template>...</template></dsfr-data-map-popup>
+  <dsfr-data-map-inset territory="guadeloupe"></dsfr-data-map-inset>
+  <dsfr-data-map-inset territory="nouvelle-caledonie"></dsfr-data-map-inset>
+  <dsfr-data-map-inset center="4.63,-52.45" zoom="8" label="CA du Centre Littoral"></dsfr-data-map-inset>
+</dsfr-data-map>
+<!-- Raccourci equivalent pour les 5 DROM : <dsfr-data-map insets="drom"> -->
 \`\`\`
 
 ### dsfr-data-map-timeline — Animation temporelle

--- a/packages/core/src/components/dsfr-data-map-inset.ts
+++ b/packages/core/src/components/dsfr-data-map-inset.ts
@@ -1,0 +1,142 @@
+/**
+ * dsfr-data-map-inset — Encart territorial d'une carte (DROM, Corse, zoom local...)
+ *
+ * Composant compagnon place comme enfant de dsfr-data-map. Rend une mini-carte
+ * verrouillee (zoom fixe, sans interactions) centree sur un territoire, qui
+ * reutilise automatiquement les couches (dsfr-data-map-layer) ET le popup
+ * (dsfr-data-map-popup) de la carte hote : un clic sur un element de l'encart
+ * ouvre le volet/la modale de la carte principale.
+ *
+ * @example
+ * <dsfr-data-map center="46.5,2.6" zoom="6" tiles="ign-plan">
+ *   <dsfr-data-map-layer source="territoires" type="geoshape" geo-field="geojson">
+ *   </dsfr-data-map-layer>
+ *   <dsfr-data-map-popup mode="panel-right" title-field="nom">
+ *     <template>...</template>
+ *   </dsfr-data-map-popup>
+ *   <dsfr-data-map-inset center="16.20,-61.45" zoom="9" label="Guadeloupe"></dsfr-data-map-inset>
+ *   <dsfr-data-map-inset center="14.63,-61.00" zoom="9" label="Martinique"></dsfr-data-map-inset>
+ * </dsfr-data-map>
+ */
+import { LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { TERRITORY_PRESETS } from '../utils/territories.js';
+
+export { TERRITORY_PRESETS, TERRITORY_GROUPS } from '../utils/territories.js';
+
+@customElement('dsfr-data-map-inset')
+export class DsfrDataMapInset extends LitElement {
+  /** Territoire predefini (guadeloupe, martinique, guyane, la-reunion, mayotte,
+   *  saint-pierre-et-miquelon, saint-martin, saint-barthelemy, nouvelle-caledonie,
+   *  polynesie-francaise, wallis-et-futuna, corse) — fournit center/zoom/label */
+  @property({ type: String })
+  territory = '';
+
+  /** Centre "lat,lon" de l'encart (requis sans territory ; prioritaire sur le preset) */
+  @property({ type: String })
+  center = '';
+
+  /** Zoom fixe de l'encart (prioritaire sur le preset) */
+  @property({ type: Number })
+  zoom = 0;
+
+  /** Libelle affiche au-dessus de l'encart (et nom accessible de la mini-carte) */
+  @property({ type: String })
+  label = '';
+
+  /** Hauteur de la mini-carte */
+  @property({ type: String })
+  height = '160px';
+
+  private _built = false;
+  private _innerMap: HTMLElement | null = null;
+
+  createRenderRoot() {
+    // Light DOM : coherent avec dsfr-data-map (Leaflet + styles globaux)
+    return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // Differer la construction : au parse initial, les dsfr-data-map-layer
+    // freres peuvent ne pas encore etre presents dans le DOM.
+    requestAnimationFrame(() => this._build());
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._innerMap?.remove();
+    this._innerMap = null;
+    this._built = false;
+  }
+
+  private _build() {
+    if (this._built || !this.isConnected) return;
+    const host = this.closest('dsfr-data-map');
+    if (!host) return;
+
+    // Resolution territoire predefini : les attributs explicites priment
+    if (this.territory) {
+      const preset = TERRITORY_PRESETS[this.territory];
+      if (!preset) {
+        console.warn(
+          `dsfr-data-map-inset: territoire inconnu "${this.territory}". ` +
+            `Territoires disponibles : ${Object.keys(TERRITORY_PRESETS).join(', ')}.`
+        );
+        return;
+      }
+      if (!this.center) this.center = preset.center;
+      if (!this.zoom) this.zoom = preset.zoom;
+      if (!this.label) this.label = preset.label;
+    }
+    if (!this.center) return;
+    if (!this.zoom) this.zoom = 8;
+
+    // Les encarts sont des enfants directs de la carte hote ; on ne clone que
+    // ses couches directes (jamais d'encart -> pas de recursion possible).
+    const layers = host.querySelectorAll(':scope > dsfr-data-map-layer');
+    if (layers.length === 0) return;
+
+    this.style.display = 'inline-block';
+    this.style.verticalAlign = 'top';
+
+    if (this.label) {
+      const labelEl = document.createElement('span');
+      labelEl.className = 'dsfr-data-map-inset__label';
+      labelEl.textContent = this.label;
+      labelEl.style.cssText =
+        'display:block;text-align:center;font-size:.8125rem;font-weight:700;margin-bottom:.25rem;';
+      this.appendChild(labelEl);
+    }
+
+    const inner = document.createElement('dsfr-data-map');
+    inner.setAttribute('center', this.center);
+    inner.setAttribute('zoom', String(this.zoom));
+    inner.setAttribute('min-zoom', String(this.zoom));
+    inner.setAttribute('max-zoom', String(this.zoom));
+    inner.setAttribute('height', this.height);
+    inner.setAttribute('no-controls', '');
+    inner.setAttribute('locked', '');
+    const tiles = host.getAttribute('tiles');
+    if (tiles) inner.setAttribute('tiles', tiles);
+    inner.setAttribute('name', this.label ? `Encart — ${this.label}` : 'Encart de carte');
+
+    for (const layer of layers) {
+      // Clone superficiel : attributs seulement (pas les popups/templates enfants).
+      const clone = layer.cloneNode(false) as HTMLElement;
+      // Jamais d'id duplique dans le document ; matchesLayer() retombe sur `source`.
+      clone.removeAttribute('id');
+      inner.appendChild(clone);
+    }
+
+    this.appendChild(inner);
+    this._innerMap = inner;
+    this._built = true;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'dsfr-data-map-inset': DsfrDataMapInset;
+  }
+}

--- a/packages/core/src/components/dsfr-data-map-layer.ts
+++ b/packages/core/src/components/dsfr-data-map-layer.ts
@@ -991,6 +991,17 @@ export class DsfrDataMapLayer extends SourceSubscriberMixin(LitElement) {
       // carte, sans for) ne fonctionnait pas car le layer exigeait un for
       if (popup.matchesLayer?.(layerId)) return popup;
     }
+
+    // 3. Carte d'encart (dsfr-data-map-inset) : deleguer aux popups de la
+    //    carte hote — le volet/la modale s'ouvre sur la carte principale
+    const inset = this._mapParent.closest('dsfr-data-map-inset');
+    const hostMap = inset?.closest('dsfr-data-map');
+    if (hostMap) {
+      for (const p of hostMap.querySelectorAll(':scope > dsfr-data-map-popup')) {
+        const popup = p as import('./dsfr-data-map-popup.js').DsfrDataMapPopup;
+        if (popup.matchesLayer?.(layerId)) return popup;
+      }
+    }
     return null;
   }
 

--- a/packages/core/src/components/dsfr-data-map-popup.ts
+++ b/packages/core/src/components/dsfr-data-map-popup.ts
@@ -185,11 +185,14 @@ export class DsfrDataMapPopup extends LitElement {
     if (!this._panelEl) {
       this._panelEl = document.createElement('div');
       this._panelEl.className = `dsfr-data-map-popup__panel dsfr-data-map-popup__panel--${side}`;
+      // Ancrer sur la zone carte (conteneur Leaflet) : le panel ne recouvre
+      // pas les compagnons hors-carte (encarts DROM...) du host
       this._panelEl.style.width = this.width;
       this._panelEl.setAttribute('role', 'complementary');
       this._panelEl.setAttribute('aria-label', "Details de l'element sélectionné");
       this._panelEl.setAttribute('aria-live', 'polite');
-      mapParent.appendChild(this._panelEl);
+      const anchor = mapParent.querySelector(':scope > .dsfr-data-map__container') ?? mapParent;
+      anchor.appendChild(this._panelEl);
       // Trigger slide-in animation
       requestAnimationFrame(() => {
         this._panelEl?.classList.add('dsfr-data-map-popup__panel--open');

--- a/packages/core/src/components/dsfr-data-map.ts
+++ b/packages/core/src/components/dsfr-data-map.ts
@@ -7,6 +7,7 @@
 import { LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { sendWidgetBeacon } from '../utils/beacon.js';
+import { TERRITORY_GROUPS } from '../utils/territories.js';
 // @ts-expect-error — Vite ?inline import returns CSS as string
 import leafletCss from 'leaflet/dist/leaflet.css?inline';
 
@@ -133,6 +134,15 @@ export class DsfrDataMap extends LitElement {
   @property({ type: Boolean, attribute: 'no-controls' })
   noControls = false;
 
+  /** Carte verrouillee : aucune interaction (pan/zoom/clavier) — encarts, vignettes */
+  @property({ type: Boolean })
+  locked = false;
+
+  /** Raccourci encarts territoriaux : groupe ("drom") et/ou territoires nommes
+   *  separes par des virgules ("drom,corse", "guadeloupe,saint-pierre-et-miquelon") */
+  @property({ type: String })
+  insets = '';
+
   @property({ type: Boolean, attribute: 'fit-bounds' })
   fitBounds = false;
 
@@ -171,7 +181,31 @@ export class DsfrDataMap extends LitElement {
     // variante fonctionnelle (convention beacon.ts). Les types de couches
     // sont remontes par chaque dsfr-data-map-layer.
     sendWidgetBeacon('dsfr-data-map');
+    this._expandInsets();
     this._deferInitUntilVisible();
+  }
+
+  /**
+   * Raccourci `insets` : genere les enfants dsfr-data-map-inset a partir de
+   * groupes ("drom") et/ou de territoires nommes ("guadeloupe,corse").
+   * Les encarts poses explicitement en HTML priment (pas de doublon).
+   */
+  private _insetsExpanded = false;
+
+  private _expandInsets() {
+    if (this._insetsExpanded || !this.insets) return;
+    this._insetsExpanded = true;
+    const names = this.insets
+      .split(',')
+      .map((t) => t.trim().toLowerCase())
+      .filter(Boolean)
+      .flatMap((t) => TERRITORY_GROUPS[t] ?? [t]);
+    for (const name of names) {
+      if (this.querySelector(`:scope > dsfr-data-map-inset[territory="${name}"]`)) continue;
+      const inset = document.createElement('dsfr-data-map-inset');
+      inset.setAttribute('territory', name);
+      this.appendChild(inset);
+    }
   }
 
   /**
@@ -243,14 +277,21 @@ export class DsfrDataMap extends LitElement {
    */
   private _applyHeight() {
     // Linear: \d and literal '.' / '%' don't overlap → no catastrophic backtracking.
-    // eslint-disable-next-line security/detect-unsafe-regex
+     
+    // La hauteur s'applique au conteneur Leaflet, pas au host : le host reste
+    // en flux auto pour laisser leur place aux compagnons hors-carte
+    // (dsfr-data-map-inset). Visuellement identique sans encart.
+    const setHeight = (px: string) => {
+      if (this._container) this._container.style.height = px;
+      this.style.height = '';
+    };
     const pctMatch = this.height.match(/^(\d+(?:\.\d+)?)%$/);
     if (pctMatch) {
       const ratio = parseFloat(pctMatch[1]) / 100;
       const applyRatio = () => {
         const w = this.clientWidth;
         if (w > 0) {
-          this.style.height = `${Math.round(w * ratio)}px`;
+          setHeight(`${Math.round(w * ratio)}px`);
         }
       };
       applyRatio();
@@ -265,10 +306,7 @@ export class DsfrDataMap extends LitElement {
       // Absolute unit — stop observing
       this._resizeObserver?.disconnect();
       this._resizeObserver = null;
-      this.style.height = this.height;
-    }
-    if (this._container) {
-      this._container.style.height = '100%';
+      setHeight(this.height);
     }
   }
 
@@ -424,7 +462,17 @@ export class DsfrDataMap extends LitElement {
       zoom: this.zoom,
       minZoom: this.minZoom,
       maxZoom: this.maxZoom,
-      zoomControl: !this.noControls,
+      zoomControl: !this.noControls && !this.locked,
+      ...(this.locked
+        ? {
+            dragging: false,
+            scrollWheelZoom: false,
+            doubleClickZoom: false,
+            boxZoom: false,
+            keyboard: false,
+            touchZoom: false,
+          }
+        : {}),
     });
 
     // Max bounds

--- a/packages/core/src/components/dsfr-data-map.ts
+++ b/packages/core/src/components/dsfr-data-map.ts
@@ -277,7 +277,7 @@ export class DsfrDataMap extends LitElement {
    */
   private _applyHeight() {
     // Linear: \d and literal '.' / '%' don't overlap → no catastrophic backtracking.
-     
+
     // La hauteur s'applique au conteneur Leaflet, pas au host : le host reste
     // en flux auto pour laisser leur place aux compagnons hors-carte
     // (dsfr-data-map-inset). Visuellement identique sans encart.

--- a/packages/core/src/index-map.ts
+++ b/packages/core/src/index-map.ts
@@ -7,4 +7,5 @@
 export { DsfrDataMap } from './components/dsfr-data-map.js';
 export { DsfrDataMapLayer } from './components/dsfr-data-map-layer.js';
 export { DsfrDataMapPopup } from './components/dsfr-data-map-popup.js';
+export { DsfrDataMapInset } from './components/dsfr-data-map-inset.js';
 export { DsfrDataMapTimeline } from './components/dsfr-data-map-timeline.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export { DsfrDataWorldMap } from './components/dsfr-data-world-map.js';
 export { DsfrDataMap } from './components/dsfr-data-map.js';
 export { DsfrDataMapLayer } from './components/dsfr-data-map-layer.js';
 export { DsfrDataMapPopup } from './components/dsfr-data-map-popup.js';
+export { DsfrDataMapInset } from './components/dsfr-data-map-inset.js';
 export { DsfrDataMapTimeline } from './components/dsfr-data-map-timeline.js';
 export { DsfrDataA11y } from './components/dsfr-data-a11y.js';
 export { DsfrDataBeacon } from './components/dsfr-data-beacon.js';

--- a/packages/core/src/utils/territories.ts
+++ b/packages/core/src/utils/territories.ts
@@ -1,0 +1,28 @@
+/**
+ * Presets des territoires français hors métropole (+ Corse) pour les encarts
+ * de carte (dsfr-data-map-inset) : cadrage territoire entier.
+ * Surchargables par les attributs center/zoom/label de l'encart.
+ */
+export const TERRITORY_PRESETS: Record<string, { center: string; zoom: number; label: string }> = {
+  guadeloupe: { center: '16.20,-61.45', zoom: 9, label: 'Guadeloupe' },
+  martinique: { center: '14.63,-61.00', zoom: 9, label: 'Martinique' },
+  guyane: { center: '4.00,-53.10', zoom: 6, label: 'Guyane' },
+  'la-reunion': { center: '-21.115,55.53', zoom: 9, label: 'La Réunion' },
+  mayotte: { center: '-12.83,45.15', zoom: 10, label: 'Mayotte' },
+  'saint-pierre-et-miquelon': {
+    center: '46.95,-56.33',
+    zoom: 9,
+    label: 'Saint-Pierre-et-Miquelon',
+  },
+  'saint-martin': { center: '18.08,-63.06', zoom: 11, label: 'Saint-Martin' },
+  'saint-barthelemy': { center: '17.90,-62.83', zoom: 11, label: 'Saint-Barthélemy' },
+  'nouvelle-caledonie': { center: '-21.30,165.50', zoom: 6, label: 'Nouvelle-Calédonie' },
+  'polynesie-francaise': { center: '-17.55,-149.55', zoom: 8, label: 'Polynésie française' },
+  'wallis-et-futuna': { center: '-13.80,-177.15', zoom: 7, label: 'Wallis-et-Futuna' },
+  corse: { center: '42.15,9.10', zoom: 7, label: 'Corse' },
+};
+
+/** Groupes nommés pour le raccourci `insets` de dsfr-data-map */
+export const TERRITORY_GROUPS: Record<string, string[]> = {
+  drom: ['guadeloupe', 'martinique', 'guyane', 'la-reunion', 'mayotte'],
+};

--- a/tests/dsfr-data-map-inset.test.ts
+++ b/tests/dsfr-data-map-inset.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+/**
+ * Tests dsfr-data-map-inset — encarts territoriaux (DROM, Corse...).
+ *
+ * L'encart clone les couches de la carte hote dans une mini-carte verrouillee
+ * et delegue son popup a la carte hote (volet unique). Presets de territoires
+ * francais + raccourci `insets` sur dsfr-data-map.
+ */
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+import {
+  DsfrDataMapInset,
+  TERRITORY_PRESETS,
+  TERRITORY_GROUPS,
+} from '@/components/dsfr-data-map-inset.js';
+import { DsfrDataMap } from '@/components/dsfr-data-map.js';
+import '@/components/dsfr-data-map-layer.js';
+import '@/components/dsfr-data-map-popup.js';
+
+const nextFrame = () => new Promise((r) => requestAnimationFrame(() => r(undefined)));
+
+// Quirk happy-dom/vitest : selon l'ordre du graphe de modules, le decorateur
+// @customElement de dsfr-data-map peut ne pas s'executer dans la fenetre de
+// test. Les tests du raccourci `insets` dependent d'un vrai upgrade (le
+// connectedCallback de la carte hote) : on garantit la definition.
+if (!customElements.get('dsfr-data-map')) {
+  customElements.define('dsfr-data-map', DsfrDataMap);
+}
+
+/** Carte hote minimale : une couche geoshape + un encart passe en options */
+function makeHost(attrs: Record<string, string> = {}): DsfrDataMap {
+  const host = document.createElement('dsfr-data-map') as DsfrDataMap;
+  host.setAttribute('center', '46.5,2.6');
+  host.setAttribute('zoom', '6');
+  host.setAttribute('tiles', 'ign-plan');
+  for (const [k, v] of Object.entries(attrs)) host.setAttribute(k, v);
+
+  const layer = document.createElement('dsfr-data-map-layer');
+  layer.id = 'couche-principale';
+  layer.setAttribute('source', 'territoires');
+  layer.setAttribute('type', 'geoshape');
+  layer.setAttribute('geo-field', 'geojson');
+  host.appendChild(layer);
+  return host;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('presets de territoires', () => {
+  it('expose les 5 DROM + COM + Corse', () => {
+    for (const t of [
+      'guadeloupe',
+      'martinique',
+      'guyane',
+      'la-reunion',
+      'mayotte',
+      'saint-pierre-et-miquelon',
+      'saint-martin',
+      'saint-barthelemy',
+      'nouvelle-caledonie',
+      'polynesie-francaise',
+      'wallis-et-futuna',
+      'corse',
+    ]) {
+      expect(TERRITORY_PRESETS[t], `preset ${t}`).toBeDefined();
+      expect(TERRITORY_PRESETS[t].center).toMatch(/^-?\d+(\.\d+)?,-?\d+(\.\d+)?$/);
+      expect(TERRITORY_PRESETS[t].zoom).toBeGreaterThan(0);
+      expect(TERRITORY_PRESETS[t].label.length).toBeGreaterThan(2);
+    }
+  });
+
+  it('le groupe drom contient les 5 DROM', () => {
+    expect(TERRITORY_GROUPS.drom).toEqual([
+      'guadeloupe',
+      'martinique',
+      'guyane',
+      'la-reunion',
+      'mayotte',
+    ]);
+  });
+});
+
+describe("construction de l'encart", () => {
+  it('territory=guadeloupe : label, mini-carte verrouillee, couche clonee sans id', async () => {
+    const host = makeHost();
+    const inset = document.createElement('dsfr-data-map-inset') as DsfrDataMapInset;
+    inset.setAttribute('territory', 'guadeloupe');
+    host.appendChild(inset);
+    document.body.appendChild(host);
+    await nextFrame();
+
+    const label = inset.querySelector('.dsfr-data-map-inset__label');
+    expect(label?.textContent).toBe('Guadeloupe');
+
+    const inner = inset.querySelector('dsfr-data-map');
+    expect(inner).not.toBeNull();
+    expect(inner!.getAttribute('center')).toBe(TERRITORY_PRESETS.guadeloupe.center);
+    expect(inner!.getAttribute('zoom')).toBe(String(TERRITORY_PRESETS.guadeloupe.zoom));
+    expect(inner!.getAttribute('min-zoom')).toBe(inner!.getAttribute('zoom'));
+    expect(inner!.getAttribute('max-zoom')).toBe(inner!.getAttribute('zoom'));
+    expect(inner!.hasAttribute('locked')).toBe(true);
+    expect(inner!.hasAttribute('no-controls')).toBe(true);
+    expect(inner!.getAttribute('tiles')).toBe('ign-plan');
+    expect(inner!.getAttribute('name')).toContain('Guadeloupe');
+
+    const clone = inner!.querySelector('dsfr-data-map-layer');
+    expect(clone).not.toBeNull();
+    expect(clone!.getAttribute('source')).toBe('territoires');
+    expect(clone!.getAttribute('geo-field')).toBe('geojson');
+    // Jamais d'id duplique dans le document
+    expect(clone!.hasAttribute('id')).toBe(false);
+    expect(document.querySelectorAll('#couche-principale').length).toBe(1);
+  });
+
+  it('les attributs explicites priment sur le preset (cadrage custom)', async () => {
+    const host = makeHost();
+    const inset = document.createElement('dsfr-data-map-inset');
+    inset.setAttribute('territory', 'guyane');
+    inset.setAttribute('center', '4.63,-52.45');
+    inset.setAttribute('zoom', '8');
+    host.appendChild(inset);
+    document.body.appendChild(host);
+    await nextFrame();
+
+    const inner = inset.querySelector('dsfr-data-map')!;
+    expect(inner.getAttribute('center')).toBe('4.63,-52.45');
+    expect(inner.getAttribute('zoom')).toBe('8');
+    // Le label vient du preset
+    expect(inset.querySelector('.dsfr-data-map-inset__label')?.textContent).toBe('Guyane');
+  });
+
+  it('territoire inconnu : warning et pas de mini-carte', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const host = makeHost();
+    const inset = document.createElement('dsfr-data-map-inset');
+    inset.setAttribute('territory', 'atlantide');
+    host.appendChild(inset);
+    document.body.appendChild(host);
+    await nextFrame();
+
+    expect(inset.querySelector('dsfr-data-map')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('atlantide'));
+    warnSpy.mockRestore();
+  });
+
+  it('sans territory ni center : pas de mini-carte', async () => {
+    const host = makeHost();
+    const inset = document.createElement('dsfr-data-map-inset');
+    host.appendChild(inset);
+    document.body.appendChild(host);
+    await nextFrame();
+    expect(inset.querySelector('dsfr-data-map')).toBeNull();
+  });
+
+  it("hors d'une dsfr-data-map : pas de construction", async () => {
+    const inset = document.createElement('dsfr-data-map-inset');
+    inset.setAttribute('territory', 'corse');
+    document.body.appendChild(inset);
+    await nextFrame();
+    expect(inset.querySelector('dsfr-data-map')).toBeNull();
+  });
+});
+
+describe('raccourci insets sur dsfr-data-map', () => {
+  it('insets="drom" genere les 5 encarts', async () => {
+    const host = makeHost({ insets: 'drom' });
+    document.body.appendChild(host);
+    await nextFrame();
+
+    const insets = host.querySelectorAll(':scope > dsfr-data-map-inset');
+    expect(insets.length).toBe(5);
+    expect([...insets].map((i) => i.getAttribute('territory'))).toEqual(TERRITORY_GROUPS.drom);
+  });
+
+  it('insets="drom,corse" cumule groupe et territoire', async () => {
+    const host = makeHost({ insets: 'drom,corse' });
+    document.body.appendChild(host);
+    await nextFrame();
+    expect(host.querySelectorAll(':scope > dsfr-data-map-inset').length).toBe(6);
+  });
+
+  it("un encart explicite pour le meme territoire n'est pas duplique", async () => {
+    const host = makeHost({ insets: 'drom' });
+    const explicit = document.createElement('dsfr-data-map-inset');
+    explicit.setAttribute('territory', 'martinique');
+    explicit.setAttribute('zoom', '10');
+    host.appendChild(explicit);
+    document.body.appendChild(host);
+    await nextFrame();
+
+    const martinique = host.querySelectorAll(
+      ':scope > dsfr-data-map-inset[territory="martinique"]'
+    );
+    expect(martinique.length).toBe(1);
+    expect(martinique[0].getAttribute('zoom')).toBe('10');
+  });
+});
+
+describe('delegation du popup a la carte hote', () => {
+  it('une couche clonee dans un encart resout le popup de la carte hote', async () => {
+    const host = makeHost();
+    const popup = document.createElement('dsfr-data-map-popup');
+    popup.setAttribute('mode', 'panel-right');
+    host.appendChild(popup);
+    const inset = document.createElement('dsfr-data-map-inset');
+    inset.setAttribute('territory', 'la-reunion');
+    host.appendChild(inset);
+    document.body.appendChild(host);
+    await nextFrame();
+
+    const clone = inset.querySelector('dsfr-data-map-layer')!;
+    const innerMap = inset.querySelector('dsfr-data-map')!;
+    // _mapParent est resolu au raccordement de la couche ; on le fixe pour
+    // tester la resolution du compagnon sans initialiser Leaflet
+    (clone as unknown as { _mapParent: Element })._mapParent = innerMap;
+    const companion = (
+      clone as unknown as { _findPopupCompanion: () => Element | null }
+    )._findPopupCompanion();
+
+    expect(companion).toBe(popup);
+  });
+});


### PR DESCRIPTION
## Quoi

Nouveau composant compagnon **`dsfr-data-map-inset`** : encarts territoriaux pour `dsfr-data-map` (le pattern « France métropolitaine + vignettes DROM » des cartes nationales), **sans duplication de template** — les encarts réutilisent les couches ET le popup de la carte hôte.

### API

```html
<dsfr-data-map center="46.5,2.6" zoom="6" tiles="ign-plan" insets="drom,corse">
  <dsfr-data-map-layer source="territoires" type="geoshape" geo-field="geojson"></dsfr-data-map-layer>
  <dsfr-data-map-popup mode="panel-right" title-field="nom"><template>…</template></dsfr-data-map-popup>
</dsfr-data-map>
```

- **12 presets** (`territory="guadeloupe"`, `"nouvelle-caledonie"`, `"saint-pierre-et-miquelon"`, `"corse"`…) dans `utils/territories.ts`, surchargeables par `center`/`zoom`/`label` ;
- **raccourci `insets`** sur la carte (groupe `drom` et/ou territoires nommés), avec dédup des encarts explicites ;
- l'encart clone les couches directes de la carte hôte (clone superficiel, id retiré) dans une mini-carte `locked` + `no-controls` au zoom verrouillé ;
- **délégation du popup** : `_findPopupCompanion` (map-layer) remonte à travers l'encart vers la carte hôte → un clic dans l'encart ouvre le volet `panel-right` de la carte principale (un seul template).

### Changements transverses (les deux points à relire en priorité)

1. **La hauteur fixe s'applique au conteneur Leaflet** et plus au host (`_applyHeight`) : le host passe en flux auto pour accueillir les compagnons hors-carte. Rendu identique pour toutes les pages existantes sans encart.
2. **Le panel du popup s'ancre sur ce conteneur** (fallback host si absent) : il recouvre la zone carte, pas le bandeau d'encarts.

- `dsfr-data-map` gagne aussi `locked` (aucune interaction pan/zoom/molette/clavier — règle au passage la capture du scroll de page par les vignettes).

## Validation

- **11 tests unitaires** (`tests/dsfr-data-map-inset.test.ts`) : presets, construction, surcharge, territoire inconnu, raccourci + dédup, délégation popup. Suite complète : **3657 tests verts** (153 fichiers), test-gardes skills inclus (`locked`, `insets`, section inset documentées dans builder-ia).
- **Validé en live** (Chrome, bundle local) sur la carte des territoires ELF : bandeau 5 DROM (vides grisés), clic sur un territoire dans l'encart Guyane/Réunion → volet sur la carte principale avec le template unique, raccourci `insets="drom,corse"`.
- Changeset **minor**.

Note tests : garde `customElements.define` explicite dans le fichier de tests — quirk happy-dom/vitest où le décorateur `@customElement` de `dsfr-data-map` ne s'exécute pas selon l'ordre du graphe de modules (comportement navigateur sain, validé en live).

Coordination : conflit potentiel trivial avec #430 (zone TILE_PRESETS de `dsfr-data-map.ts`, sections disjointes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)