### PR TITLE
docs(guide): carte ELF — pin dsfr-data@0.14.1 (fix molette volet)

### DIFF
--- a/guide/examples/carte-territoires-electrification.html
+++ b/guide/examples/carte-territoires-electrification.html
@@ -8,14 +8,14 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <!-- Leaflet : charge dynamiquement par dsfr-data.umd.js - NE PAS inclure manuellement -->
-  <!-- dsfr-data : epingle en exact @0.14.0 + SRI (les encarts exigent >= 0.14.0 et l'URL
+  <!-- dsfr-data : epingle en exact @0.14.1 + SRI (les encarts exigent >= 0.14.0 et l'URL
        flottante @0 est cachee 7 jours par les navigateurs — un visiteur du jour verrait
        l'ancien bundle sans les encarts). Bundle complet (core + map).
        Requiert >= 0.14.0 : geo-field accepte les GeoJSON serialises en chaine (#426),
        {{champ:number}} dans les templates de map-popup (#426), et encarts DROM
        dsfr-data-map-inset (#431).
        Major flottant : pas de SRI (cf. check:sri). -->
-  <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0.14.0/dist/dsfr-data.umd.js" integrity="sha384-ret3o1hM0mCYurTTJFE+H95QXn2KVJvME0Wx9+CYPa2HeU7INtiLk3CD/bbMXC4X" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0.14.1/dist/dsfr-data.umd.js" integrity="sha384-ALUgPrDviRrtKpK/jNJklM71cOkCsw3BJRQv9YEUgIF4f2WyXkoZCYjd1a4hwMHX" crossorigin="anonymous"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
 
   <style>


### PR DESCRIPTION
Bump du pin CDN de la carte ELF vers **0.14.1** (+ hash SRI régénéré) pour livrer le fix #436 : la molette sur le volet scrolle le volet au lieu de zoomer la carte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)