### PR TITLE
docs(guide): carte ELF v3 — tokens sombres, édito épuré, callout, facettes carte+liste

### DIFF
--- a/guide/examples/carte-territoires-electrification.html
+++ b/guide/examples/carte-territoires-electrification.html
@@ -27,32 +27,33 @@
     .dot--commune { background: #E4794A; }
 
     .tp .sect { font-size: .75rem; font-weight: 700; letter-spacing: .06em; text-transform: uppercase;
-      color: #666; margin: 1.25rem 0 .5rem; border-bottom: 1px solid #ddd; padding-bottom: .25rem; }
+      color: var(--text-mention-grey); margin: 1.25rem 0 .5rem;
+      border-bottom: 1px solid var(--border-default-grey); padding-bottom: .25rem; }
     .tp .sect:first-of-type { margin-top: .75rem; }
     .tp .grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: .5rem .75rem; }
-    .tp .cell .v { display: block; font-size: 1.375rem; font-weight: 700; color: #000091; line-height: 1.2; }
-    .tp .cell .k { display: block; font-size: .75rem; color: #3a3a3a; }
+    .tp .cell .v { display: block; font-size: 1.375rem; font-weight: 700; color: var(--text-title-blue-france); line-height: 1.2; }
+    .tp .cell .k { display: block; font-size: .75rem; color: var(--text-default-grey); }
     .tp .bar-row { display: flex; justify-content: space-between; font-size: .8125rem; margin: .5rem 0 .2rem; }
     .tp .bar-row .bv { font-weight: 700; }
-    .tp .bar { height: .375rem; background: #eee; border-radius: .375rem; overflow: hidden; }
-    .tp .bar .fill { height: 100%; border-radius: .375rem; background: #000091; }
-    .tp .bar .fill--warm { background: #B34000; }
-    .tp .bar .fill--green { background: #00A95F; }
-    .tp .mention { font-size: .75rem; color: #666; margin-top: 1rem; }
-    .badge-EPCI { background: #ececfe; color: #000091; }
-    .badge-Groupement { background: #c3fad5; color: #297254; }
-    .badge-Commune { background: #fee9dd; color: #855d48; }
+    .tp .bar { height: .375rem; background: var(--background-contrast-grey); border-radius: .375rem; overflow: hidden; }
+    .tp .bar .fill { height: 100%; border-radius: .375rem; background: var(--background-action-high-blue-france); }
+    .tp .bar .fill--warm { background: var(--orange-terre-battue-main-645, #B34000); }
+    .tp .bar .fill--green { background: var(--green-emeraude-main-632, #00A95F); }
+    .tp .mention { font-size: .75rem; color: var(--text-mention-grey); margin-top: 1rem; }
+    /* Tokens des badges accent DSFR (adaptes automatiquement au mode sombre) */
+    .badge-EPCI { background: var(--background-contrast-blue-cumulus); color: var(--text-label-blue-cumulus); }
+    .badge-Groupement { background: var(--background-contrast-green-emeraude); color: var(--text-label-green-emeraude); }
+    .badge-Commune { background: var(--background-contrast-orange-terre-battue); color: var(--text-label-orange-terre-battue); }
 
     /* Encarts DROM (dsfr-data-map-inset) */
     #carte { display: flow-root; }
     dsfr-data-map-inset { float: left; width: calc(20% - .6rem); margin: .75rem .75rem 0 0; }
     dsfr-data-map-inset:last-of-type { margin-right: 0; }
-    dsfr-data-map-inset > dsfr-data-map { display: block; border: 1px solid #ddd; border-radius: .25rem; overflow: hidden; }
+    dsfr-data-map-inset > dsfr-data-map { display: block; border: 1px solid var(--border-default-grey); border-radius: .25rem; overflow: hidden; }
     /* DROM sans territoire engagé : grisés, non cliquables */
     .inset--empty { filter: grayscale(1); opacity: .45; pointer-events: none; }
 
-    /* Filtres + recherche de la liste sur une seule ligne, libelle au-dessus du champ */
-    dsfr-data-list .dsfr-data-list__filters { float: left; display: flex; gap: 1rem; margin-right: 1rem; }
+    /* Recherche de la liste : libelle visible au-dessus du champ, export a droite */
     dsfr-data-list .dsfr-data-list__toolbar { display: flex; align-items: flex-end; justify-content: space-between; }
     dsfr-data-list .fr-search-bar { flex-wrap: wrap; max-width: 320px; }
     dsfr-data-list .fr-search-bar .fr-label {
@@ -60,22 +61,19 @@
       clip: auto; clip-path: none; overflow: visible; white-space: normal;
     }
     dsfr-data-list .fr-search-bar .fr-input { flex: 1 1 0; width: auto; min-width: 0; }
-    dsfr-data-list p.fr-text--sm { clear: left; }
   </style>
 </head>
 <body>
   <main class="fr-container fr-py-3w">
 
-    <h1 class="fr-h3 fr-mb-1v">Territoires d'électrification</h1>
-    <p class="fr-text--lead fr-mb-2w">Collectivités engagées dans le plan <b>Électrifions&nbsp;la&nbsp;France</b></p>
-
+    <!-- Page destinee a etre incorporee : pas de h1 propre, on demarre au h2 -->
     <h2 class="fr-h4 fr-mb-1w">100 Territoires d'électrification</h2>
     <p class="fr-text--lead fr-mb-2w">Au terme d'un processus conduit par les préfets et le Secrétariat général
       pour la planification écologique, le Gouvernement annonce la sélection de 108 territoires qui s'engagent
       à accélérer l'électrification des usages et bénéficieront jusqu'en 2030 d'un accompagnement renforcé.</p>
 
-    <div class="fr-highlight fr-mb-3w">
-      <p class="fr-text--sm">Parmi les 196 candidatures examinées par les préfets et le Secrétariat général pour
+    <div class="fr-callout fr-mb-3w">
+      <p class="fr-callout__text fr-text--sm">Parmi les 196 candidatures examinées par les préfets et le Secrétariat général pour
         la planification écologique, 108 territoires d'électrification ont été retenus afin de permettre un
         accompagnement de qualité des projets ambitieux sur lesquels ils s'engagent. Portés par des exécutifs
         locaux dynamiques, ces projets peuvent concerner, selon les cas, l'électrification des transports, le
@@ -95,7 +93,9 @@
          Les contours sont dans une colonne Text `geojson` (chaîne) : geo-field
          les parse nativement depuis la 0.13.0. Le formatage fr-FR du volet
          utilise {{champ:number}} (même syntaxe que dsfr-data-display).
-         Pipeline : source(grist) -> normalize(compute irve_total) -> carte + volet + liste
+         Pipeline : source(grist) -> normalize(compute irve_total) -> facets(type, region)
+                    -> carte (+ encarts) + liste. Les KPI restent sur le flux non filtre
+                    (totaux du plan).
          ==================================================================== -->
     <dsfr-data-source id="territoires-src" api-type="grist"
       base-url="https://chartsbuilder.miweb.run/grist-gouv-proxy/api/docs/jGd2ge4dy2ZM/tables/Territoires/records">
@@ -114,6 +114,17 @@
       <dsfr-data-kpi source="territoires" value="nb_engagements:sum" label="Engagements recensés"></dsfr-data-kpi>
     </dsfr-data-kpi-group>
 
+    <!-- Filtres a facettes : agissent sur la carte, les encarts et la liste (aval du pipeline) -->
+    <div class="fr-mt-3w">
+      <dsfr-data-facets id="territoires-filtres" source="territoires"
+        fields="type,region"
+        labels="type:Type | region:Région"
+        display="type:select | region:select"
+        cols="type:3 | region:3"
+        sort="alpha">
+      </dsfr-data-facets>
+    </div>
+
     <!-- Légende -->
     <div class="map-legend fr-text--sm fr-mt-3w fr-mb-1w">
       <span><span class="dot dot--epci"></span>EPCI</span>
@@ -125,7 +136,7 @@
     <!-- Carte : les contours GeoJSON (colonne Text Grist) sont lus tels quels par geo-field -->
     <dsfr-data-map id="carte" center="46.5,2.6" zoom="6" min-zoom="3" height="620px" tiles="ign-plan"
       name="Carte des territoires d'électrification">
-      <dsfr-data-map-layer source="territoires" type="geoshape"
+      <dsfr-data-map-layer source="territoires-filtres" type="geoshape"
         geo-field="geojson"
         color-field="type"
         color-map="EPCI:#000091,Groupement:#00A95F,Commune:#E4794A"
@@ -185,10 +196,9 @@
 
     <!-- Tableau de données -->
     <h2 class="fr-h5 fr-mt-4w fr-mb-1w">Liste des territoires</h2>
-    <dsfr-data-list source="territoires"
+    <dsfr-data-list source="territoires-filtres"
       columns="nom:Territoire, type:Type, region:Région, departements_tous:Département(s), nb_communes:Communes, population:Population, vp_elec_pct:% VE, irve_total:IRVE, nb_engagements:Engagements"
       search
-      filters="type,region"
       sort="nom:asc"
       pagination="10"
       export="csv"></dsfr-data-list>


### PR DESCRIPTION
Retours Bertrand sur la v2 :

1. **Mode sombre lisible** : tout l'habillage custom (volet, sections, barres, badges, bordures d'encarts) passe sur les **tokens de couleur DSFR** — les valeurs en `#000091` illisibles sur fond sombre deviennent `var(--text-title-blue-france)`, badges sur les tokens des badges accent (`blue-cumulus`/`green-emeraude`/`orange-terre-battue`), etc.
2. **Édito épuré** : h1 + sous-titre supprimés (page destinée à être incorporée), démarrage au h2 ;
3. **Mise en avant → callout** (`fr-callout`) ;
4. **Filtres au-dessus de la carte** : remplacement des filtres locaux de la liste par `dsfr-data-facets` (selects Type/Région, tri alpha, compteurs, bouton « Réinitialiser ») inséré dans le pipeline `normalize → facets → carte + encarts + liste` — **un filtre agit sur la carte, les encarts DROM et la liste simultanément**. Les KPI restent branchés sur le flux non filtré (totaux du plan).

## Validation
Live dans Chrome en **mode sombre** : sélection « Auvergne-Rhône-Alpes » → 17 résultats synchronisés carte/encarts/liste, volet entièrement lisible (valeurs, badges, barres), réinitialisation OK. `check:accents` et `check:sri` verts en local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)