### PR TITLE
feat(map,kpi): couches décoratives (shape-class, no-interactive) + KPI littéral

### DIFF
--- a/.changeset/decorative-layers-kpi-literal.md
+++ b/.changeset/decorative-layers-kpi-literal.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': minor
+---
+
+`dsfr-data-map-layer` : nouveaux attributs `shape-class` (classe CSS sur les tracés SVG — permet des motifs hachurés via un `<pattern>` défini par la page) et `no-interactive` (couche décorative sans clic/tooltip/popup — contours administratifs, habillage). `dsfr-data-kpi` : valeur littérale avec le préfixe `=` (`value="=667"`, `value="=87 %"`) affichée telle quelle, sans dépendre d'une source — pour les chiffres validés à la main.

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -910,7 +910,7 @@ Attend un tableau d'objets. L'attribut \`valeur\` determine comment extraire/agr
 | Attribut | Type | Défaut | Requis | Description |
 |----------|------|--------|--------|-------------|
 | source | String | \`""\` | oui | ID de la dsfr-data-source ou dsfr-data-query |
-| value | String | \`""\` | oui | Expression : \`"champ"\`, \`"champ:avg"\`, \`"champ:sum"\`, \`"champ:min"\`, \`"champ:max"\`, \`"count:champ:valeur"\` (grammaire commune champ:fn, #303). Alias deprecie : \`valeur\` |
+| value | String | \`""\` | oui | Expression : \`"champ"\`, \`"champ:avg"\`, \`"champ:sum"\`, \`"champ:min"\`, \`"champ:max"\`, \`"count:champ:valeur"\` (grammaire commune champ:fn, #303). Alias deprecie : \`valeur\` · litteral avec \`=\` : \`value="=667"\`, \`value="=87 %"\` (sans source) |
 | heading | String | \`""\` | non | Titre affiche AU-DESSUS de la valeur (surtitre, majuscules grises). Nomme \`heading\` (pas \`title\`, qui collisionne avec la propriete DOM native) |
 | label | String | \`""\` | non | Libelle sous la valeur (et sous les \`lines\`) |
 | description | String | \`""\` | non | Description pour accessibilité (sr-only) |
@@ -2442,6 +2442,8 @@ Leaflet est charge dynamiquement (pas inclus dans le bundle).
 | lat-field | String | \`""\` | Chemin vers latitude |
 | lon-field | String | \`""\` | Chemin vers longitude |
 | geo-field | String | \`""\` | Chemin vers GeoJSON (Point, Polygon) — objet ou chaine JSON serialisee (colonnes Text Grist/CSV) |
+| shape-class | String | \`""\` | Classe CSS appliquee aux traces SVG (geoshape/circle) — motifs hachures via <pattern> defini par la page |
+| no-interactive | Boolean | \`false\` | Couche decorative : aucun clic/tooltip/popup (contours administratifs, habillage) |
 | popup-template | String | \`""\` | Template : \`"{nom} — {val} kW"\` |
 | popup-fields | String | \`""\` | Champs pour tableau auto : \`"nom,adresse"\` |
 | tooltip-field | String | \`""\` | Champ affiche au survol |

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -1,0 +1,41 @@
+# Scripts de démo vidéo — chartsBuilder
+
+Scripts de démonstration vidéo de **3 minutes maximum** chacun, couvrant les parcours clés de chartsBuilder (dsfr-data). Chaque script détaille, étape par étape : l'écran affiché, les clics et actions à réaliser, et le discours de la voix off.
+
+## Série 1 — Prise en main des outils
+
+| # | Vidéo | Fichier | Durée cible |
+|---|-------|---------|-------------|
+| 1 | Créer des sources de données | [demo-01-sources.md](demo-01-sources.md) | ≤ 3 min |
+| 2 | Utiliser le Builder | [demo-02-builder.md](demo-02-builder.md) | ≤ 3 min |
+| 3 | Utiliser le Builder IA | [demo-03-builder-ia.md](demo-03-builder-ia.md) | ≤ 3 min |
+| 4 | Utiliser le Playground | [demo-04-playground.md](demo-04-playground.md) | ≤ 3 min |
+| 5 | Créer un compte et utiliser les favoris | [demo-05-compte-favoris.md](demo-05-compte-favoris.md) | ≤ 3 min |
+
+## Série 2 — Scénarios métier (cas d'usage bout en bout)
+
+| # | Vidéo | Fichier | Durée cible |
+|---|-------|---------|-------------|
+| 6 | Illustrer un article sur les soldes : recherche de données (INSEE Melodi) → graphique | [demo-06-metier-soldes.md](demo-06-metier-soldes.md) | ≤ 3 min |
+| 7 | Article d'actu RappelConso (DGCCRF) : dataviz intégrées dans Drupal 11 | [demo-07-metier-rappelconso.md](demo-07-metier-rappelconso.md) | ≤ 3 min |
+| 8 | Tableau de bord prix des contrôles techniques : Claude in Chrome + MCP ChartsBuilder | [demo-08-metier-dashboard-mcp.md](demo-08-metier-dashboard-mcp.md) | ≤ 3 min |
+
+Les scénarios métier s'appuient sur des données publiques **vérifiées au moment de la rédaction** (juillet 2026) : indice de volume des ventes INSEE (`DS_ICA`, activité 47.71), `rappelconso-v2-gtin-trie` (~17 500 fiches) et `prix-controle-technique` (~143 000 tarifs) sur data.economie.gouv.fr. Chaque script métier comporte des chiffres de secours pour la voix off et exige une répétition générale avant tournage.
+
+## Conventions des scripts
+
+- **Format** : chaque script est découpé en séquences horodatées (`0:00 – 0:20`, etc.).
+- **Trois colonnes d'information par séquence** :
+  - 🖥️ **Écran** : ce qui est visible à l'image (page, panneau, zoom éventuel).
+  - 🖱️ **Actions** : les clics, saisies et navigations à exécuter, avec les libellés exacts des boutons.
+  - 🎙️ **Voix off** : le texte à lire, calibré pour la durée de la séquence (~140 mots/min).
+- **Préparation** : chaque script commence par une section « Prérequis » (état de départ, données à préparer, compte à créer en amont, etc.).
+- **Environnement de tournage** : instance locale (`npm run dev`, http://localhost:5173) ou instance de démo déployée. Navigateur en fenêtre 1920×1080, thème clair DSFR, zoom 100 %.
+
+## Fil rouge des données
+
+Pour la cohérence entre les vidéos, les démos s'appuient sur des jeux de données publics déjà référencés dans le [guide utilisateur](../USER-GUIDE.md) :
+
+- **Industrie du futur** — bénéficiaires et investissements par région (data.economie.gouv.fr, OpenDataSoft).
+- **Fiscalité locale** — taux de taxes foncières par commune (data.economie.gouv.fr).
+- **Répertoire national des élus** — maires de France (tabular-api.data.gouv.fr).

--- a/docs/demo/demo-01-sources.md
+++ b/docs/demo/demo-01-sources.md
@@ -1,0 +1,65 @@
+# Démo 1 — Créer des sources de données
+
+> **Durée cible** : 2 min 55 · **App** : `apps/sources` · **URL** : `/apps/sources/index.html` (nav « Sources »)
+
+## Objectif de la vidéo
+
+Montrer les deux façons de brancher des données dans Charts builder : une **source manuelle** (saisie directe) et une **connexion à une API publique** par simple copier-coller d'URL, avec détection automatique de la plateforme. Terminer sur le pont vers le Builder.
+
+## Prérequis (avant tournage)
+
+- Instance lancée (`npm run dev` → http://localhost:5173) ou instance de démo.
+- État vierge (ou presque) de la page Sources pour montrer l'écran « 3 façons de commencer ».
+- Visite guidée déjà vue (elle se lance au premier chargement — la passer avant le tournage).
+- URL à coller préparée dans le presse-papiers : page du jeu de données **Industrie du futur** sur data.economie.gouv.fr (OpenDataSoft).
+- Trois lignes de données prêtes pour la saisie manuelle (ex. `region` / `budget` : Île-de-France 120, Bretagne 85, Occitanie 97).
+
+---
+
+## Séquence 1 — Introduction (0:00 – 0:20)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Page d'accueil Charts builder, puis clic sur la tuile **« Sources »**. L'app s'ouvre : sidebar des connexions à gauche, zone d'exploration à droite avec l'écran **« 3 façons de commencer »** (Données manuelles, API publique, Grist). |
+| 🖱️ **Actions** | Naviguer vers **« Sources »**. Laisser 3 s sur l'écran d'accueil de l'app. |
+| 🎙️ **Voix off** | « Tout graphique commence par des données. Dans Charts builder, l'outil Sources centralise leur connexion. Trois façons de commencer : saisir des données manuelles, brancher une API publique, ou connecter un document Grist. Nous allons voir les deux premières. » |
+
+## Séquence 2 — Créer une source manuelle (0:20 – 1:05)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Clic sur **« Créer une source manuelle »** dans la sidebar. La modale **« Nouvelle source manuelle »** s'ouvre : champ **« Nom de la source »**, trois onglets **« Tableau »**, **« Coller JSON »**, **« Importer CSV »**. |
+| 🖱️ **Actions** | 1. Cliquer sur **« Créer une source manuelle »**. 2. Saisir le nom : `Budget par région`. 3. Rester sur l'onglet **« Tableau »** : nommer deux colonnes (`region`, `budget`), cliquer deux fois sur **« Ajouter une ligne »**, remplir les 3 lignes préparées. 4. Montrer d'un survol rapide les onglets **« Coller JSON »** et **« Importer CSV »**. 5. Cliquer sur **« Sauvegarder »** → toast « Source “Budget par région” ajoutée. ». La carte apparaît dans **« Jeux de données locaux »**. |
+| 🎙️ **Voix off** | « Premier cas : j'ai mes chiffres sous la main. Je crée une source manuelle, je la nomme, et je saisis mes données directement dans le tableau — je pourrais aussi coller du JSON ou importer un fichier CSV. Je sauvegarde : la source apparaît dans mes jeux de données locaux, stockée dans le navigateur, prête à alimenter un graphique. » |
+
+## Séquence 3 — Connecter une API publique par détection d'URL (1:05 – 2:00)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Clic sur **« Nouvelle connexion »**. Modale **« Nouvelle connexion »**, étape 1 : champ **« Adresse du jeu de données »** avec son texte d'aide (« Collez l'URL d'une page de données… la configuration est déduite automatiquement »). Après **« Continuer »** : étape 2 avec le message **« Plateforme détectée : OpenDataSoft. Tout est prêt — enregistrez pour récupérer les données. »**, champ **« Nom de la connexion »**, bloc **« Paramètres avancés »** replié. |
+| 🖱️ **Actions** | 1. Cliquer sur **« Nouvelle connexion »**. 2. Coller l'URL de la page du jeu « Industrie du futur » (data.economie.gouv.fr). 3. Cliquer sur **« Continuer »** → montrer le message de détection. 4. Saisir le nom : `Industrie du futur`. 5. Déplier 2 s **« Paramètres avancés »** (URL des données pré-remplie, emplacement des données déduit), replier. 6. Cliquer sur **« Tester et sauvegarder »** → le bouton passe à « Test en cours… », puis la carte apparaît dans la sidebar avec son statut de connexion. |
+| 🎙️ **Voix off** | « Deuxième cas : les données sont déjà en ligne. Je copie simplement l'adresse de la page du jeu de données — ici, le programme Industrie du futur sur data.economie.gouv.fr — et je la colle. Charts builder reconnaît la plateforme automatiquement : OpenDataSoft, Tabular de data.gouv.fr, l'INSEE, Grist ou n'importe quelle API JSON. Tout est pré-configuré ; les paramètres avancés restent accessibles si besoin. "Tester et sauvegarder" : la connexion est réellement vérifiée avant d'être enregistrée — pas de mauvaise surprise plus tard. » |
+
+## Séquence 4 — Explorer et prévisualiser les données (2:00 – 2:35)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Clic sur la carte de la connexion → l'explorateur s'ouvre à droite, onglet **« Aperçu »** : tableau des 20 premières lignes et bandeau de métadonnées (nombre de lignes, typage des colonnes, ex. « 8 texte · 3 nombre »). Barre d'action au-dessus. |
+| 🖱️ **Actions** | 1. Cliquer sur la connexion `Industrie du futur` dans la sidebar. 2. Parcourir l'aperçu (scroll horizontal léger). 3. Pointer le bandeau de métadonnées. 4. Cliquer sur **« En faire un jeu en ligne »** → la carte apparaît dans **« Jeux de données en ligne »**. 5. Montrer le bouton **« Rafraîchir »**. |
+| 🎙️ **Voix off** | « Un clic sur la connexion, et j'explore les données : aperçu des premières lignes, types de colonnes détectés — texte, nombre, géographie. J'en fais un jeu de données en ligne : il reste relié à l'API et pourra être rafraîchi à tout moment, contrairement au jeu local qui fige une copie. » |
+
+## Séquence 5 — Vers le Builder (2:35 – 2:55)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Barre d'action de l'aperçu : boutons **« Utiliser dans le Builder »**, **« Garder en favori »**, **« Exporter vers Grist »**. Clic sur **« Utiliser dans le Builder »** → l'app Builder s'ouvre avec la source présélectionnée. Fondu de fin. |
+| 🖱️ **Actions** | Survoler les trois boutons d'action, puis cliquer sur **« Utiliser dans le Builder »**. Laisser 2 s sur le Builder ouvert. |
+| 🎙️ **Voix off** | « Mes sources sont prêtes. Depuis l'aperçu, je peux les garder en favori, les exporter vers Grist… ou passer directement à la suite : "Utiliser dans le Builder" ouvre le générateur de graphiques avec la source déjà sélectionnée. C'est l'objet de la prochaine vidéo. » |
+
+---
+
+## Plan B / variantes
+
+- Si data.economie.gouv.fr est indisponible au tournage, utiliser une URL Tabular (tabular-api.data.gouv.fr, jeu « Répertoire national des élus ») — même parcours de détection.
+- Fonctions coupables si dépassement : séquence 4 réduite (sans « En faire un jeu en ligne »), survol des boutons d'action raccourci.
+- Bonus hors chrono (si version longue un jour) : **« Joindre deux sources »** (jointure avec aperçu live) et l'**import/export global** JSON de la sidebar.

--- a/docs/demo/demo-02-builder.md
+++ b/docs/demo/demo-02-builder.md
@@ -1,0 +1,80 @@
+# Démo 2 — Utiliser le Builder
+
+> **Durée cible** : 2 min 50 · **App** : `apps/builder` · **URL** : `/apps/builder/index.html` (nav « Créer un graphique »)
+
+## Objectif de la vidéo
+
+Montrer qu'en moins de trois minutes, on passe d'un jeu de données à un graphique DSFR prêt à intégrer : choix de la source, type de graphique, configuration des axes, génération, copie du code.
+
+## Prérequis (avant tournage)
+
+- Instance lancée (`npm run dev` → http://localhost:5173) ou instance de démo.
+- Une source **« Industrie du futur »** (API OpenDataSoft data.economie.gouv.fr) déjà créée dans Sources (cf. [démo 1](demo-01-sources.md)) — la vidéo 2 ne re-montre pas la création.
+- Visite guidée déjà vue (ou désactivée) pour qu'elle ne se déclenche pas à l'ouverture.
+- Onglet **« Aperçu »** actif, panneau de gauche déplié sur « Source de données ».
+
+---
+
+## Séquence 1 — Introduction (0:00 – 0:20)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Page d'accueil Charts builder. Survol de la carte **« Créer un graphique »**, clic. L'app Builder s'ouvre : configuration à gauche, aperçu à droite avec l'état vide guidé (« Charger une source de données », « Choisir un type de graphique »…). |
+| 🖱️ **Actions** | Depuis l'accueil, cliquer sur **« Créer un graphique »**. Laisser 2 s sur l'écran d'accueil du Builder. |
+| 🎙️ **Voix off** | « Le Builder de Charts builder, c'est le générateur visuel de graphiques. À gauche, la configuration pas à pas ; à droite, l'aperçu en temps réel. Aucune ligne de code à écrire : on configure, on génère, on copie. » |
+
+## Séquence 2 — Choisir la source de données (0:20 – 0:45)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Section **« Source de données »** en haut du panneau gauche. Le menu déroulant **« Source »** affiche « — Choisir — ». Zoom léger sur la section. |
+| 🖱️ **Actions** | Ouvrir le menu **« Source »**, sélectionner la source **« Industrie du futur »**. Les champs disponibles se chargent automatiquement dans les sélecteurs (pas de bouton à cliquer). Montrer d'un geste de souris le lien **« Nouvelle »** qui renvoie vers l'app Sources. |
+| 🎙️ **Voix off** | « Première étape : les données. Je choisis une source déjà connectée — ici, les bénéficiaires du programme Industrie du futur, publiés sur data.economie.gouv.fr. Dès la sélection, le Builder interroge l'API et découvre les champs disponibles. Si la source n'existe pas encore, le lien "Nouvelle" ouvre l'outil Sources. » |
+
+## Séquence 3 — Choisir le type de graphique (0:45 – 1:05)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Section **« Type de graphique »** : grille de 11 vignettes — Barres, Barres H, Lignes, Camembert, Anneau, Radar, Nuage, Jauge, KPI, Carte, Tableau. |
+| 🖱️ **Actions** | Balayer la grille au survol (1–2 s), puis cliquer sur **« Barres »**. |
+| 🎙️ **Voix off** | « Deuxième étape : le type de visualisation. Onze types sont disponibles, tous conformes au Design System de l'État : barres, lignes, camembert, radar, jauge, KPI, carte départementale, tableau… Je pars sur un graphique en barres. » |
+
+## Séquence 4 — Configurer les données (1:05 – 1:40)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Section **« Configuration des données »**. Sélecteurs **« Étiquettes (axe horizontal) »** et **« Valeur à mesurer (Série 1) »**, puis le select **« Si plusieurs lignes par catégorie, agréger par »**. |
+| 🖱️ **Actions** | 1. Dans **« Étiquettes (axe horizontal) »**, choisir `nom_region`. 2. Dans **« Valeur à mesurer (Série 1) »**, choisir `nombre_beneficiaires`. 3. Dans **« Si plusieurs lignes par catégorie, agréger par »**, laisser **« Somme »** (montrer le badge d'agrégation suggérée). 4. Dans **« Ordre »**, choisir **« Décroissant »**. Survoler sans l'activer la bascule **« Mode avancé (filtres & requêtes) »**. |
+| 🎙️ **Voix off** | « Troisième étape : je relie les données au graphique. En abscisse, la région ; en valeur, le nombre de bénéficiaires. Comme il y a plusieurs lignes par région, le Builder propose de lui-même une agrégation — je garde la somme — et je trie par ordre décroissant. Pour aller plus loin, un mode avancé permet filtres, regroupements et agrégations multiples. » |
+
+## Séquence 5 — Apparence et génération (1:40 – 2:10)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Section **« Apparence »** : champs **« Titre »**, **« Sous-titre / Source »**, sélecteur **« Palette de couleurs »** avec nuanciers. Puis clic sur le grand bouton **« Générer le graphique »** ; le graphique en barres apparaît dans l'onglet **« Aperçu »** à droite. |
+| 🖱️ **Actions** | 1. Saisir le titre : `Bénéficiaires Industrie du futur par région`. 2. Sous-titre : `Source : data.economie.gouv.fr`. 3. Ouvrir **« Palette de couleurs »**, choisir **« Couleurs distinctes par catégorie »**. 4. Cliquer sur **« Générer le graphique »**. Laisser l'animation du graphique se jouer 3 s, survoler une barre pour montrer l'infobulle. |
+| 🎙️ **Voix off** | « Je soigne l'habillage : un titre, la mention de la source, et une palette DSFR — ici, couleurs distinctes par catégorie. Un clic sur "Générer le graphique"… et voilà. Le graphique est rendu à droite, interactif, avec les infobulles au survol, exactement tel qu'il s'affichera sur votre site. » |
+
+## Séquence 6 — Récupérer le code (2:10 – 2:40)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Panneau de droite : bascule sur l'onglet **« Code généré »**. Le snippet HTML complet s'affiche avec la mention « Copiez ce code pour l'intégrer dans votre page : ». Montrer aussi 2 s l'onglet **« Données brutes »**. |
+| 🖱️ **Actions** | 1. Cliquer sur l'onglet **« Code généré »**. 2. Faire défiler brièvement le code. 3. Cliquer sur **« Copier le code »** → toast « Code copié dans le presse-papiers ». 4. Clic rapide sur l'onglet **« Données brutes »** puis retour à **« Aperçu »**. |
+| 🎙️ **Voix off** | « Le résultat, c'est un simple fragment HTML autonome : les composants dsfr-data, les liens vers les styles et scripts nécessaires — pas d'iframe, pas de dépendance à installer. "Copier le code", et il ne reste qu'à le coller dans n'importe quelle page web. L'onglet Données brutes permet au passage de vérifier ce que renvoie l'API. » |
+
+## Séquence 7 — Conclusion et ouvertures (2:40 – 2:50)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Retour sur l'onglet **« Aperçu »**. Survol des deux boutons d'action **« Playground »** et **« Favoris »** en haut à droite du panneau d'aperçu. |
+| 🖱️ **Actions** | Survoler **« Playground »** (infobulle « Ouvrir dans le Playground ») puis **« Favoris »** (infobulle « Sauvegarder en favoris »). Ne pas cliquer. |
+| 🎙️ **Voix off** | « Envie d'aller plus loin ? Le bouton Playground ouvre le code dans l'éditeur interactif, et le bouton Favoris sauvegarde le graphique pour le retrouver plus tard. Ce sont les sujets des prochaines vidéos. » |
+
+---
+
+## Plan B / variantes
+
+- Si l'API data.economie.gouv.fr est lente au tournage, utiliser une source manuelle préparée à l'avance (mêmes champs).
+- Version courte (2 min) : couper la séquence 7 et le passage « Données brutes ».
+- Pour illustrer la richesse sans rallonger : après la séquence 5, changer le type en **« Camembert »** et regénérer (≈ 10 s) — optionnel.

--- a/docs/demo/demo-03-builder-ia.md
+++ b/docs/demo/demo-03-builder-ia.md
@@ -1,0 +1,73 @@
+# Démo 3 — Utiliser le Builder IA
+
+> **Durée cible** : 2 min 55 · **App** : `apps/builder-ia` · **URL** : `/apps/builder-ia/index.html` (nav « Assistant IA »)
+
+## Objectif de la vidéo
+
+Montrer la création d'un graphique par simple conversation en français avec l'assistant, propulsé par Albert (l'IA souveraine de l'État) : demande en langage naturel, boucle agentique visible (l'IA inspecte les vraies données avant de générer), itération, puis export du code embarquable.
+
+## Prérequis (avant tournage)
+
+- Instance avec la **configuration Albert serveur** active (badge « Albert (serveur) » dans la section « Configuration IA ») — aucun token à saisir à l'écran.
+- Source **« Industrie du futur »** (OpenDataSoft, data.economie.gouv.fr) déjà créée dans Sources — champs `nom_region`, `nombre_beneficiaires`, `montant_investissement`.
+- Visite guidée déjà vue ; conversation précédente effacée (bouton corbeille « Effacer la conversation »).
+- Prompts répétés en amont : les temps de réponse de l'IA varient — prévoir des coupes au montage sur les temps d'attente.
+
+---
+
+## Séquence 1 — Introduction (0:00 – 0:20)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Page d'accueil, clic sur **« Assistant IA »**. L'app s'ouvre : à gauche la configuration et le chat **« Assistant graphiques »** avec son message d'accueil (« Sélectionnez une source de données… Décrivez le graphique souhaité en français »), à droite le panneau avec les onglets **« Aperçu »**, **« Code »**, **« Données »** et le message « Discutez avec l'assistant pour créer votre graphique ». |
+| 🖱️ **Actions** | Naviguer vers **« Assistant IA »**. Laisser 3 s sur l'interface. |
+| 🎙️ **Voix off** | « Et si on créait un graphique simplement en le décrivant ? C'est le Builder IA : un assistant conversationnel propulsé par Albert, l'IA souveraine de l'État. On lui parle en français, il construit le graphique — et il vérifie les données réelles avant de répondre. » |
+
+## Séquence 2 — Charger la source (0:20 – 0:35)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Section **« Source de données »** : select **« Source »**, bouton **« Charger »**. Zoom bref sur le badge d'état IA « Albert (serveur) » dans **« Configuration IA »**. |
+| 🖱️ **Actions** | 1. Sélectionner la source **« Industrie du futur »** dans **« Source »**. 2. Cliquer sur **« Charger »**. 3. Pointer 2 s le badge « Albert (serveur) ». |
+| 🎙️ **Voix off** | « Comme dans le Builder classique, tout part d'une source de données — je charge les bénéficiaires du programme Industrie du futur. L'IA est déjà configurée côté serveur : rien à installer, aucun jeton à saisir. » |
+
+## Séquence 3 — Première demande en langage naturel (0:35 – 1:30)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Champ de saisie (placeholder « Decrivez le graphique que vous souhaitez créer... »). Saisie du prompt, envoi. Le chat affiche « Réflexion en cours… » puis les étapes de raisonnement en direct : « J'examine le jeu de données… », « Je vérifie le rendu du graphique… ». Le graphique en barres apparaît dans l'onglet **« Aperçu »**, la réponse de l'assistant s'affiche avec des suggestions cliquables. |
+| 🖱️ **Actions** | 1. Taper : `Un diagramme en barres des bénéficiaires par région, top 5.` 2. Appuyer sur **Entrée**. 3. Laisser dérouler les étapes de raisonnement (zoom sur ces libellés). 4. Le graphique se dessine à droite. 5. Montrer le bloc repliable « Raisonnement de l'assistant (N étapes) » et les suggestions (« Changer le type de graphique », « Ajouter des facettes », « Générer le code embarquable »). |
+| 🎙️ **Voix off** | « Je décris ce que je veux, en français : "un diagramme en barres des bénéficiaires par région, top cinq". Et regardez ce qui se passe : l'assistant ne devine pas — il travaille. Il examine le jeu de données, vérifie les champs et les valeurs réelles, teste le rendu, et corrige tout seul si quelque chose cloche. Quelques secondes plus tard, le graphique est là : les cinq premières régions, agrégées et triées. Chaque étape du raisonnement reste consultable, et l'assistant me propose déjà des pistes pour continuer. » |
+
+## Séquence 4 — Itérer par la conversation (1:30 – 2:10)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Nouvelle saisie dans le chat. Le graphique de l'aperçu se transforme en camembert. Deuxième itération : ajout d'un filtre. |
+| 🖱️ **Actions** | 1. Taper : `Passe en camembert` (ou cliquer la suggestion **« Changer le type de graphique »** puis préciser). 2. Envoi → l'aperçu devient un camembert. 3. Taper : `Reviens en barres et montre plutôt le montant d'investissement par région`. 4. Envoi → le graphique se met à jour. |
+| 🎙️ **Voix off** | « La conversation continue, le graphique suit. "Passe en camembert" — c'est fait. "Reviens en barres et montre plutôt le montant d'investissement" — l'assistant garde le contexte de tout l'échange et reconfigure le graphique à chaque tour. Pas de formulaire, pas de documentation à lire : on affine par le dialogue, comme avec un collègue. » |
+
+## Séquence 5 — Générer et récupérer le code (2:10 – 2:45)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Clic sur la suggestion **« Générer le code embarquable »**. Bascule sur l'onglet **« Code »** : le snippet HTML complet s'affiche. Clic sur **« Copier le code »** → toast « Code copie dans le presse-papiers ! ». Survol du bouton « Ouvrir dans le Playground ». |
+| 🖱️ **Actions** | 1. Cliquer sur la suggestion **« Générer le code embarquable »**. 2. Ouvrir l'onglet **« Code »**, faire défiler le snippet. 3. Cliquer sur **« Copier le code »**. 4. Survoler le bouton d'ouverture dans le Playground. Jeter un œil rapide à l'onglet **« Données »**. |
+| 🎙️ **Voix off** | « Dernière étape : "génère le code embarquable". L'assistant produit le fragment HTML autonome — composants dsfr-data, styles et scripts inclus — identique à celui du Builder classique. Je le copie, ou je l'ouvre dans le Playground pour le retoucher à la main. L'onglet Données permet de contrôler ce que renvoie l'API. » |
+
+## Séquence 6 — Conclusion (2:45 – 2:55)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Vue d'ensemble de l'app : le chat avec l'historique de la conversation à gauche, le graphique final à droite. Fondu de fin. |
+| 🖱️ **Actions** | Dézoomer / plan large. |
+| 🎙️ **Voix off** | « Du langage naturel au widget prêt à publier, en moins de trois minutes — et avec une IA hébergée en France. C'est le Builder IA de Charts builder. » |
+
+---
+
+## Plan B / variantes
+
+- Prompts de rechange validés par les tests : `barres population par region`, `kpi prix moyen dans le departement 48` (selon la source chargée).
+- Si l'IA est lente, couper les attentes au montage en gardant à l'écran les étapes de raisonnement (elles font partie de la démonstration).
+- Si le serveur Albert est indisponible : basculer sur un jeton personnel dans **« Configuration IA »** (hors champ), ou reporter le tournage — ne pas montrer le mode dégradé par commandes (`barres champ1 champ2`) dans cette vidéo.
+- Ne **pas** promettre d'autres fournisseurs à l'écran ; mentionner uniquement Albert (la compatibilité OpenAI/Anthropic/Mistral existe mais n'est pas l'objet de la démo).

