### PR TITLE
docs: alignement specs/guide/builder-carto avec v0.14 + pin CDN carte ELF

### DIFF
--- a/apps/builder-carto/src/main.ts
+++ b/apps/builder-carto/src/main.ts
@@ -223,11 +223,14 @@ function renderMapConfig() {
         <div class="carto-field">
           <label for="map-tiles">Fond de carte</label>
           <select id="map-tiles" class="fr-select fr-select--sm">
-            <option value="ign-plan" ${m.tiles === 'ign-plan' ? 'selected' : ''}>IGN Plan</option>
+            <option value="ign-plan" ${m.tiles === 'ign-plan' || m.tiles === 'ign-topo' ? 'selected' : ''}>IGN Plan</option>
             <option value="ign-ortho" ${m.tiles === 'ign-ortho' ? 'selected' : ''}>IGN Ortho</option>
-            <option value="ign-topo" ${m.tiles === 'ign-topo' ? 'selected' : ''}>IGN Topographique</option>
             <option value="ign-cadastre" ${m.tiles === 'ign-cadastre' ? 'selected' : ''}>IGN Cadastre</option>
-            <option value="osm" ${m.tiles === 'osm' ? 'selected' : ''}>OpenStreetMap</option>
+            <option value="osm" ${m.tiles === 'osm' ? 'selected' : ''}>OpenStreetMap France</option>
+            <option value="osm-standard" ${m.tiles === 'osm-standard' ? 'selected' : ''}>OpenStreetMap</option>
+            <option value="carto-positron" ${m.tiles === 'carto-positron' ? 'selected' : ''}>CARTO clair (dataviz)</option>
+            <option value="carto-dark" ${m.tiles === 'carto-dark' ? 'selected' : ''}>CARTO sombre</option>
+            <option value="opentopomap" ${m.tiles === 'opentopomap' ? 'selected' : ''}>OpenTopoMap</option>
           </select>
         </div>
         <div class="carto-inline">

--- a/apps/builder-carto/src/state.ts
+++ b/apps/builder-carto/src/state.ts
@@ -19,7 +19,17 @@ export type LayerType = 'marker' | 'geoshape' | 'circle' | 'heatmap';
 
 export type PopupMode = 'none' | 'tooltip' | 'popup' | 'panel-right' | 'panel-left';
 
-export type TilePreset = 'ign-plan' | 'ign-ortho' | 'ign-topo' | 'ign-cadastre' | 'osm';
+export type TilePreset =
+  | 'ign-plan'
+  | 'ign-ortho'
+  | 'ign-cadastre'
+  | 'osm'
+  | 'osm-standard'
+  | 'carto-positron'
+  | 'carto-dark'
+  | 'opentopomap'
+  // Deprecie (redirige vers ign-plan) — conserve pour les etats sauvegardes
+  | 'ign-topo';
 
 export interface LayerConfig {
   id: string;

--- a/guide/examples/carte-territoires-electrification.html
+++ b/guide/examples/carte-territoires-electrification.html
@@ -8,14 +8,14 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <!-- Leaflet : charge dynamiquement par dsfr-data.umd.js - NE PAS inclure manuellement -->
-  <!-- dsfr-data : epingle sur @0.14 (les encarts exigent >= 0.14.0 et l'URL @0 est
-       cachee 7 jours par les navigateurs — un visiteur du jour verrait l'ancien bundle).
-       Bundle complet (core + map).
+  <!-- dsfr-data : epingle en exact @0.14.0 + SRI (les encarts exigent >= 0.14.0 et l'URL
+       flottante @0 est cachee 7 jours par les navigateurs — un visiteur du jour verrait
+       l'ancien bundle sans les encarts). Bundle complet (core + map).
        Requiert >= 0.14.0 : geo-field accepte les GeoJSON serialises en chaine (#426),
        {{champ:number}} dans les templates de map-popup (#426), et encarts DROM
        dsfr-data-map-inset (#431).
        Major flottant : pas de SRI (cf. check:sri). -->
-  <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0.14/dist/dsfr-data.umd.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0.14.0/dist/dsfr-data.umd.js" integrity="sha384-ret3o1hM0mCYurTTJFE+H95QXn2KVJvME0Wx9+CYPa2HeU7INtiLk3CD/bbMXC4X" crossorigin="anonymous"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
 
   <style>

--- a/guide/examples/carte-territoires-electrification.html
+++ b/guide/examples/carte-territoires-electrification.html
@@ -8,12 +8,14 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <!-- Leaflet : charge dynamiquement par dsfr-data.umd.js - NE PAS inclure manuellement -->
-  <!-- dsfr-data : derniere version 0.x (@0, non figee). Bundle complet (core + map).
+  <!-- dsfr-data : epingle sur @0.14 (les encarts exigent >= 0.14.0 et l'URL @0 est
+       cachee 7 jours par les navigateurs — un visiteur du jour verrait l'ancien bundle).
+       Bundle complet (core + map).
        Requiert >= 0.14.0 : geo-field accepte les GeoJSON serialises en chaine (#426),
        {{champ:number}} dans les templates de map-popup (#426), et encarts DROM
        dsfr-data-map-inset (#431).
        Major flottant : pas de SRI (cf. check:sri). -->
-  <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0/dist/dsfr-data.umd.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0.14/dist/dsfr-data.umd.js"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
 
   <style>

--- a/guide/guide-exemples-map.html
+++ b/guide/guide-exemples-map.html
@@ -224,7 +224,9 @@
         <p>
           Le composant <code>dsfr-data-map-popup</code> definit un template HTML et un mode d'affichage.
           En mode <code>panel-right</code>, un panneau lateral s'ouvre au clic sur un POI et se met a jour
-          a chaque nouveau clic. Le template utilise la syntaxe <code>{{champ}}</code>.
+          a chaque nouveau clic. Le template utilise les memes expressions que <code>dsfr-data-display</code> :
+          <code>{{champ}}</code>, <code>{{champ:number}}</code> (format fr-FR), <code>{{champ|défaut}}</code>,
+          chemins imbriques.
         </p>
 
         <h4>Panneau lateral avec template personnalise</h4>
@@ -258,6 +260,35 @@
       &lt;/table&gt;
     &lt;/template&gt;
   &lt;/dsfr-data-map-popup&gt;
+&lt;/dsfr-data-map&gt;</pre>
+          </div>
+        </section>
+
+        <!-- ============================================================ -->
+        <h2>Encarts DROM (dsfr-data-map-inset)</h2>
+        <p>
+          Le composant compagnon <code>dsfr-data-map-inset</code> ajoute des mini-cartes territoriales
+          verrouillees sous la carte principale (DROM, COM, Corse). Les encarts reutilisent les couches
+          et le popup de la carte hote : un clic dans un encart ouvre le volet de la carte principale.
+          12 territoires predefinis via <code>territory</code>, ou raccourci <code>insets</code> sur la carte.
+          Exemple complet : <a href="examples/carte-territoires-electrification.html">carte des territoires
+          d'electrification</a>.
+        </p>
+        <section class="fr-accordion fr-mt-1w">
+          <h3 class="fr-accordion__title"><button class="fr-accordion__btn" aria-expanded="false" aria-controls="code-insets">Code source</button></h3>
+          <div class="fr-collapse" id="code-insets">
+<pre class="example-code">&lt;!-- Raccourci : les 5 DROM + la Corse --&gt;
+&lt;dsfr-data-map center="46.5,2.6" zoom="6" tiles="ign-plan" insets="drom,corse"&gt;
+  &lt;dsfr-data-map-layer source="territoires" type="geoshape" geo-field="geojson"&gt;&lt;/dsfr-data-map-layer&gt;
+  &lt;dsfr-data-map-popup mode="panel-right" title-field="nom"&gt;&lt;template&gt;...&lt;/template&gt;&lt;/dsfr-data-map-popup&gt;
+&lt;/dsfr-data-map&gt;
+
+&lt;!-- Ou en explicite, avec surcharge du cadrage --&gt;
+&lt;dsfr-data-map center="46.5,2.6" zoom="6"&gt;
+  &lt;dsfr-data-map-layer source="territoires" type="geoshape" geo-field="geojson"&gt;&lt;/dsfr-data-map-layer&gt;
+  &lt;dsfr-data-map-inset territory="guadeloupe"&gt;&lt;/dsfr-data-map-inset&gt;
+  &lt;dsfr-data-map-inset territory="guyane" center="4.63,-52.45" zoom="8"&gt;&lt;/dsfr-data-map-inset&gt;
+  &lt;dsfr-data-map-inset territory="nouvelle-caledonie"&gt;&lt;/dsfr-data-map-inset&gt;
 &lt;/dsfr-data-map&gt;</pre>
           </div>
         </section>

--- a/specs/components/dsfr-data-map.html
+++ b/specs/components/dsfr-data-map.html
@@ -53,6 +53,8 @@
             <tr><td><code>tiles</code></td><td>String</td><td><code>"ign-plan"</code></td><td>Fond de carte predefini ou URL template custom</td></tr>
             <tr><td><code>sovereign-only</code></td><td>Boolean</td><td><code>false</code></td><td>Restreint <code>tiles</code> aux presets IGN souverains. Tout autre preset (ex. <code>osm-fr</code>) ou URL custom est refuse avec un <code>console.warn</code> et remplace par <code>ign-plan</code>.</td></tr>
             <tr><td><code>no-controls</code></td><td>Boolean</td><td><code>false</code></td><td>Masque les controles de zoom Leaflet</td></tr>
+            <tr><td><code>locked</code></td><td>Boolean</td><td><code>false</code></td><td>Carte verrouillee : aucune interaction (pan, zoom, molette, clavier). Utilise par les encarts et vignettes.</td></tr>
+            <tr><td><code>insets</code></td><td>String</td><td><code>""</code></td><td>Raccourci encarts territoriaux : groupe et/ou territoires nommes separes par des virgules (<code>"drom"</code>, <code>"drom,corse"</code>). Genere les <code>dsfr-data-map-inset</code> correspondants.</td></tr>
             <tr><td><code>fit-bounds</code></td><td>Boolean</td><td><code>false</code></td><td>Ajuste automatiquement le viewport aux données</td></tr>
             <tr><td><code>max-bounds</code></td><td>String</td><td><code>""</code></td><td>Limites <code>"latSW,lonSW,latNE,lonNE"</code></td></tr>
             <tr><td><code>name</code></td><td>String</td><td><code>""</code></td><td>Titre de la carte (aria-label et beacon)</td></tr>
@@ -66,13 +68,17 @@
           <tbody>
             <tr><td><code>ign-plan</code></td><td>Geoplateforme IGN — Plan IGN</td><td>Oui</td><td><code>data.geopf.fr/wmts</code> (layer <code>GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2</code>)</td></tr>
             <tr><td><code>ign-ortho</code></td><td>Geoplateforme IGN — Orthophoto</td><td>Oui</td><td><code>data.geopf.fr/wmts</code> (layer <code>ORTHOIMAGERY.ORTHOPHOTOS</code>)</td></tr>
-            <tr><td><code>ign-topo</code></td><td>Geoplateforme IGN — Carte topographique (SCAN 25/100)</td><td>Oui</td><td><code>data.geopf.fr/wmts</code> (layer <code>GEOGRAPHICALGRIDSYSTEMS.MAPS.BDUNI.J1</code>)</td></tr>
+            <tr><td><code>ign-topo</code></td><td><em>Deprecie</em> — redirige vers <code>ign-plan</code> avec un <code>console.warn</code> (couche BDUNI quasi vide ; couches SCAN topo soumises a clé API)</td><td>Oui (via <code>ign-plan</code>)</td><td>—</td></tr>
             <tr><td><code>ign-cadastre</code></td><td>Geoplateforme IGN — Cadastre</td><td>Oui</td><td><code>data.geopf.fr/wmts</code> (layer <code>CADASTRALPARCELS.PARCELLAIRE_EXPRESS</code>)</td></tr>
             <tr><td><code>osm-fr</code></td><td>OpenStreetMap France (association)</td><td>Non (associatif hors État)</td><td><code>{s}.tile.openstreetmap.fr/osmfr</code></td></tr>
+            <tr><td><code>osm-standard</code></td><td>OpenStreetMap (OSM Foundation)</td><td>Non</td><td><code>tile.openstreetmap.org</code></td></tr>
+            <tr><td><code>carto-positron</code></td><td>CARTO — fond clair sobre (dataviz)</td><td>Non</td><td><code>{s}.basemaps.cartocdn.com/light_all</code></td></tr>
+            <tr><td><code>carto-dark</code></td><td>CARTO — fond sombre</td><td>Non</td><td><code>{s}.basemaps.cartocdn.com/dark_all</code></td></tr>
+            <tr><td><code>opentopomap</code></td><td>OpenTopoMap (CC-BY-SA)</td><td>Non</td><td><code>{s}.tile.opentopomap.org</code></td></tr>
           </tbody>
         </table>
-        <p class="fr-mt-2w"><strong>Mode <code>sovereign-only</code></strong> : pour les DSI qui imposent une politique "zero tiers externe non souverain", ajouter l'attribut booleen <code>sovereign-only</code> sur <code>&lt;dsfr-data-map&gt;</code> restreint les presets disponibles aux seules tuiles IGN (<code>ign-plan</code>, <code>ign-ortho</code>, <code>ign-topo</code>, <code>ign-cadastre</code>). Tout autre preset ou URL custom est refuse avec un avertissement console et remplace par <code>ign-plan</code>.</p>
-        <p><strong>Alias de retrocompatibilite</strong> : <code>tiles="osm"</code> reste accepte et pointe vers le preset <code>osm-fr</code>.</p>
+        <p class="fr-mt-2w"><strong>Mode <code>sovereign-only</code></strong> : pour les DSI qui imposent une politique "zero tiers externe non souverain", ajouter l'attribut booleen <code>sovereign-only</code> sur <code>&lt;dsfr-data-map&gt;</code> restreint les presets disponibles aux seules tuiles IGN (<code>ign-plan</code>, <code>ign-ortho</code>, <code>ign-cadastre</code> — <code>ign-topo</code>, deprecie, y resout vers <code>ign-plan</code>). Tout autre preset ou URL custom est refuse avec un avertissement console et remplace par <code>ign-plan</code>.</p>
+        <p><strong>Alias de retrocompatibilite</strong> : <code>tiles="osm"</code> reste accepte et pointe vers le preset <code>osm-fr</code> ; <code>tiles="ign-topo"</code> (deprecie) pointe vers <code>ign-plan</code>.</p>
 
         <!-- ============================================================ -->
         <!-- dsfr-data-map-layer -->
@@ -88,7 +94,7 @@
             <tr><td><code>type</code></td><td>String</td><td><code>"marker"</code></td><td>Type de couche : <code>marker</code>, <code>geoshape</code>, <code>circle</code>, <code>heatmap</code></td></tr>
             <tr><td><code>lat-field</code></td><td>String</td><td><code>""</code></td><td>Chemin vers la latitude</td></tr>
             <tr><td><code>lon-field</code></td><td>String</td><td><code>""</code></td><td>Chemin vers la longitude</td></tr>
-            <tr><td><code>geo-field</code></td><td>String</td><td><code>""</code></td><td>Chemin vers un GeoJSON (Point, Polygon, MultiPolygon)</td></tr>
+            <tr><td><code>geo-field</code></td><td>String</td><td><code>""</code></td><td>Chemin vers un GeoJSON (Point, Polygon, MultiPolygon) — objet ou <strong>chaine JSON serialisee</strong> (colonnes Text Grist, CSV), parsee automatiquement (memoise)</td></tr>
           </tbody>
         </table>
 
@@ -204,6 +210,46 @@
         </ul>
 
         <!-- ============================================================ -->
+        <!-- dsfr-data-map-inset -->
+        <!-- ============================================================ -->
+
+        <h2 class="fr-mt-4w">dsfr-data-map-inset — Encarts territoriaux</h2>
+        <p>
+          Composant compagnon place comme enfant de <code>dsfr-data-map</code>. Rend une mini-carte
+          verrouillee (zoom fixe, aucune interaction) centree sur un territoire — le pattern
+          « France metropolitaine + vignettes DROM » des cartes nationales. L'encart reutilise
+          automatiquement les couches (<code>dsfr-data-map-layer</code>) <strong>et le popup</strong>
+          de la carte hote : un clic sur un element de l'encart ouvre le volet ou la modale de la
+          carte principale (template unique, pas de duplication).
+        </p>
+
+        <table class="attr-table">
+          <thead><tr><th>Attribut</th><th>Type</th><th>Défaut</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>territory</code></td><td>String</td><td><code>""</code></td><td>Territoire predefini : <code>guadeloupe</code>, <code>martinique</code>, <code>guyane</code>, <code>la-reunion</code>, <code>mayotte</code>, <code>saint-pierre-et-miquelon</code>, <code>saint-martin</code>, <code>saint-barthelemy</code>, <code>nouvelle-caledonie</code>, <code>polynesie-francaise</code>, <code>wallis-et-futuna</code>, <code>corse</code>. Fournit centre, zoom et libelle.</td></tr>
+            <tr><td><code>center</code></td><td>String</td><td><code>""</code></td><td>Centre <code>"lat,lon"</code> (requis sans <code>territory</code> ; prioritaire sur le preset)</td></tr>
+            <tr><td><code>zoom</code></td><td>Number</td><td><code>8</code></td><td>Zoom fixe de l'encart (prioritaire sur le preset)</td></tr>
+            <tr><td><code>label</code></td><td>String</td><td><code>""</code></td><td>Libelle affiche au-dessus de l'encart (et nom accessible de la mini-carte)</td></tr>
+            <tr><td><code>height</code></td><td>String</td><td><code>"160px"</code></td><td>Hauteur de la mini-carte</td></tr>
+          </tbody>
+        </table>
+
+        <p class="fr-mt-2w">
+          <strong>Raccourci</strong> : l'attribut <code>insets</code> de <code>dsfr-data-map</code>
+          genere les encarts automatiquement — <code>insets="drom"</code> (les 5 DROM) ou une liste
+          <code>insets="drom,corse"</code>. Un encart pose explicitement en HTML pour le meme
+          territoire prime (pas de doublon).
+        </p>
+
+<pre class="code-block">&lt;dsfr-data-map center="46.5,2.6" zoom="6" tiles="ign-plan" insets="drom"&gt;
+  &lt;dsfr-data-map-layer source="territoires" type="geoshape" geo-field="geojson"&gt;&lt;/dsfr-data-map-layer&gt;
+  &lt;dsfr-data-map-popup mode="panel-right" title-field="nom"&gt;&lt;template&gt;...&lt;/template&gt;&lt;/dsfr-data-map-popup&gt;
+&lt;/dsfr-data-map&gt;
+
+&lt;!-- ou en explicite, avec surcharge de cadrage : --&gt;
+&lt;dsfr-data-map-inset territory="guyane" center="4.63,-52.45" zoom="8"&gt;&lt;/dsfr-data-map-inset&gt;</pre>
+
+        <!-- ============================================================ -->
         <!-- dsfr-data-map-popup -->
         <!-- ============================================================ -->
 
@@ -226,8 +272,12 @@
 
         <h3>Template</h3>
         <p>
-          Le contenu est défini via un element <code>&lt;template&gt;</code> enfant avec interpolation
-          <code>{{champ}}</code>. Sans template, un tableau clé/valeur est genere automatiquement.
+          Le contenu est défini via un element <code>&lt;template&gt;</code> enfant avec les memes
+          expressions d'interpolation que <code>dsfr-data-display</code> (toujours echappees) :
+          <code>{{champ}}</code>, <code>{{champ.sous.clé}}</code> (chemins imbriques),
+          <code>{{champ:number}}</code> (formatage fr-FR avec separateur de milliers),
+          <code>{{champ|défaut}}</code> (repli si null/undefined).
+          Sans template, un tableau clé/valeur est genere automatiquement.
         </p>
 
         <h3>Modes</h3>

--- a/specs/components/dsfr-data-map.html
+++ b/specs/components/dsfr-data-map.html
@@ -54,7 +54,7 @@
             <tr><td><code>sovereign-only</code></td><td>Boolean</td><td><code>false</code></td><td>Restreint <code>tiles</code> aux presets IGN souverains. Tout autre preset (ex. <code>osm-fr</code>) ou URL custom est refuse avec un <code>console.warn</code> et remplace par <code>ign-plan</code>.</td></tr>
             <tr><td><code>no-controls</code></td><td>Boolean</td><td><code>false</code></td><td>Masque les controles de zoom Leaflet</td></tr>
             <tr><td><code>locked</code></td><td>Boolean</td><td><code>false</code></td><td>Carte verrouillee : aucune interaction (pan, zoom, molette, clavier). Utilise par les encarts et vignettes.</td></tr>
-            <tr><td><code>insets</code></td><td>String</td><td><code>""</code></td><td>Raccourci encarts territoriaux : groupe et/ou territoires nommes separes par des virgules (<code>"drom"</code>, <code>"drom,corse"</code>). Genere les <code>dsfr-data-map-inset</code> correspondants.</td></tr>
+            <tr><td><code>insets</code></td><td>String</td><td><code>""</code></td><td>Raccourci encarts territoriaux : groupe et/ou territoires nommes separes par des virgules (<code>"drom"</code>, <code>"drom,corse"</code>). Produit les <code>dsfr-data-map-inset</code> correspondants.</td></tr>
             <tr><td><code>fit-bounds</code></td><td>Boolean</td><td><code>false</code></td><td>Ajuste automatiquement le viewport aux données</td></tr>
             <tr><td><code>max-bounds</code></td><td>String</td><td><code>""</code></td><td>Limites <code>"latSW,lonSW,latNE,lonNE"</code></td></tr>
             <tr><td><code>name</code></td><td>String</td><td><code>""</code></td><td>Titre de la carte (aria-label et beacon)</td></tr>


### PR DESCRIPTION
Audit d'alignement post-releases 0.13/0.14 (demande Bertrand) — état des lieux et corrections :

## Déjà aligné (rien à faire)
- **skills builder-ia** (`apps/builder-ia/src/skills.ts`) : geo-field chaîne, `{{champ:number}}` popup, `locked`, `insets`, section `dsfr-data-map-inset`, fonds de carte — couvert par les PR #427/#430/#431 (test-gardes verts) ;
- **MCP** : `skills.json` est généré au build depuis les skills builder-ia (`scripts/build-skills-json.ts`) → aligné automatiquement, prod re-spawnée après ;
- **guide « Fonds de carte »** : mis à jour par la PR #430.

## Corrigé ici
- **`specs/components/dsfr-data-map.html`** (n'avait rien du jour) : attributs `locked`/`insets`, nouvelle section **dsfr-data-map-inset**, `geo-field` chaîne JSON, expressions du template popup, table des fonds (ign-topo déprécié + carto/opentopomap/osm-standard), mode sovereign-only reformulé ;
- **guide map** : section « Encarts DROM » (code + lien vers l'exemple ELF) + expressions de template du popup ;
- **builder-carto** : `TilePreset` + sélecteur alignés (suivi signalé dans #430) — ign-topo retiré du sélecteur, repli `ign-plan` pour les états sauvegardés ;
- **carte ELF** : CDN épinglé sur `@0.14` — l'URL `@0` porte un `cache-control: max-age=604800` (7 j) côté navigateur : un visiteur ayant chargé la page avant la release ne voyait **pas les encarts DROM** (constaté par Bertrand). Le pin change l'URL donc bust le cache.

## Validation
Suite complète : **3662 tests verts** (153 fichiers). `npm run build` + `build:apps` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)