### PR TITLE
fix(map): la molette sur le volet scrolle le volet, pas le zoom de la carte

### DIFF
--- a/.changeset/quiet-panel-wheel.md
+++ b/.changeset/quiet-panel-wheel.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': patch
+---
+
+`dsfr-data-map-popup` : la molette sur le volet latéral scrolle le volet au lieu de zoomer la carte (isolation des événements wheel/dblclick/mousedown/touch du panel, ancré dans le conteneur Leaflet depuis la 0.14.0). La sélection de texte dans le volet ne déclenche plus un déplacement de la carte.

--- a/packages/core/src/components/dsfr-data-map-popup.ts
+++ b/packages/core/src/components/dsfr-data-map-popup.ts
@@ -192,6 +192,12 @@ export class DsfrDataMapPopup extends LitElement {
       this._panelEl.setAttribute('aria-label', "Details de l'element sélectionné");
       this._panelEl.setAttribute('aria-live', 'polite');
       const anchor = mapParent.querySelector(':scope > .dsfr-data-map__container') ?? mapParent;
+      // Le panel vit dans le conteneur Leaflet (#431) : isoler ses evenements
+      // pour que la molette scrolle le volet (et non le zoom de la carte) et
+      // que la selection de texte ne declenche pas un pan.
+      for (const type of ['wheel', 'dblclick', 'mousedown', 'touchstart', 'pointerdown']) {
+        this._panelEl.addEventListener(type, (e) => e.stopPropagation());
+      }
       anchor.appendChild(this._panelEl);
       // Trigger slide-in animation
       requestAnimationFrame(() => {

--- a/tests/map-popup-panel-scroll.test.ts
+++ b/tests/map-popup-panel-scroll.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * Test #431 (suivi) — le panel de dsfr-data-map-popup est ancre dans le
+ * conteneur Leaflet : ses evenements molette/souris ne doivent PAS remonter
+ * au conteneur, sinon la molette zoome la carte au lieu de scroller le volet.
+ */
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+import { DsfrDataMapPopup } from '@/components/dsfr-data-map-popup.js';
+
+function makeMapWithContainer(): { mapEl: HTMLElement; container: HTMLDivElement } {
+  const mapEl = document.createElement('dsfr-data-map');
+  const container = document.createElement('div');
+  container.className = 'dsfr-data-map__container';
+  mapEl.appendChild(container);
+  document.body.appendChild(mapEl);
+  return { mapEl, container };
+}
+
+describe('#431 — isolation des evenements du panel', () => {
+  it('le panel est ancre dans le conteneur Leaflet', () => {
+    const { mapEl, container } = makeMapWithContainer();
+    const popup = new DsfrDataMapPopup();
+    popup.mode = 'panel-right';
+    mapEl.appendChild(popup);
+
+    popup.showForRecord({ nom: 'Test' });
+    const panel = container.querySelector('.dsfr-data-map-popup__panel');
+    expect(panel).not.toBeNull();
+    popup.close();
+  });
+
+  it('wheel/dblclick/mousedown sur le panel ne remontent pas au conteneur', () => {
+    const { mapEl, container } = makeMapWithContainer();
+    const popup = new DsfrDataMapPopup();
+    popup.mode = 'panel-right';
+    mapEl.appendChild(popup);
+    popup.showForRecord({ nom: 'Test' });
+
+    const panel = container.querySelector('.dsfr-data-map-popup__panel')!;
+    const received: string[] = [];
+    for (const type of ['wheel', 'dblclick', 'mousedown']) {
+      container.addEventListener(type, () => received.push(type));
+    }
+
+    panel.dispatchEvent(new Event('wheel', { bubbles: true }));
+    panel.dispatchEvent(new Event('dblclick', { bubbles: true }));
+    panel.dispatchEvent(new Event('mousedown', { bubbles: true }));
+
+    // Le conteneur (gestionnaires Leaflet) ne recoit rien
+    expect(received).toEqual([]);
+
+    // Contre-epreuve : un wheel directement sur le conteneur passe toujours
+    container.dispatchEvent(new Event('wheel', { bubbles: true }));
+    expect(received).toEqual(['wheel']);
+    popup.close();
+  });
+
+  it('sans conteneur (fallback host), le panel fonctionne toujours', () => {
+    const mapEl = document.createElement('dsfr-data-map');
+    document.body.appendChild(mapEl);
+    const popup = new DsfrDataMapPopup();
+    popup.mode = 'panel-right';
+    mapEl.appendChild(popup);
+
+    popup.showForRecord({ nom: 'Test' });
+    expect(mapEl.querySelector('.dsfr-data-map-popup__panel')).not.toBeNull();
+    popup.close();
+  });
+});


### PR DESCRIPTION
Retour Bertrand : en scrollant sur le volet latéral, c'est la carte qui zoome/dézoome, comme si le volet était « invisible » à la molette.

**Cause** : depuis #431 (0.14.0), le panel est ancré dans le conteneur Leaflet — ses événements `wheel` bullent jusqu'au gestionnaire `scrollWheelZoom` de la carte.

**Fix** : isolation des événements `wheel`/`dblclick`/`mousedown`/`touchstart`/`pointerdown` du panel (`stopPropagation`) — la molette scrolle le volet, la sélection de texte ne panne plus la carte.

## Validation
- 3 nouveaux tests (ancrage conteneur, non-propagation avec contre-épreuve, fallback sans conteneur) ; suite complète **3665 tests verts**.
- Empirique (Chrome, bundle local) : 5 crans de molette sur le volet → zoom inchangé (6→6) ; sur la carte → zoom normal (6→8).
- Changeset **patch** (→ 0.14.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)