--- a/docs/demo/demo-04-playground.md
+++ b/docs/demo/demo-04-playground.md
@@ -1,0 +1,71 @@
+# Démo 4 — Utiliser le Playground
+
+> **Durée cible** : 2 min 50 · **App** : `apps/playground` · **URL** : `/apps/playground/index.html` (tuile « Playground »)
+
+## Objectif de la vidéo
+
+Montrer le Playground comme bac à sable : galerie de plus de 30 exemples prêts à l'emploi, édition du code en direct avec aperçu instantané, et export d'un extrait autonome (« + Deps » puis « Copier »).
+
+## Prérequis (avant tournage)
+
+- Instance lancée (`npm run dev` → http://localhost:5173).
+- Visite guidée du Playground déjà vue (4 bulles au premier passage — la passer avant, ou la garder pour la séquence 1 en version rapide).
+- Connexion réseau opérationnelle (les exemples appellent data.economie.gouv.fr et tabular-api.data.gouv.fr en direct).
+
+---
+
+## Séquence 1 — Introduction (0:00 – 0:20)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Page d'accueil, clic sur la tuile **« Playground »**. L'app s'ouvre en écran scindé : éditeur de code sombre (thème Dracula) à gauche, aperçu rendu à droite — l'exemple « Barres — Fiscalite locale » est chargé et déjà exécuté. |
+| 🖱️ **Actions** | Naviguer vers le Playground. Laisser le graphique par défaut s'afficher (2–3 s). |
+| 🎙️ **Voix off** | « Le Playground, c'est le bac à sable de Charts builder : un éditeur de code à gauche, le rendu en temps réel à droite. Idéal pour expérimenter, comprendre les composants dsfr-data, ou ajuster finement un code généré par le Builder. » |
+
+## Séquence 2 — La galerie d'exemples (0:20 – 0:50)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Menu déroulant **« Charger un exemple : »** ouvert, montrant les catégories : Mode direct, Avec requête (dsfr-data-query), Avec normalisation, Facettes, Jointure multi-sources, Cartes interactives… Sélection de **« KPI — Industrie du futur »**, confirmation « Remplacer le code actuel par cet exemple ? », rendu d'une grille de 4 tuiles KPI. |
+| 🖱️ **Actions** | 1. Ouvrir le sélecteur **« Charger un exemple : »**, faire défiler lentement les catégories. 2. Choisir **« KPI — Industrie du futur »**. 3. Valider **« Remplacer le code actuel par cet exemple ? »**. 4. Laisser les KPI se charger. |
+| 🎙️ **Voix off** | « Plus de trente exemples prêts à l'emploi, classés par usage : graphiques branchés en direct sur une API, requêtes avec agrégation, nettoyage de données, filtres à facettes, jointures entre deux sources, cartes interactives… Je charge l'exemple KPI : quatre indicateurs calculés à la volée — somme, moyenne, maximum — depuis les données d'Industrie du futur. » |
+
+## Séquence 3 — Éditer le code en direct (0:50 – 1:40)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Retour sur l'exemple **« Barres — Fiscalite locale »**. Zoom sur l'éditeur : le composant `<dsfr-data-chart source="data" type="bar" …>`. Modification de `type="bar"` en `type="line"`, puis de `limit="15"` en `limit="30"` dans `<dsfr-data-source>`. À chaque exécution, l'aperçu se met à jour. |
+| 🖱️ **Actions** | 1. Recharger l'exemple **« Barres — Fiscalite locale »**. 2. Dans l'éditeur, remplacer `type="bar"` par `type="line"`. 3. Cliquer sur **« Executer »** (ou `Ctrl+Entrée`) → le graphique passe en courbe. 4. Modifier `limit="15"` → `limit="30"`. 5. `Ctrl+Entrée` → la courbe s'étend à 30 communes. 6. Montrer le bouton **« Reinitialiser »** (sans cliquer, ou cliquer pour revenir à l'état initial). |
+| 🎙️ **Voix off** | « C'est là que le Playground prend tout son sens : le code est vivant. Les composants dsfr-data se configurent par simples attributs HTML. Je change le type "bar" en "line", j'exécute — Contrôle-Entrée — et le graphique devient une courbe. Je passe la limite de quinze à trente communes, j'exécute à nouveau : l'API est réinterrogée et l'aperçu suit. Pas de compilation, pas de rechargement de page. Et si je me perds, "Réinitialiser" restaure l'exemple d'origine. » |
+
+## Séquence 4 — Exporter un code autonome (1:40 – 2:15)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Barre d'outils de l'éditeur : **« Executer »**, **« Reinitialiser »**, **« + Deps »**, **« Copier »**, **« Favoris »**, **« Pipeline »**. Clic sur **« + Deps »** : un bloc de `<link>` et `<script>` (DSFR, Chart.js, dsfr-data) s'ajoute en tête du code. Clic sur **« Copier »** → toast « Code copie dans le presse-papiers ». |
+| 🖱️ **Actions** | 1. Cliquer sur **« + Deps »** — montrer le bloc CDN ajouté (le bouton devient **« - Deps »**). 2. Cliquer sur **« Copier »** → toast. 3. Cliquer sur **« - Deps »** pour montrer la bascule inverse. |
+| 🎙️ **Voix off** | « Dans le Playground, les bibliothèques DSFR et dsfr-data sont injectées automatiquement. Pour emporter le code ailleurs, le bouton "+ Deps" ajoute les dépendances nécessaires — styles DSFR, Chart.js, la bibliothèque dsfr-data — et l'extrait devient totalement autonome. "Copier", et il est prêt à être collé dans n'importe quelle page de votre site. » |
+
+## Séquence 5 — L'effet waouh : carte interactive (2:15 – 2:40)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Sélection de l'exemple **« Carte — 5000 CT avec clustering + panneau »** (catégorie Carte interactive). Une carte Leaflet se charge avec des milliers de points regroupés en clusters ; zoom sur la carte, clic sur un cluster puis un marqueur. |
+| 🖱️ **Actions** | 1. Charger l'exemple **« Carte — 5000 CT avec clustering + panneau »**, confirmer. 2. Zoomer/dézoomer sur la carte, cliquer un cluster, ouvrir le panneau d'un marqueur. |
+| 🎙️ **Voix off** | « Le Playground, c'est aussi la vitrine des composants avancés. Ici, une carte interactive qui affiche cinq mille collectivités avec regroupement automatique des points — le tout en quelques lignes de HTML déclaratif. » |
+
+## Séquence 6 — Conclusion (2:40 – 2:50)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Survol des boutons **« Favoris »** et **« Pipeline »**, puis du lien **« Guide et exemples »**. Fondu de fin. |
+| 🖱️ **Actions** | Survoler **« Favoris »** (sauvegarde du code), **« Pipeline »** (visualisation du pipeline de composants) et le lien **« Guide et exemples »**. Ne pas cliquer. |
+| 🎙️ **Voix off** | « Chaque expérimentation peut être sauvegardée en favori pour la retrouver plus tard, et le guide en ligne documente tous les composants. À vous de jouer. » |
+
+---
+
+## Plan B / variantes
+
+- Les exemples peuvent être préchargés par URL : `?example=direct-bar`, `?example=direct-kpi` — utile pour enchaîner les prises sans manipuler le sélecteur.
+- Si la carte 5000 points est lente au tournage, remplacer la séquence 5 par **« Carte — PIB par pays »** (carte du monde, chargement plus léger).
+- Version courte (2 min 15) : couper la séquence 5.

