### PR TITLE
fix(map): fit-bounds sans animation (zoom animé annulé, vue figée)

### DIFF
--- a/.changeset/calm-fit-noanim.md
+++ b/.changeset/calm-fit-noanim.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': patch
+---
+
+`dsfr-data-map` : le `fit-bounds` s'applique sans animation — le zoom animé de Leaflet était régulièrement annulé (re-rendu des couches, compagnons hors-carte) et laissait la vue inchangée après un filtrage multiselect.

--- a/packages/core/src/components/dsfr-data-map.ts
+++ b/packages/core/src/components/dsfr-data-map.ts
@@ -636,7 +636,11 @@ export class DsfrDataMap extends LitElement {
     // zone, la vue ne bouge pas (les encarts s'en chargent).
     const clipped = clipBoundsForFit(combined, this.maxBounds, L);
     if (!clipped) return;
-    this._leafletMap.fitBounds(clipped, { padding: [20, 20] });
+    // Sans animation : le zoom anime de Leaflet est regulierement annule
+    // (re-rendu des couches sur moveend, compagnons hors-carte) — constate
+    // empiriquement : le fit anime laissait la vue inchangee apres un
+    // filtrage multiselect, le fit direct fonctionne toujours.
+    this._leafletMap.fitBounds(clipped, { padding: [20, 20], animate: false });
   }
 
   /**


### PR DESCRIPTION
Suite de #439 : en passant le filtre région en **multiselect** sur la carte ELF, le fit ne s'appliquait plus — `fitBounds` **animé** est régulièrement annulé par les re-rendus Leaflet (constaté : fit animé → vue inchangée ; `animate: false` → fit correct dans 100 % des cas ; `setView` direct fonctionnait).

Fix : `_applyFitBounds` applique le fit **sans animation**.

## Validation (Chrome, bundle local, multiselect)
initial z5 France · Bretagne z7 47.5,-3.1 · +Pays de la Loire z7 47.5,-2.2 (cadre élargi aux deux) · décochage → z5 France. Suite complète 3671 tests verts. Changeset patch (→ 0.14.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)