### PR TITLE
docs(guide): carte ELF v2 — pin dsfr-data@0.15.1

### DIFF
--- a/guide/examples/carte-territoires-electrification-v2.html
+++ b/guide/examples/carte-territoires-electrification-v2.html
@@ -8,13 +8,13 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <!-- Leaflet : charge dynamiquement par dsfr-data.umd.js - NE PAS inclure manuellement -->
-  <!-- dsfr-data : epingle en exact @0.15.0 + SRI (les encarts exigent >= 0.14.0 et l'URL
+  <!-- dsfr-data : epingle en exact @0.15.1 + SRI (les encarts exigent >= 0.14.0 et l'URL
        flottante @0 est cachee 7 jours par les navigateurs — un visiteur du jour verrait
        l'ancien bundle sans les encarts). Bundle complet (core + map).
        Requiert >= 0.15.0 : encarts DROM (#431), fit-bounds clippe (#439),
        couches decoratives shape-class/no-interactive et KPI litteral (#443).
        Major flottant : pas de SRI (cf. check:sri). -->
-  <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0.15.0/dist/dsfr-data.umd.js" integrity="sha384-BBythqgFOo9hhs8K7Oh7gc6V6ydiCYq8/kSh7D2cputmlOayaPlBTkgQKwqWVWhE" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/dsfr-data@0.15.1/dist/dsfr-data.umd.js" integrity="sha384-SlRXMKY/piVeIXOPkZfpbzwxkhKiIL3yX3TGb07cUVB9Kza1bq2F+YH31Ji/zf/O" crossorigin="anonymous"></script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
 
   <style>


### PR DESCRIPTION
Bump du pin CDN de la v2 vers **0.15.1** (+ SRI) pour livrer le fix #446 : le zoom automatique sur la région filtrée fonctionne avec la couche de contours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)