--- a/docs/demo/demo-05-compte-favoris.md
+++ b/docs/demo/demo-05-compte-favoris.md
@@ -1,0 +1,65 @@
+# Démo 5 — Créer un compte et utiliser les favoris
+
+> **Durée cible** : 2 min 55 · **Apps** : en-tête commun (`auth-modal`) + `apps/favorites` · **URL favoris** : `/apps/favorites/index.html`
+
+## Objectif de la vidéo
+
+Montrer la création d'un compte (avec vérification par email), puis le cycle de vie d'un favori : sauvegarde depuis le Builder, consultation dans l'app Favoris, réédition, partage public par lien anonyme — et la synchronisation multi-appareils apportée par le compte.
+
+## Prérequis (avant tournage)
+
+- Instance en **mode serveur** (backend + base de données actifs) : le bouton **« Connexion »** n'apparaît dans l'en-tête que si un backend est détecté.
+- Une adresse email de démo accessible à l'écran (boîte mail ouverte dans un second onglet) pour montrer l'email de vérification. ⚠️ Ne pas utiliser une adresse personnelle réelle.
+- Un graphique prêt à générer dans le Builder (source « Industrie du futur », type Barres — cf. démo 2) pour la séquence de sauvegarde en favori.
+- Aucune session ouverte (déconnecté), et un compte qui n'existe pas encore pour cette adresse. Note : le **premier** utilisateur d'une instance devient admin et est connecté immédiatement sans email de vérification — pour montrer le parcours standard, l'instance doit déjà avoir au moins un compte.
+
+---
+
+## Séquence 1 — Créer son compte (0:00 – 0:50)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | N'importe quelle page de l'app, en-tête visible. Clic sur **« Connexion »** → la modale s'ouvre avec les onglets **« Connexion »** / **« Inscription »**. Bascule sur **« Inscription »** : champs **« Nom d'affichage »**, **« Email »**, **« Mot de passe »** (aide : « 8 caractères minimum, 1 majuscule, 1 minuscule, 1 chiffre »). Si le SSO est activé sur l'instance, un bouton « Se connecter avec… » apparaît au-dessus du formulaire, séparé par « — ou — ». |
+| 🖱️ **Actions** | 1. Cliquer sur **« Connexion »** dans l'en-tête. 2. Choisir l'onglet **« Inscription »**. 3. Remplir : nom d'affichage `Camille Demo`, email de démo, mot de passe conforme. 4. Cliquer sur **« S'inscrire »**. 5. Basculer sur l'onglet boîte mail : ouvrir l'email de vérification, cliquer le lien. 6. Revenir sur l'app, se connecter via l'onglet **« Connexion »** (**« Se connecter »**). L'en-tête affiche désormais le menu **« Mon espace »**. |
+| 🎙️ **Voix off** | « Jusqu'ici, tout était stocké dans le navigateur. Pour retrouver son travail partout, on crée un compte. Un nom, un email, un mot de passe robuste — et sur les instances qui le proposent, la connexion peut aussi passer par le SSO de votre organisation. Je valide mon adresse depuis l'email reçu, je me connecte : le menu "Mon espace" confirme que je suis identifiée. À partir de maintenant, mes sources, favoris et tableaux de bord sont synchronisés sur le serveur — je les retrouverai depuis n'importe quel poste. » |
+
+## Séquence 2 — Sauvegarder un favori depuis le Builder (0:50 – 1:25)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | App Builder, graphique « Bénéficiaires Industrie du futur par région » généré. Clic sur le bouton étoile **« Favoris »** en haut du panneau d'aperçu → dialogue **« Sauvegarder en favoris »**, champ **« Nom du favori »** (placeholder « Ex : Population par région 2024 »). |
+| 🖱️ **Actions** | 1. Ouvrir le Builder, générer le graphique préparé (raccourci de tournage : état déjà prêt, un seul clic sur **« Générer le graphique »**). 2. Cliquer sur le bouton **« Favoris »** (étoile). 3. Nommer : `Bénéficiaires par région`. 4. Cliquer sur **« Sauvegarder »** → toast « Graphique “Bénéficiaires par région” ajouté à vos favoris. » ; l'étoile devient pleine. |
+| 🎙️ **Voix off** | « Direction le Builder. Mon graphique est généré ; plutôt que de copier le code tout de suite, je le mets de côté : un clic sur l'étoile, un nom, et il rejoint mes favoris. L'étoile pleine me confirme la sauvegarde — et comme je suis connectée, le favori part aussitôt sur le serveur. » |
+
+## Séquence 3 — L'app Favoris (1:25 – 2:05)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Navigation vers l'app Favoris. Sidebar **« Mes favoris »** avec compteur, tri (**« Plus recents / Plus anciens / Nom (A-Z) / Par type »**), champ **« Rechercher... »**, boutons **« Exporter »** / **« Importer »**. Clic sur le favori → zone principale : aperçu live du graphique + code. Barre d'actions : **« Playground »**, **« Builder »**, **« Copier le code »**, **« Partager »**, corbeille. |
+| 🖱️ **Actions** | 1. Ouvrir l'app **Favoris**. 2. Montrer la liste (nom, type, date, app d'origine) et taper 2 lettres dans **« Rechercher... »**. 3. Sélectionner `Bénéficiaires par région` → aperçu + code. 4. Cliquer sur le crayon **« Renommer »**, corriger le nom, valider. 5. Cliquer sur **« Builder »** → le Builder se rouvre avec toute la configuration restaurée ; revenir aux Favoris. |
+| 🎙️ **Voix off** | « L'app Favoris rassemble tout ce que j'ai mis de côté — graphiques du Builder, de l'assistant IA ou du Playground. Je peux trier, rechercher, renommer. Et surtout : un favori n'est pas une image figée. Le bouton Builder restaure l'intégralité de la configuration — source, type, réglages — pour reprendre l'édition exactement où je l'avais laissée. » |
+
+## Séquence 4 — Partager publiquement (2:05 – 2:40)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Clic sur **« Partager »** (infobulle « Partager publiquement (lien anonyme) ») → modale **« Partager publiquement »** avec le **« Lien public »** généré, boutons **« Copier »** et **« Revoquer le lien »**. Ouverture du lien dans une fenêtre de navigation privée : la vue publique affiche le graphique, sans compte ni connexion. |
+| 🖱️ **Actions** | 1. Cliquer sur **« Partager »**. 2. Dans la modale, cliquer sur **« Copier »**. 3. Coller le lien dans une fenêtre privée → le graphique s'affiche pour un visiteur anonyme. 4. Revenir sur la modale et montrer (sans cliquer) **« Revoquer le lien »**. |
+| 🎙️ **Voix off** | « Besoin de montrer le résultat à un collègue avant publication ? Le partage public génère un lien secret et anonyme : la personne voit le graphique sans compte ni installation. Et si le partage n'a plus lieu d'être, on révoque le lien d'un clic. » |
+
+## Séquence 5 — Conclusion (2:40 – 2:55)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Retour sur la liste des favoris ; ouverture rapide du menu **« Mon espace »** dans l'en-tête (nom et email affichés, entrées « Mot de passe » et « Se deconnecter »). Fondu de fin. |
+| 🖱️ **Actions** | Ouvrir le menu **« Mon espace »**, le laisser affiché 2 s. |
+| 🎙️ **Voix off** | « Un compte, des favoris synchronisés, le partage en un lien : Charts builder devient votre espace de travail dataviz. Sources, Builder, assistant IA, Playground, favoris — vous avez maintenant tous les outils en main. » |
+
+---
+
+## Plan B / variantes
+
+- Si l'envoi d'email n'est pas configuré sur l'instance de tournage, filmer le parcours d'inscription jusqu'au message de confirmation, puis enchaîner avec un compte pré-vérifié (coupe au montage) — ne pas montrer d'astuce d'activation manuelle à l'écran.
+- La suppression d'un favori (corbeille → modale « Supprimer ce favori ? … Cette action est irreversible. ») peut remplacer la séquence 4 si le partage public n'est pas activé sur l'instance.
+- Hors chrono (version longue) : **« Exporter »** / **« Importer »** des favoris en JSON (`dsfr-data-favoris.json`), et l'ouverture d'un favori dans le **Playground**.
+- Instance en mode `OIDC_ONLY` : le formulaire local disparaît — cette vidéo suppose une instance avec inscription locale activée.

