### PR TITLE
fix(map,csp): tuiles CARTO/OSM en prod + fit-bounds non pollué par les couches décoratives

### DIFF
--- a/.changeset/quiet-decorative-bounds.md
+++ b/.changeset/quiet-decorative-bounds.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': patch
+---
+
+`dsfr-data-map-layer` : une couche décorative (`no-interactive`) n'enregistre plus son emprise dans le `fit-bounds` de la carte — un fond de contours administratifs (France entière) empêchait le zoom automatique de suivre les données filtrées.

--- a/docker/security-headers.conf
+++ b/docker/security-headers.conf
@@ -41,6 +41,9 @@ add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autopl
 #     - data.geopf.fr            : tuiles IGN (presets ign-*, cadastre) chargées
 #                                  par dsfr-data-map
 #     - *.tile.openstreetmap.fr  : tuiles OSM-FR (preset par défaut)
+#     - tile.openstreetmap.org   : tuiles OSM Foundation (preset osm-standard, #429)
+#     - *.basemaps.cartocdn.com  : tuiles CARTO positron/dark (#429 — fonds dataviz)
+#     - *.tile.opentopomap.org   : tuiles OpenTopoMap (#429)
 #     - image.tmdb.org           : posters/banners de films (démo Ghibli du guide,
 #                                  api ghibliapi.vercel.app renvoie des URLs TMDB)
 #     - data: blob:              : icônes/images embarquées par les composants
@@ -61,4 +64,4 @@ add_header Permissions-Policy "accelerometer=(), ambient-light-sensor=(), autopl
 #                                      `connect-src 'self'`.
 #
 # Cf. issue #168 — PR-2. Validée par le DAST ZAP (workflow .github/workflows/dast.yml).
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; font-src 'self' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; img-src 'self' data: blob: https://cdn.jsdelivr.net https://unpkg.com https://esm.sh https://*.gouv.fr https://data.geopf.fr https://*.tile.openstreetmap.fr https://image.tmdb.org; connect-src 'self' https://*.opendatasoft.com https://*.gouv.fr https://api.openai.com https://api.anthropic.com https://api.mistral.ai https://generativelanguage.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; font-src 'self' https://cdn.jsdelivr.net https://unpkg.com https://esm.sh; img-src 'self' data: blob: https://cdn.jsdelivr.net https://unpkg.com https://esm.sh https://*.gouv.fr https://data.geopf.fr https://*.tile.openstreetmap.fr https://tile.openstreetmap.org https://*.basemaps.cartocdn.com https://*.tile.opentopomap.org https://image.tmdb.org; connect-src 'self' https://*.opendatasoft.com https://*.gouv.fr https://api.openai.com https://api.anthropic.com https://api.mistral.ai https://generativelanguage.googleapis.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;

--- a/packages/core/src/components/dsfr-data-map-layer.ts
+++ b/packages/core/src/components/dsfr-data-map-layer.ts
@@ -650,12 +650,17 @@ export class DsfrDataMapLayer extends SourceSubscriberMixin(LitElement) {
     // Report bounds for fit-bounds — par cle de layer, remplacement a
     // chaque rendu (#294)
     if (this._mapParent?.fitBounds) {
-      const layerBounds = (this._clusterGroup || this._layerGroup).getBounds?.();
+      // Une couche decorative (no-interactive : contours administratifs,
+      // habillage) ne pilote pas le viewport — son emprise (France entiere)
+      // empecherait le fit de suivre les donnees filtrees.
+      const layerBounds = this.noInteractive
+        ? null
+        : (this._clusterGroup || this._layerGroup).getBounds?.();
       if (layerBounds?.isValid?.()) {
         this._mapParent.registerLayerBounds(this._boundsKey, layerBounds);
       } else {
-        // Couche devenue vide (filtrage amont) : liberer ses bounds, sinon
-        // l'ancienne emprise fausse le fit des rendus suivants
+        // Couche devenue vide (filtrage amont) ou decorative : liberer ses
+        // bounds, sinon l'ancienne emprise fausse le fit des rendus suivants
         this._mapParent.unregisterLayerBounds(this._boundsKey);
       }
     }


### PR DESCRIPTION
Deux régressions constatées sur la carte v2 en prod :

1. **Aucun fond de carte** : la CSP nginx n'autorisait pas les hôtes des presets ajoutés par #430 — `img-src` étendu à `*.basemaps.cartocdn.com`, `tile.openstreetmap.org` et `*.tile.opentopomap.org` (doc du snippet mise à jour) ;
2. **Zoom région cassé** : la couche de contours (décorative, `no-interactive`) enregistrait son emprise France entière dans le `fit-bounds` → l'union ne suivait plus le filtre. Une couche `no-interactive` ne pilote plus le viewport (changeset patch → 0.15.1).

## Validation
Empirique (bundle local, contours affichés) : sélection Bretagne → z7 47.5,-3.1 ; retour « Tous » → z5 France. Suite complète 3678 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)