### PR TITLE
feat(kpi): format compact (notation fr-FR — 14,8 M)

### DIFF
--- a/.changeset/compact-kpi-format.md
+++ b/.changeset/compact-kpi-format.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': minor
+---
+
+`dsfr-data-kpi` (et la famille `formatValue` partagée) : nouveau format `compact` — notation compacte fr-FR (`14 785 684` → « 14,8 M », `6 676` → « 6,7 k ») pour les grands chiffres des tuiles KPI.

--- a/apps/builder-ia/src/skills.ts
+++ b/apps/builder-ia/src/skills.ts
@@ -915,7 +915,7 @@ Attend un tableau d'objets. L'attribut \`valeur\` determine comment extraire/agr
 | label | String | \`""\` | non | Libelle sous la valeur (et sous les \`lines\`) |
 | description | String | \`""\` | non | Description pour accessibilité (sr-only) |
 | icon | String | \`""\` | non | Classe Remix Icon : \`ri-global-line\`, \`ri-money-euro-circle-line\`, etc. Alias deprecie : \`icone\` |
-| format | String | \`"nombre"\` | non | Format : nombre, pourcentage, euro, decimal |
+| format | String | \`"nombre"\` | non | Format : nombre, pourcentage, euro, decimal, compact (14,8 M) |
 | trend | String | \`""\` | non | RACCOURCI HERITE (preferez \`lines\`). Expression d'agregation \`"champ:fn"\` (\`"evolution:avg"\`) — PAS un litteral. Rendue avec une fleche en pourcentage fr-FR (\`↑ 5,2 %\`). Alias deprecie : \`tendance\` |
 | lines | String | \`""\` | non | Lignes secondaires declaratives (JSON), rendues ENTRE la valeur et le \`label\`. Chaque item : \`value\` (expression \`champ:fn\`) OU \`text\` (statique), + \`format\`, \`sign\`, \`prefix\`, \`suffix\`, \`color\` (\`"auto"\`=vert si >=0/rouge si <0, token DSFR, ou couleur CSS), \`na\` (repli si non fini). Ex. \`[{"value":"evol:avg","sign":true,"suffix":"vs mai 2025","color":"auto"}]\` |
 | color-token | String | \`""\` | non | Forcer la couleur (token semantique DSFR) : vert, orange, rouge, bleu. Alias deprecies : \`color\`, \`couleur\` |

--- a/packages/shared/src/utils/formatters.ts
+++ b/packages/shared/src/utils/formatters.ts
@@ -8,7 +8,7 @@
  * contrat du composant dsfr-data-kpi (`format="pourcentage"`).
  */
 
-export type FormatType = 'nombre' | 'pourcentage' | 'euro' | 'decimal';
+export type FormatType = 'nombre' | 'pourcentage' | 'euro' | 'decimal' | 'compact';
 
 import { toNumber } from './number-parser.js';
 
@@ -40,12 +40,22 @@ export function formatValue(
       return formatCurrency(num);
     case 'decimal':
       return formatDecimal(num);
+    case 'compact':
+      return formatCompact(num);
     default:
       return formatNumber(num);
   }
 }
 
 /** Nombre entier avec separateurs de milliers (format francais) */
+/** Notation compacte fr-FR : 14 785 684 → "14,8 M", 6 676 → "6,7 k" */
+function formatCompact(value: number): string {
+  return new Intl.NumberFormat('fr-FR', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
 export function formatNumber(value: number): string {
   return new Intl.NumberFormat('fr-FR', {
     maximumFractionDigits: 0,

--- a/tests/formatters.test.ts
+++ b/tests/formatters.test.ts
@@ -173,3 +173,15 @@ describe('formatters', () => {
     });
   });
 });
+
+describe('formatValue — compact (fr-FR)', () => {
+  it('millions : 14 785 684 → "14,8 M"', () => {
+    expect(formatValue(14785684, 'compact')).toBe('14,8\u00a0M');
+  });
+  it('milliers : 6 676 → "6,7 k"', () => {
+    expect(formatValue(6676, 'compact')).toBe('6,7\u00a0k');
+  });
+  it('petits nombres : 42 → "42"', () => {
+    expect(formatValue(42, 'compact')).toBe('42');
+  });
+});


### PR DESCRIPTION
Nouveau format `compact` dans la famille `formatValue` partagée (#317) : notation compacte fr-FR via `Intl.NumberFormat` (1 décimale max) — `14 785 684` → **« 14,8 M »**, `6 676` → « 6,7 k ».

Usage : `<dsfr-data-kpi value="population:sum" format="compact">` — demandé pour le KPI Habitants de la carte ELF v2 (la valeur reste calculée depuis les données, pas de littéral en dur).

3 tests (millions/milliers/petits nombres, NBSP fr-FR) ; suite complète **3681 verts** ; skills + changeset **minor** (→ 0.16.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)