--- a/docs/demo/demo-06-metier-soldes.md
+++ b/docs/demo/demo-06-metier-soldes.md
@@ -1,0 +1,69 @@
+# Démo métier 6 — Illustrer un article sur les soldes : de la recherche de données au graphique
+
+> **Durée cible** : 2 min 55 · **Persona** : rédacteur / chargé de communication · **Apps** : Sources + Builder
+> **Données** : INSEE Melodi, dataset `DS_ICA` — indice de volume des ventes (IVVC) du commerce de détail d'habillement (NAF 47.71)
+
+## Scénario
+
+« On me demande d'illustrer un article sur les soldes en France. Je n'ai pas de données sous la main : je les cherche, je les branche, et je produis un graphique qui montre l'effet des soldes sur les ventes d'habillement. »
+
+L'angle éditorial : dans la série mensuelle de l'INSEE, **le pic de janvier** (soldes d'hiver) saute aux yeux — en 2026, l'indice bondit à 124 en janvier avant de retomber à 83 en février.
+
+## Prérequis (avant tournage)
+
+- Instance Charts builder lancée.
+- Onglets prêts dans le navigateur : data.gouv.fr et le catalogue de données INSEE (catalogue-donnees.insee.fr).
+- URL Melodi préparée dans un gestionnaire de notes (elle sera collée à l'écran) :
+  `https://api.insee.fr/melodi/data/DS_ICA?ACTIVITY=47.71&IDX_TYPE=IVVC&SEASONAL_ADJUST=N`
+  (ACTIVITY 47.71 = commerce de détail d'habillement ; IVVC = indice de volume des ventes ; SEASONAL_ADJUST=N = série brute, indispensable pour voir la saisonnalité des soldes).
+- ⚠️ **Répétition générale obligatoire** : dérouler une fois le parcours complet (détection de l'URL Melodi, aperçu, graphique) pour noter les noms exacts des colonnes aplaties (`TIME_PERIOD`, `OBS_VALUE_NIVEAU`) et vérifier le temps de chargement de la série.
+
+---
+
+## Séquence 1 — La commande, et la chasse aux données (0:00 – 0:40)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Maquette de l'article en cours de rédaction (traitement de texte ou CMS) avec un emplacement vide « [graphique ici] ». Puis navigateur : recherche « soldes » sur data.gouv.fr — résultats décevants (comptes publics, délibérations municipales…). Bascule sur le site de l'INSEE. |
+| 🖱️ **Actions** | 1. Montrer 3 s l'article en préparation. 2. Taper `soldes` dans la recherche de data.gouv.fr, faire défiler les résultats. 3. Ouvrir le catalogue INSEE, montrer la fiche de l'indice de chiffre d'affaires / volume des ventes dans le commerce de détail. |
+| 🎙️ **Voix off** | « La rédaction me demande d'illustrer un article sur les soldes. Premier réflexe : chercher des données ouvertes. Sur data.gouv.fr, "soldes" renvoie surtout… des soldes comptables. Le bon filon est ailleurs : l'INSEE publie chaque mois l'indice de volume des ventes du commerce de détail, décliné par activité — dont l'habillement, le secteur roi des soldes. Et son API Melodi est ouverte, sans clé. » |
+
+## Séquence 2 — Brancher l'API INSEE dans Sources (0:40 – 1:20)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | App **Sources** de Charts builder. Clic sur **« Nouvelle connexion »**, collage de l'URL Melodi dans **« Adresse du jeu de données »**, clic sur **« Continuer »** → message **« Plateforme détectée : INSEE (Melodi) »**. Nom pré-rempli, clic sur **« Tester et sauvegarder »**. |
+| 🖱️ **Actions** | 1. Ouvrir **Sources**. 2. **« Nouvelle connexion »**. 3. Coller l'URL `https://api.insee.fr/melodi/data/DS_ICA?ACTIVITY=47.71&IDX_TYPE=IVVC&SEASONAL_ADJUST=N`. 4. **« Continuer »** — zoom sur « Plateforme détectée : INSEE (Melodi) ». 5. Renommer la connexion : `Ventes habillement (INSEE)`. 6. **« Tester et sauvegarder »**. |
+| 🎙️ **Voix off** | « Pas besoin de lire la documentation de l'API : je colle l'adresse dans Charts builder, qui reconnaît la plateforme INSEE Melodi et pré-configure tout. L'URL embarque déjà mes filtres : l'activité habillement, l'indice de volume des ventes, et la série brute — car c'est justement la saisonnalité qui m'intéresse. Test de connexion, sauvegarde : c'est branché. » |
+
+## Séquence 3 — Vérifier les données (1:20 – 1:40)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Explorateur de la connexion, onglet **« Aperçu »** : tableau des observations aplaties — colonnes `TIME_PERIOD` (mois) et `OBS_VALUE_NIVEAU` (indice), bandeau de métadonnées. |
+| 🖱️ **Actions** | 1. Cliquer sur la connexion. 2. Parcourir l'aperçu : pointer `TIME_PERIOD` et `OBS_VALUE_NIVEAU`. 3. Cliquer sur **« Utiliser dans le Builder »**. |
+| 🎙️ **Voix off** | « Un coup d'œil à l'aperçu : une ligne par mois depuis 2005, avec la période et la valeur de l'indice. C'est exactement la matière qu'il me faut. Direction le Builder. » |
+
+## Séquence 4 — Construire la courbe (1:40 – 2:25)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Builder, source présélectionnée. Type **« Lignes »**. Configuration : étiquettes `TIME_PERIOD`, valeur `OBS_VALUE_NIVEAU`, ordre **« Ordre source »**. Mode avancé activé, filtre `TIME_PERIOD:gte:2023-01` pour resserrer sur les 3 dernières années. Titre, palette, **« Générer le graphique »** : la courbe apparaît avec ses pics de décembre-janvier. |
+| 🖱️ **Actions** | 1. Type de graphique : **« Lignes »**. 2. **« Étiquettes (axe horizontal) »** : `TIME_PERIOD` — libellé `Mois`. 3. **« Valeur à mesurer (Série 1) »** : `OBS_VALUE_NIVEAU` — libellé `Indice de volume des ventes`. 4. **« Ordre »** : **« Ordre source »**. 5. Activer **« Mode avancé (filtres & requêtes) »**, filtre : `TIME_PERIOD:gte:2023-01`. 6. Titre : `L'effet soldes sur les ventes d'habillement` ; sous-titre : `Indice de volume des ventes, base 100 en 2021 — Source : INSEE`. 7. **« Générer le graphique »**. 8. Survoler le point de janvier 2026 (124) puis février (83). |
+| 🎙️ **Voix off** | « Une courbe, la période en abscisse, l'indice en ordonnée. Je filtre sur les trois dernières années pour que le motif reste lisible. Et le voilà, mon angle d'article : chaque mois de janvier, les ventes d'habillement s'envolent — ici l'indice grimpe à 124 — avant de retomber à 83 en février. L'effet soldes, visible d'un seul regard. Le graphique cite sa source et sa base : l'INSEE, base 100 en 2021. » |
+
+## Séquence 5 — Livrer le graphique (2:25 – 2:55)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Onglet **« Code généré »**, clic sur **« Copier le code »**. Retour à la maquette de l'article : le code est collé, le graphique s'affiche dans la page (montage). Fondu de fin. |
+| 🖱️ **Actions** | 1. Onglet **« Code généré »** → **« Copier le code »** (toast). 2. Coller dans la page de l'article (ou montrer le rendu final préparé). 3. Plan final sur l'article illustré. |
+| 🎙️ **Voix off** | « Il ne reste qu'à copier le fragment HTML et à le coller dans l'article. Le graphique est autonome, aux couleurs de l'État, accessible — et comme il interroge l'API de l'INSEE, il affichera les prochains mois sans que j'aie à y retoucher. De la recherche de données au graphique publié : quelques minutes. » |
+
+---
+
+## Plan B / variantes
+
+- Si la détection Melodi ou l'aplatissement des colonnes ne se comporte pas comme attendu à la répétition : télécharger la série en CSV depuis le site INSEE et la charger en **source manuelle** (onglet « Importer CSV ») — le reste du parcours Builder est identique (mais le graphique devient statique : adapter la dernière phrase de la voix off).
+- Si la série complète est trop lente à charger : garder le filtre d'URL et ajouter `&maxResult=…` réduit, ou resserrer le filtre du Builder à `2024-01`.
+- Chiffres de secours pour la voix off (vérifiés en juillet 2026) : décembre 2025 = 144, janvier 2026 = 124, février 2026 = 83.

--- a/docs/demo/demo-07-metier-rappelconso.md
+++ b/docs/demo/demo-07-metier-rappelconso.md
@@ -1,0 +1,78 @@
+# Démo métier 7 — Un article d'actu sur RappelConso, dataviz intégrées dans Drupal
+
+> **Durée cible** : 2 min 55 · **Persona** : rédacteur web d'un site institutionnel · **Apps** : Sources + Builder + Drupal 11
+> **Données** : `rappelconso-v2-gtin-trie` (DGCCRF) sur data.economie.gouv.fr — ~17 500 fiches de rappel
+> **CMS de démonstration** : https://drupal11.lab.miweb.run (instance VibeLab)
+
+## Scénario
+
+« On me confie le jeu de données RappelConso de la DGCCRF et on me demande un article d'actualité sur ce dispositif. Je crée quelques dataviz — un chiffre clé et une répartition par catégorie — et je les intègre directement dans mon article Drupal. »
+
+Le message éditorial : depuis son lancement, RappelConso a publié **plus de 17 500 rappels de produits**, dont **près de 8 sur 10 concernent l'alimentation**.
+
+## Prérequis (avant tournage)
+
+- Instance Charts builder lancée ; instance Drupal 11 accessible (drupal11.lab.miweb.run), compte contributeur connecté.
+- ⚠️ Drupal : vérifier qu'un format de texte autorisant le HTML complet (« Full HTML » ou équivalent) est actif pour le corps des articles, et que les balises `<script>`/composants personnalisés ne sont pas filtrées — sinon activer le format ou passer par un bloc HTML brut. **Répéter l'intégration avant le tournage.**
+- Page du jeu de données ouverte dans un onglet : `https://data.economie.gouv.fr/explore/dataset/rappelconso-v2-gtin-trie/`.
+- Article Drupal pré-rédigé (titre + 2 paragraphes) en brouillon, avec deux emplacements réservés pour les dataviz.
+- Les deux snippets générés pendant la démo peuvent être pré-copiés dans un presse-papiers multiple en secours.
+
+---
+
+## Séquence 1 — Le sujet et les données (0:00 – 0:30)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Page du dataset RappelConso sur data.economie.gouv.fr : titre, description DGCCRF, onglet tableau. Copie de l'URL depuis la barre d'adresse. |
+| 🖱️ **Actions** | 1. Parcourir 5 s la page du jeu de données (scroll sur le tableau : `date_publication`, `categorie_produit`, `motif_rappel`…). 2. Copier l'URL de la page. |
+| 🎙️ **Voix off** | « Produits contaminés, jouets dangereux, airbags défectueux : depuis 2021, tous les rappels de produits sont publiés sur RappelConso. La DGCCRF ouvre ces données sur data.economie.gouv.fr — plus de 17 000 fiches. Mon article d'actualité doit raconter ce dispositif, chiffres à l'appui. Je copie simplement l'adresse de la page. » |
+
+## Séquence 2 — Brancher la source (0:30 – 1:00)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | App **Sources** : **« Nouvelle connexion »**, collage de l'URL, **« Continuer »** → **« Plateforme détectée : OpenDataSoft. Tout est prêt — enregistrez pour récupérer les données. »** Nom `RappelConso`, **« Tester et sauvegarder »**. Aperçu rapide des colonnes. |
+| 🖱️ **Actions** | 1. Ouvrir **Sources** → **« Nouvelle connexion »**. 2. Coller l'URL de la page → **« Continuer »**. 3. Nommer `RappelConso` → **« Tester et sauvegarder »**. 4. Cliquer la connexion, onglet **« Aperçu »** : pointer `categorie_produit` et `date_publication`. 5. **« Utiliser dans le Builder »**. |
+| 🎙️ **Voix off** | « Dans Charts builder, je colle l'URL de la page : plateforme OpenDataSoft détectée, configuration déduite, connexion testée. L'aperçu me montre la matière : catégorie de produit, motif du rappel, date de publication. Tout ce qu'il faut pour deux visualisations : un chiffre clé, et une répartition. » |
+
+## Séquence 3 — Dataviz 1 : le chiffre clé (1:00 – 1:25)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Builder : type **« KPI »**, agrégation **« Comptage »**, style et unité configurés. **« Générer le graphique »** → grande tuile « ~17 500 » ; onglet **« Code généré »** → **« Copier le code »**. |
+| 🖱️ **Actions** | 1. Type de graphique : **« KPI »**. 2. Agrégation : **« Comptage »**. 3. Dans **« Apparence »** : titre `Rappels publiés depuis 2021`, **« Style KPI »** : Info, **« Unité »** : `rappels`. 4. **« Générer le graphique »**. 5. Onglet **« Code généré »** → **« Copier le code »**, garder le snippet de côté. |
+| 🎙️ **Voix off** | « Première dataviz : le chiffre qui pose le sujet. Un composant KPI, un comptage sur l'ensemble des fiches — plus de 17 500 rappels publiés. Je génère, je copie le code : premier widget prêt. » |
+
+## Séquence 4 — Dataviz 2 : la répartition par catégorie (1:25 – 1:55)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Builder : type **« Camembert »**, étiquettes `categorie_produit`, valeur en comptage, tri décroissant. Génération : l'alimentation écrase les autres parts. **« Copier le code »**. |
+| 🖱️ **Actions** | 1. Type : **« Camembert »**. 2. **« Étiquettes »** : `categorie_produit` — libellé `Catégorie`. 3. Agrégation : **« Comptage »**, **« Ordre »** : **« Décroissant »**. 4. Titre : `Rappels par catégorie de produit` ; sous-titre : `Source : RappelConso — DGCCRF`. 5. Palette : **« Couleurs distinctes par catégorie »**. 6. **« Générer le graphique »** — survoler la part « alimentation ». 7. **« Copier le code »**. |
+| 🎙️ **Voix off** | « Deuxième dataviz : qui est concerné ? Un camembert des rappels par catégorie de produit. Le résultat parle de lui-même : l'alimentation représente près de huit rappels sur dix — treize mille cinq cents fiches à elle seule. Voilà l'angle de mon article. Je copie ce deuxième fragment. » |
+
+## Séquence 5 — Intégrer dans l'article Drupal (1:55 – 2:40)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Drupal 11 (drupal11.lab.miweb.run), édition de l'article en brouillon. Passage du corps en mode d'édition HTML (bouton **« Source »** de CKEditor, format de texte « Full HTML »). Collage du snippet KPI après le premier paragraphe, du camembert après le second. **« Enregistrer »** → l'article publié affiche les deux dataviz interactives. |
+| 🖱️ **Actions** | 1. Ouvrir l'article en modification dans Drupal. 2. Vérifier le format de texte (« Full HTML »), basculer l'éditeur en mode **« Source »**. 3. Coller le snippet KPI à l'emplacement 1, le snippet camembert à l'emplacement 2. 4. Cliquer sur **« Enregistrer »**. 5. Faire défiler l'article publié : le chiffre clé puis le camembert se chargent et s'affichent ; survoler une part du camembert. |
+| 🎙️ **Voix off** | « Direction mon site sous Drupal. Pas de module à installer : les widgets Charts builder sont de simples fragments HTML. J'ouvre mon article, je passe l'éditeur en mode source, je colle chaque fragment à sa place, j'enregistre. Et voilà : mon article d'actualité affiche un chiffre clé et un graphique interactifs, aux couleurs du Design System de l'État — et comme ils interrogent l'API de la DGCCRF en direct, ils resteront à jour au fil des prochains rappels, sans retoucher l'article. » |
+
+## Séquence 6 — Conclusion (2:40 – 2:55)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Plan large de l'article publié, scroll lent du titre au camembert. Fondu de fin. |
+| 🖱️ **Actions** | Scroll de relecture. |
+| 🎙️ **Voix off** | « Un jeu de données public, deux dataviz, un article enrichi — sans écrire une ligne de code, et sans dépendance côté CMS. Charts builder s'intègre partout où l'on peut coller du HTML : Drupal, WordPress, ou un site statique. » |
+
+---
+
+## Plan B / variantes
+
+- Si le format « Full HTML » n'est pas disponible sur l'instance Drupal : utiliser un champ/bloc « HTML brut » ou le module d'insertion de code, et le préciser en voix off (« selon la configuration de votre CMS »).
+- Troisième dataviz possible si le rythme le permet (+20 s) : **courbe des rappels par mois** (étiquettes `date_publication` tronquée au mois via le mode avancé, comptage) — sinon la garder pour une capture d'écran de fin.
+- Chiffres de secours pour la voix off (vérifiés en juillet 2026) : 17 566 fiches au total ; alimentation 13 570 (77 %) ; bébés-enfants 1 217 ; maison-habitat 589.
+- Si data.economie.gouv.fr est lent : les deux snippets pré-générés en prérequis permettent de tourner la séquence Drupal indépendamment.

--- a/docs/demo/demo-08-metier-dashboard-mcp.md
+++ b/docs/demo/demo-08-metier-dashboard-mcp.md
@@ -1,0 +1,76 @@
+# Démo métier 8 — Un tableau de bord construit par l'IA : Claude + extension Chrome + MCP ChartsBuilder
+
+> **Durée cible** : 3 min 00 · **Persona** : chargé d'études / data analyst outillé IA · **Outils** : Claude (claude.ai) + extension **Claude in Chrome** + connecteur MCP **ChartsBuilder** + Playground
+> **Données** : `prix-controle-technique` (DGCCRF) sur data.economie.gouv.fr — ~143 000 tarifs de centres de contrôle technique
+
+## Scénario
+
+« On me demande un tableau de bord sur les prix des contrôles techniques publiés par la DGCCRF. Plutôt que de le construire écran par écran, je le délègue à Claude : le connecteur MCP ChartsBuilder lui fournit les spécifications des composants dsfr-data, et l'extension Claude in Chrome lui permet de tester lui-même le résultat dans mon navigateur. »
+
+Le message : **l'IA généraliste devient un intégrateur Charts builder compétent** dès qu'on lui branche le MCP — et elle vérifie son propre travail dans le navigateur.
+
+## Prérequis (avant tournage)
+
+- Compte claude.ai avec : le connecteur MCP **ChartsBuilder** activé (serveur `dsfr-data-mcp` en mode HTTP — il expose 4 outils : `list_skills`, `get_skill`, `get_relevant_skills`, `generate_widget_code`) et l'extension **Claude in Chrome** installée et autorisée sur `chartsbuilder.miweb.run`.
+- Conversation Claude vierge ; onglet Chrome ouvert sur le Playground de l'instance (`https://chartsbuilder.miweb.run/playground/`).
+- Prompt principal répété en amont (les temps de génération varient — prévoir des coupes au montage).
+- ⚠️ Répétition générale : dérouler le prompt une fois pour vérifier que les outils MCP répondent et que l'extension a bien les permissions sur le domaine.
+
+---
+
+## Séquence 1 — La commande et le dispositif (0:00 – 0:30)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Page du dataset `prix-controle-technique` sur data.economie.gouv.fr (143 000 lignes : centre, commune, région, catégorie de véhicule, prix de la visite). Puis claude.ai : ouverture du panneau des connecteurs, le connecteur **ChartsBuilder** est actif avec ses outils visibles. |
+| 🖱️ **Actions** | 1. Montrer 5 s la page du jeu de données (colonnes `cct_denomination`, `nom_region`, `cat_vehicule_libelle`, `prix_visite`). 2. Basculer sur claude.ai, ouvrir la liste des connecteurs, pointer **ChartsBuilder** et ses outils. |
+| 🎙️ **Voix off** | « La DGCCRF publie les tarifs de tous les centres de contrôle technique de France — cent quarante-trois mille lignes. On me demande un tableau de bord. Cette fois, je ne vais pas le construire moi-même : je vais le faire construire. Mon assistant Claude est relié au connecteur MCP ChartsBuilder, qui lui donne accès aux spécifications de tous les composants dataviz — et l'extension Claude in Chrome lui prête mes mains dans le navigateur. » |
+
+## Séquence 2 — Le prompt (0:30 – 0:55)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Zone de saisie claude.ai. Saisie du prompt complet, envoi. |
+| 🖱️ **Actions** | Taper et envoyer : `Construis-moi un tableau de bord HTML avec les composants dsfr-data sur le dataset "prix-controle-technique" de data.economie.gouv.fr (API OpenDataSoft) : un KPI du prix moyen de la visite pour une voiture particulière, un graphique en barres du prix moyen par région, et un tableau des 10 centres les moins chers. Source dynamique (pas de données en dur). Teste ensuite le rendu dans le Playground de chartsbuilder.miweb.run avec l'extension Chrome.` |
+| 🎙️ **Voix off** | « Ma commande tient en une phrase — ou presque : un indicateur du prix moyen pour une voiture particulière, un comparatif par région, et le palmarès des centres les moins chers. Je précise deux exigences de pro : des sources dynamiques branchées sur l'API, et une vérification du rendu dans le Playground. » |
+
+## Séquence 3 — Claude consulte le MCP et génère le code (0:55 – 1:40)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Fil de la conversation : les appels d'outils MCP s'affichent — `get_relevant_skills` puis `generate_widget_code` (dérouler un appel pour montrer la spécification reçue : attributs de `dsfr-data-kpi`, `dsfr-data-query`…). Puis Claude rédige le bloc de code HTML complet du tableau de bord. |
+| 🖱️ **Actions** | 1. Laisser dérouler les appels d'outils ; déplier celui de `generate_widget_code` 3 s. 2. Faire défiler le code produit : `<dsfr-data-source api-type="opendatasoft" dataset-id="prix-controle-technique">`, un `<dsfr-data-kpi>` avec filtre voiture particulière, un `<dsfr-data-query>` avec `group-by` région et moyenne, un `<dsfr-data-list>` trié par prix. |
+| 🎙️ **Voix off** | « Regardez ce qui se passe : avant d'écrire la moindre ligne, Claude interroge le serveur MCP. Celui-ci lui renvoie les "skills" ChartsBuilder — la documentation exacte de chaque composant, la même qui alimente le Builder IA. Résultat : pas de code inventé. L'assistant assemble une source branchée sur l'API de Bercy, une requête qui agrège les prix par région côté serveur, un KPI filtré sur les voitures particulières, et un tableau trié. Du dsfr-data idiomatique, comme l'aurait écrit un intégrateur qui connaît la bibliothèque. » |
+
+## Séquence 4 — Claude teste lui-même dans le navigateur (1:40 – 2:30)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | L'extension Claude in Chrome prend la main : l'onglet du **Playground** s'active, le code est collé dans l'éditeur, clic sur **« Executer »**. Le tableau de bord se rend dans l'aperçu : la tuile KPI (~84 €), les barres par région, le tableau des centres. Claude capture l'écran et commente le résultat dans la conversation. |
+| 🖱️ **Actions** | 1. Ne pas toucher au clavier : montrer la navigation pilotée par l'extension (badge actif). 2. Le code apparaît dans l'éditeur du Playground, **« Executer »** est cliqué. 3. Zoom sur le rendu : KPI, barres, tableau. 4. Retour au fil claude.ai : Claude confirme le rendu (capture à l'appui) et propose un ajustement. |
+| 🎙️ **Voix off** | « Et maintenant, la partie la plus impressionnante : je ne copie rien moi-même. Via l'extension Chrome, Claude ouvre le Playground de mon instance, colle son code, l'exécute — et vérifie le résultat de ses propres yeux. Le prix moyen d'un contrôle technique pour une voiture particulière : quatre-vingt-quatre euros. Les écarts entre régions, le palmarès des centres. Si un champ était erroné, il le verrait à l'écran et corrigerait. La boucle générer-tester-corriger, entièrement déléguée. » |
+
+## Séquence 5 — Itération en langage naturel (2:30 – 2:50)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Nouvelle consigne dans claude.ai : `Ajoute un second KPI avec le prix moyen de la contre-visite maximale, et trie les régions par prix décroissant.` Claude modifie le code, le re-teste dans le Playground : le tableau de bord se met à jour. |
+| 🖱️ **Actions** | 1. Envoyer la consigne d'ajustement. 2. Laisser l'extension rejouer le collage + **« Executer »**. 3. Plan sur le tableau de bord final à l'écran. |
+| 🎙️ **Voix off** | « Un ajustement ? Je le demande, en français. L'assistant met le code à jour, le rejoue dans le Playground, et me montre le résultat. Le tableau de bord est prêt à être copié dans une page, sauvegardé en favori — ou remis à l'équipe web tel quel. » |
+
+## Séquence 6 — Conclusion (2:50 – 3:00)
+
+| | |
+|---|---|
+| 🖥️ **Écran** | Écran scindé (montage) : le fil de conversation Claude à gauche, le tableau de bord rendu à droite. Fondu de fin. |
+| 🖱️ **Actions** | Plan de conclusion. |
+| 🎙️ **Voix off** | « Un jeu de données public, un prompt, trois minutes : le MCP ChartsBuilder transforme n'importe quel assistant IA en intégrateur dataviz de l'État — et le navigateur devient son banc d'essai. » |
+
+---
+
+## Plan B / variantes
+
+- Si l'extension Chrome n'a pas la main au tournage : Claude fournit le code dans la conversation, l'utilisateur le colle lui-même dans le Playground (adapter la voix off des séquences 4–5 : « je colle son code et j'exécute »).
+- Si le premier rendu de Claude comporte une erreur à la répétition : la **garder** dans la vidéo si elle est corrigée par la boucle de test — c'est l'argument central (l'IA vérifie et corrige) ; sinon régénérer.
+- Chiffres de secours pour la voix off (vérifiés en juillet 2026) : 142 963 tarifs ; prix moyen visite « Voiture particulière » ≈ 84,34 € (28 531 tarifs) ; motos ≈ 71 € ; camping-cars ≈ 88 €.
+- Variante « poste développeur » : même scénario dans Claude Code (le serveur `dsfr-data-mcp` en mode stdio via `npx dsfr-data-mcp`), le code étant écrit directement dans un fichier du projet — à réserver à un public technique.

--- a/packages/core/src/components/dsfr-data-kpi.ts
+++ b/packages/core/src/components/dsfr-data-kpi.ts
@@ -275,7 +275,9 @@ export class DsfrDataKpi extends SourceSubscriberMixin(LitElement) {
     if (this.description) return this.description;
 
     const value = this._computeValue();
-    const formattedValue = formatValue(value as number, this.format);
+    // Litteral chaine (value="=87 %") : affiche tel quel, sans formatage numerique
+    const formattedValue =
+      typeof value === 'string' ? value : formatValue(value as number, this.format);
     let label = this.heading
       ? `${this.heading} — ${this.label}: ${formattedValue}`
       : `${this.label}: ${formattedValue}`;
@@ -306,7 +308,9 @@ export class DsfrDataKpi extends SourceSubscriberMixin(LitElement) {
 
   render() {
     const value = this._computeValue();
-    const formattedValue = formatValue(value as number, this.format);
+    // Litteral chaine (value="=87 %") : affiche tel quel, sans formatage numerique
+    const formattedValue =
+      typeof value === 'string' ? value : formatValue(value as number, this.format);
     const colorClass = COLOR_CLASSES[this._getColor()] || COLOR_CLASSES.bleu;
     const tendance = this._getTendanceInfo();
     const resolvedLines = this._resolveLines();

--- a/packages/core/src/components/dsfr-data-kpi.ts
+++ b/packages/core/src/components/dsfr-data-kpi.ts
@@ -181,7 +181,16 @@ export class DsfrDataKpi extends SourceSubscriberMixin(LitElement) {
 
   private _computeValue(): number | string | null {
     const expr = this.value || this.valeur;
-    if (!this._sourceData || !expr) return null;
+    if (!expr) return null;
+    // Valeur litterale : value="=667" ou value="=87 %" — affichee telle
+    // quelle (nombre si numerique), sans dependre d'une source de donnees.
+    // Pour les chiffres valides a la main ou non calculables depuis le flux.
+    if (expr.startsWith('=')) {
+      const literal = expr.slice(1).trim();
+      const num = Number(literal.replace(',', '.'));
+      return literal !== '' && !Number.isNaN(num) ? num : literal;
+    }
+    if (!this._sourceData) return null;
     return computeAggregation(this._sourceData, expr);
   }
 

--- a/packages/core/src/components/dsfr-data-map-layer.ts
+++ b/packages/core/src/components/dsfr-data-map-layer.ts
@@ -102,6 +102,16 @@ export class DsfrDataMapLayer extends SourceSubscriberMixin(LitElement) {
   @property({ type: String, attribute: 'geo-field' })
   geoField = '';
 
+  /** Classe CSS appliquee aux traces SVG de la couche (geoshape/circle) —
+   *  permet un style page (motif hachure, pointilles...) via CSS/SVG <pattern> */
+  @property({ type: String, attribute: 'shape-class' })
+  shapeClass = '';
+
+  /** Couche decorative : aucune interaction (pas de clic, tooltip ni popup) —
+   *  contours administratifs, habillage */
+  @property({ type: Boolean, attribute: 'no-interactive' })
+  noInteractive = false;
+
   // --- Display ---
 
   @property({ type: String, attribute: 'popup-template' })
@@ -731,16 +741,20 @@ export class DsfrDataMapLayer extends SourceSubscriberMixin(LitElement) {
     if (!geoJson) return;
 
     const layer = Leaf.geoJSON(geoJson as import('geojson').GeoJsonObject, {
+      interactive: !this.noInteractive,
       style: {
         color: recordColor,
         weight: 1,
         fillColor,
         fillOpacity: this.fillOpacity,
+        ...(this.shapeClass ? { className: this.shapeClass } : {}),
       },
     });
 
-    this._bindPopup(layer, record);
-    this._bindTooltip(layer, record);
+    if (!this.noInteractive) {
+      this._bindPopup(layer, record);
+      this._bindTooltip(layer, record);
+    }
     group.addLayer(layer);
   }
 
@@ -761,27 +775,26 @@ export class DsfrDataMapLayer extends SourceSubscriberMixin(LitElement) {
     }
 
     const circleColor = this._resolveColor(record);
+    const circleOptions = {
+      radius: r,
+      color: circleColor,
+      fillColor: circleColor,
+      fillOpacity: this.fillOpacity,
+      weight: 1,
+      interactive: !this.noInteractive,
+      ...(this.shapeClass ? { className: this.shapeClass } : {}),
+    };
     let circle: import('leaflet').Layer;
     if (this.radiusUnit === 'm') {
-      circle = Leaf.circle([coords.lat, coords.lon], {
-        radius: r,
-        color: circleColor,
-        fillColor: circleColor,
-        fillOpacity: this.fillOpacity,
-        weight: 1,
-      });
+      circle = Leaf.circle([coords.lat, coords.lon], circleOptions);
     } else {
-      circle = Leaf.circleMarker([coords.lat, coords.lon], {
-        radius: r,
-        color: circleColor,
-        fillColor: circleColor,
-        fillOpacity: this.fillOpacity,
-        weight: 1,
-      });
+      circle = Leaf.circleMarker([coords.lat, coords.lon], circleOptions);
     }
 
-    this._bindPopup(circle, record);
-    this._bindTooltip(circle, record);
+    if (!this.noInteractive) {
+      this._bindPopup(circle, record);
+      this._bindTooltip(circle, record);
+    }
     group.addLayer(circle);
   }
 

--- a/tests/map-layer-decorative.test.ts
+++ b/tests/map-layer-decorative.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * Tests des attributs de couche decorative (v0.15.0) :
+ * - shape-class : classe CSS sur les traces SVG (motifs hachures via <pattern>)
+ * - no-interactive : couche sans clic/tooltip/popup (contours administratifs)
+ * - dsfr-data-kpi value="=..." : valeur litterale sans source
+ */
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+import { DsfrDataMapLayer } from '@/components/dsfr-data-map-layer.js';
+import { DsfrDataKpi } from '@/components/dsfr-data-kpi.js';
+
+const POLY = {
+  type: 'Polygon',
+  coordinates: [
+    [
+      [0, 0],
+      [1, 0],
+      [1, 1],
+      [0, 0],
+    ],
+  ],
+};
+
+function makeFakeLayer() {
+  return { on: vi.fn(), bindPopup: vi.fn(), bindTooltip: vi.fn() };
+}
+
+describe('shape-class / no-interactive — geoshape', () => {
+  it('propage className et interactive:false, sans binder popup/tooltip', () => {
+    const layer = new DsfrDataMapLayer();
+    layer.geoField = 'geom';
+    layer.shapeClass = 'hachures';
+    layer.noInteractive = true;
+
+    const captured: Array<Record<string, unknown>> = [];
+    const fakeLeaf = {
+      geoJSON: (_g: unknown, opts: Record<string, unknown>) => {
+        captured.push(opts);
+        return makeFakeLayer();
+      },
+    };
+    const group = { addLayer: vi.fn() };
+    const bindPopup = vi.spyOn(
+      layer as unknown as { _bindPopup: (...a: unknown[]) => void },
+      '_bindPopup' as never
+    );
+
+    (layer as unknown as Record<string, CallableFunction>)._addGeoshape.call(
+      layer,
+      { geom: POLY },
+      fakeLeaf,
+      group,
+      [],
+      []
+    );
+
+    expect(captured[0].interactive).toBe(false);
+    expect((captured[0].style as Record<string, unknown>).className).toBe('hachures');
+    expect(bindPopup).not.toHaveBeenCalled();
+    expect(group.addLayer).toHaveBeenCalledTimes(1);
+  });
+
+  it('par defaut : interactif, pas de className', () => {
+    const layer = new DsfrDataMapLayer();
+    layer.geoField = 'geom';
+
+    const captured: Array<Record<string, unknown>> = [];
+    const fakeLeaf = {
+      geoJSON: (_g: unknown, opts: Record<string, unknown>) => {
+        captured.push(opts);
+        return makeFakeLayer();
+      },
+    };
+    (layer as unknown as Record<string, CallableFunction>)._addGeoshape.call(
+      layer,
+      { geom: POLY },
+      fakeLeaf,
+      { addLayer: vi.fn() },
+      [],
+      []
+    );
+
+    expect(captured[0].interactive).toBe(true);
+    expect('className' in (captured[0].style as object)).toBe(false);
+  });
+});
+
+describe('shape-class / no-interactive — circle', () => {
+  it('propage les options au circleMarker', () => {
+    const layer = new DsfrDataMapLayer();
+    layer.latField = 'lat';
+    layer.lonField = 'lon';
+    layer.shapeClass = 'poi-special';
+    layer.noInteractive = true;
+
+    const captured: Array<Record<string, unknown>> = [];
+    const fakeLeaf = {
+      circleMarker: (_c: unknown, opts: Record<string, unknown>) => {
+        captured.push(opts);
+        return makeFakeLayer();
+      },
+    };
+    (layer as unknown as Record<string, CallableFunction>)._addCircle.call(
+      layer,
+      { lat: 46, lon: 2 },
+      fakeLeaf,
+      { addLayer: vi.fn() }
+    );
+
+    expect(captured[0].interactive).toBe(false);
+    expect(captured[0].className).toBe('poi-special');
+  });
+});
+
+describe('dsfr-data-kpi — valeur litterale', () => {
+  const compute = (v: string) => {
+    const kpi = new DsfrDataKpi();
+    kpi.value = v;
+    return (kpi as unknown as { _computeValue: () => number | string | null })._computeValue();
+  };
+
+  it('value="=667" rend le nombre 667 sans source', () => {
+    expect(compute('=667')).toBe(667);
+  });
+
+  it('value="=87 %" rend la chaine telle quelle', () => {
+    expect(compute('=87 %')).toBe('87 %');
+  });
+
+  it('value="=14,8" accepte la virgule decimale', () => {
+    expect(compute('=14,8')).toBe(14.8);
+  });
+
+  it('sans = : comportement inchange (null sans source)', () => {
+    expect(compute('population:sum')).toBe(null);
+  });
+});


### PR DESCRIPTION
Prérequis lib pour la carte ELF **v2** (remarques SGPE) :

- **`shape-class`** sur `dsfr-data-map-layer` : classe CSS appliquée aux tracés SVG (geoshape/circle) — permet le **hachurage** des 5 territoires `reduire_taille=1` via un `<pattern>` SVG défini par la page ;
- **`no-interactive`** : couche décorative sans clic/tooltip/popup (fond de **contours régions**) ;
- **`dsfr-data-kpi value="=667"`** : valeur littérale (préfixe `=`, nombre ou chaîne, virgule décimale acceptée) sans dépendre d'une source — pour le KPI « engagements prévisionnels » validé à la main et le « 87 % rurales ».

## Validation
7 tests nouveaux (plumbing options Leaflet + littéraux) ; suite complète **3678 verts** ; skills builder-ia à jour ; changeset **minor** (→ 0.15.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)