### PR TITLE
fix(map): fit-bounds clippé par max-bounds + bounds libérées par couche vidée

### DIFF
--- a/.changeset/metro-fit-clip.md
+++ b/.changeset/metro-fit-clip.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': patch
+---
+
+`dsfr-data-map` : combiné à `max-bounds`, `fit-bounds` clippe désormais l'emprise des données à la zone d'intérêt avant d'ajuster la vue — un jeu incluant des territoires lointains (DROM) ne dézoome plus la carte au monde entier, et des données filtrées entièrement hors zone laissent la vue en place (les encarts s'en chargent). `dsfr-data-map-layer` libère ses bounds quand un filtre amont le vide (l'ancienne emprise ne fausse plus les ajustements suivants). Résultat : `fit-bounds max-bounds="…"` + `dsfr-data-facets` = zoom automatique sur la région sélectionnée.

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -2429,7 +2429,7 @@ Leaflet est charge dynamiquement (pas inclus dans le bundle).
 | no-controls | Boolean | \`false\` | Masque les controles de zoom |
 | locked | Boolean | \`false\` | Carte verrouillee : aucune interaction (pan/zoom/clavier) — encarts, vignettes |
 | insets | String | \`""\` | Raccourci encarts territoriaux : groupe et/ou territoires nommes (\`"drom"\`, \`"drom,corse"\`) |
-| fit-bounds | Boolean | \`false\` | Ajuste le viewport aux données |
+| fit-bounds | Boolean | \`false\` | Ajuste le viewport aux données a chaque mise a jour (combine a max-bounds : emprise clippee a la zone — les DROM ne dezooment pas la vue, un filtre regional zoome dessus) |
 | max-bounds | String | \`""\` | Limites \`"latSW,lonSW,latNE,lonNE"\` |
 | name | String | \`""\` | Titre (aria-label) |
 

--- a/packages/core/src/components/dsfr-data-map-layer.ts
+++ b/packages/core/src/components/dsfr-data-map-layer.ts
@@ -643,6 +643,10 @@ export class DsfrDataMapLayer extends SourceSubscriberMixin(LitElement) {
       const layerBounds = (this._clusterGroup || this._layerGroup).getBounds?.();
       if (layerBounds?.isValid?.()) {
         this._mapParent.registerLayerBounds(this._boundsKey, layerBounds);
+      } else {
+        // Couche devenue vide (filtrage amont) : liberer ses bounds, sinon
+        // l'ancienne emprise fausse le fit des rendus suivants
+        this._mapParent.unregisterLayerBounds(this._boundsKey);
       }
     }
 

--- a/packages/core/src/components/dsfr-data-map.ts
+++ b/packages/core/src/components/dsfr-data-map.ts
@@ -124,6 +124,29 @@ export function resolveTilePreset(
   return { key: isKnownPreset ? canonical : null, warning: deprecationWarning };
 }
 
+/**
+ * Clippe des bounds de donnees par un attribut max-bounds "latSW,lonSW,latNE,lonNE"
+ * avant un fitBounds. Retourne null si l'intersection est vide (la vue ne doit
+ * pas bouger) ; les bounds inchangees si max-bounds est absent ou invalide.
+ *
+ * Expose pour les tests.
+ */
+export function clipBoundsForFit(
+  combined: import('leaflet').LatLngBounds,
+  maxBounds: string,
+  leaflet: typeof import('leaflet')
+): import('leaflet').LatLngBounds | null {
+  if (!maxBounds) return combined;
+  const parts = maxBounds.split(',').map(Number);
+  if (parts.length !== 4 || parts.some((n) => Number.isNaN(n))) return combined;
+  const south = Math.max(combined.getSouth(), parts[0]);
+  const west = Math.max(combined.getWest(), parts[1]);
+  const north = Math.min(combined.getNorth(), parts[2]);
+  const east = Math.min(combined.getEast(), parts[3]);
+  if (south >= north || west >= east) return null;
+  return leaflet.latLngBounds([south, west], [north, east]);
+}
+
 /** Expose pour les tests (valeurs read-only). */
 export const __tilePresetsForTests = {
   presets: TILE_PRESETS,
@@ -606,9 +629,14 @@ export class DsfrDataMap extends LitElement {
   private _applyFitBounds() {
     if (!this._leafletMap || !L || this._layerBounds.size === 0) return;
     const combined = this._combineBounds([...this._layerBounds.values()], L);
-    if (combined) {
-      this._leafletMap.fitBounds(combined, { padding: [20, 20] });
-    }
+    if (!combined) return;
+    // fit-bounds + max-bounds : le fit est clippe a la zone d'interet de la
+    // carte. Un jeu incluant des territoires lointains (DROM) ne dezoome plus
+    // la vue au monde entier ; si les donnees filtrees sont entierement hors
+    // zone, la vue ne bouge pas (les encarts s'en chargent).
+    const clipped = clipBoundsForFit(combined, this.maxBounds, L);
+    if (!clipped) return;
+    this._leafletMap.fitBounds(clipped, { padding: [20, 20] });
   }
 
   /**

--- a/tests/map-fit-bounds-clip.test.ts
+++ b/tests/map-fit-bounds-clip.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * Tests fit-bounds + max-bounds (#294 suite) — zoom automatique sur les
+ * donnees filtrees sans dezoomer au monde entier quand le jeu contient des
+ * territoires lointains (DROM).
+ *
+ * - clipBoundsForFit : intersection donnees ∩ max-bounds avant le fit
+ *   (null = intersection vide, la vue ne bouge pas)
+ * - unregisterLayerBounds : une couche videe par un filtre libere ses bounds
+ *   (sinon l'ancienne emprise fausse les fits suivants)
+ */
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+import { DsfrDataMap, clipBoundsForFit } from '@/components/dsfr-data-map.js';
+
+function bounds(south: number, west: number, north: number, east: number) {
+  return {
+    getSouth: () => south,
+    getWest: () => west,
+    getNorth: () => north,
+    getEast: () => east,
+    isValid: () => true,
+  } as unknown as import('leaflet').LatLngBounds;
+}
+
+const fakeLeaflet = {
+  latLngBounds: (sw: [number, number], ne: [number, number]) => bounds(sw[0], sw[1], ne[0], ne[1]),
+} as unknown as typeof import('leaflet');
+
+const METRO = '40.5,-6.5,52,10.5';
+
+describe('clipBoundsForFit', () => {
+  it('sans max-bounds : bounds inchangees', () => {
+    const b = bounds(41, -5, 51, 9);
+    expect(clipBoundsForFit(b, '', fakeLeaflet)).toBe(b);
+  });
+
+  it('max-bounds invalide : bounds inchangees', () => {
+    const b = bounds(41, -5, 51, 9);
+    expect(clipBoundsForFit(b, 'nawak', fakeLeaflet)).toBe(b);
+    expect(clipBoundsForFit(b, '1,2,3', fakeLeaflet)).toBe(b);
+  });
+
+  it('jeu France entiere (DROM inclus) clippe a la metropole', () => {
+    // Bounds combinees de la Reunion (-21) a Lille (51)
+    const world = bounds(-21.4, -61.8, 51.1, 55.8);
+    const clipped = clipBoundsForFit(world, METRO, fakeLeaflet)!;
+    expect(clipped.getSouth()).toBe(40.5);
+    expect(clipped.getWest()).toBe(-6.5);
+    expect(clipped.getNorth()).toBe(51.1);
+    expect(clipped.getEast()).toBe(10.5);
+  });
+
+  it('region metropolitaine : intersection = la region elle-meme', () => {
+    const bretagne = bounds(47.2, -5.2, 48.9, -1.0);
+    const clipped = clipBoundsForFit(bretagne, METRO, fakeLeaflet)!;
+    expect(clipped.getSouth()).toBe(47.2);
+    expect(clipped.getWest()).toBe(-5.2);
+    expect(clipped.getNorth()).toBe(48.9);
+    expect(clipped.getEast()).toBe(-1.0);
+  });
+
+  it('donnees entierement hors zone (DROM seul) : null, la vue ne bouge pas', () => {
+    const martinique = bounds(14.3, -61.3, 14.9, -60.8);
+    expect(clipBoundsForFit(martinique, METRO, fakeLeaflet)).toBe(null);
+  });
+});
+
+describe('bounds liberees par une couche videe (filtrage amont)', () => {
+  it('unregisterLayerBounds retire la cle sans refit quand tout est vide', () => {
+    const map = new DsfrDataMap();
+    map.registerLayerBounds('communes', bounds(43, 1, 44, 2));
+    expect((map as unknown as { _layerBounds: Map<string, unknown> })._layerBounds.size).toBe(1);
+    map.unregisterLayerBounds('communes');
+    expect((map as unknown as { _layerBounds: Map<string, unknown> })._layerBounds.size).toBe(0);
+    // Idempotent
+    map.unregisterLayerBounds('communes');
+    expect((map as unknown as { _layerBounds: Map<string, unknown> })._layerBounds.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Demande Bertrand : zoomer automatiquement sur une région quand elle est sélectionnée dans les filtres (`dsfr-data-facets`).

`fit-bounds` se ré-applique déjà à chaque rendu, mais deux défauts l'empêchaient de servir ce cas (constatés empiriquement) :
1. un jeu incluant les DROM faisait dézoomer la vue au monde entier (z3) ;
2. une couche **vidée** par un filtre gardait ses bounds périmées (fit faussé : z6 centre France au lieu de la Bretagne).

## Fix
- **`clipBoundsForFit`** (exposé pour tests) : l'emprise combinée des données est intersectée avec `max-bounds` avant le `fitBounds` ; intersection vide → la vue ne bouge pas (les encarts DROM s'en chargent) ;
- **map-layer** : bounds désenregistrées quand la couche n'a plus de features.

## Usage déclaratif
`<dsfr-data-map fit-bounds max-bounds="38.5,-13,54,15" …>` + facettes → sélection Bretagne = zoom Bretagne, retour « Tous » = vue métropole, région DROM = vue stable.

## Validation
- 10 tests (5 clip + lifecycle) ; suite complète **3671 verts**.
- Empirique (Chrome, bundle local) : initial z5 France · Bretagne z7 47.5,-3.2 · Occitanie z7 43.7,2.7 · retour z5. Nota : `max-bounds` doit laisser une marge au viewport (le clamp Leaflet recentre sinon) — zone retenue pour la page : `38.5,-13,54,15`.
- Changeset **patch** (→ 0.14.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)