### PR TITLE
fix(ci): release notes cumulatives — previous_tag_name explicite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,28 +21,40 @@ jobs:
       release_id: ${{ steps.create.outputs.id }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Determine version
         id: version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+            TAG="${{ github.event.inputs.version }}"
           else
-            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            TAG="${{ github.ref_name }}"
           fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          # Tag v* precedent (ordre semver) : sans previous_tag_name explicite,
+          # l'auto-generation GitHub choisit une mauvaise base (les tags
+          # dsfr-data@* de changesets s'intercalent) et les notes cumulent
+          # tout l'historique depuis v0.5.x.
+          PREV=$(git tag --sort=-v:refname | grep '^v' | sed -n "/^${TAG}\$/,\$p" | sed -n 2p)
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         id: create
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases \
-            -f tag_name="${{ steps.version.outputs.tag }}" \
+          ARGS=(-f tag_name="${{ steps.version.outputs.tag }}" \
             -f name="${{ steps.version.outputs.tag }}" \
             -f target_commitish="${{ github.sha }}" \
             -F draft=true \
-            -F generate_release_notes=true \
-            --jq '.id')
+            -F generate_release_notes=true)
+          if [ -n "${{ steps.version.outputs.prev }}" ]; then
+            ARGS+=(-f previous_tag_name="${{ steps.version.outputs.prev }}")
+          fi
+          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases "${ARGS[@]}" --jq '.id')
           echo "id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
 
   build-tauri:


### PR DESCRIPTION
## Problème

Chaque release GitHub \`vX.Y.Z\` (workflow Tauri) reprenait **tout l'historique des releases précédentes** dans son « What's Changed » : les 12 releases de v0.7.3 à v0.16.0 démarraient toutes à la PR #50 (jusqu'à 225 PRs listées sur v0.16.0).

## Cause

\`release.yml\` crée la release avec \`generate_release_notes=true\` **sans** \`previous_tag_name\`. L'heuristique GitHub de choix du tag de base se perd à cause des tags \`dsfr-data@X.Y.Z\` (changesets) intercalés avec les \`vX.Y.Z\`, et retombe systématiquement sur une base d'époque v0.5.x.

## Correctif

- \`create-release\` : checkout avec \`fetch-depth: 0\` + \`fetch-tags\`, calcul du tag \`v*\` précédent par tri semver (\`git tag --sort=-v:refname\`), passage explicite de \`previous_tag_name\` à l'API. Repli silencieux sur l'ancien comportement si le tag est introuvable.
- Logique testée localement : v0.16.0 → v0.15.1, v0.13.0 → v0.12.0 (tag sans release GitHub, borne correcte quand même), v0.7.3 → v0.7.2, tag inconnu → repli.

## Réparation du stock (déjà faite, hors diff)

Les 12 releases existantes ont été régénérées via l'API \`generate-notes\` avec les bonnes paires de tags puis patchées — ex. v0.16.0 liste désormais ses 3 PRs (#448, #449, #450) avec le bon lien Full Changelog v0.15.1...v0.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)