### PR TITLE
feat(builder-carto): réalignement complet sur les capacités carto v0.13→v0.16

### DIFF
--- a/.changeset/builder-carto-realignement.md
+++ b/.changeset/builder-carto-realignement.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': patch
+---
+
+`@dsfr-data/shared` : export de `saveToStorageQuiet` dans le barrel applicatif (persistance d'état du builder carto, sans déclencher le hook de synchronisation API). Aucun impact sur les composants `dsfr-data-*`.

--- a/apps/builder-carto/index.html
+++ b/apps/builder-carto/index.html
@@ -24,6 +24,7 @@
         <div class="carto-col-actions">
           <button id="btn-add-layer" class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-add-line" title="Ajouter une couche">Ajouter</button>
           <button id="btn-remove-layer" class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-delete-line" title="Supprimer la couche active">Supprimer</button>
+          <button id="btn-reset" class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-refresh-line" title="Repartir de zéro">Réinitialiser</button>
         </div>
 
         <ul id="layers-list" class="carto-layers__list"></ul>
@@ -55,6 +56,7 @@
               Cliquez sur "Executer" pour afficher l'aperçu de la carte.
             </p>
           </div>
+          <div id="preview-status" class="carto-preview-status" role="status" aria-live="polite"></div>
         </div>
 
         <div slot="code">

--- a/apps/builder-carto/src/field-service.ts
+++ b/apps/builder-carto/src/field-service.ts
@@ -1,0 +1,176 @@
+/**
+ * Assistance de saisie : echantillonne la source d'une couche via le pipeline
+ * dsfr-data reel (un <dsfr-data-source> cache, limit 50) pour decouvrir les
+ * champs disponibles, leur taux de remplissage et proposer les champs
+ * geographiques / temporels probables.
+ */
+import type { FieldInfo, LayerConfig } from './state.js';
+import { buildSourceTag } from './ui/code-generator.js';
+
+export interface FieldSuggestions {
+  geo: string;
+  lat: string;
+  lon: string;
+  time: string;
+}
+
+export interface FieldScanResult {
+  fields: FieldInfo[];
+  suggestions: FieldSuggestions;
+  sampleSize: number;
+}
+
+const GEO_NAME_HINTS = ['geo_point_2d', 'geopoint', 'geo_point', 'geo_shape', 'geometry', 'geom'];
+const LAT_NAME_HINTS = ['lat', 'latitude', 'y'];
+const LON_NAME_HINTS = ['lon', 'lng', 'longitude', 'x'];
+const TIME_NAME_HINTS = ['date', 'annee', 'year', 'mois', 'time', 'periode', 'jour'];
+
+function valueType(v: unknown): string {
+  if (v === null || v === undefined) return 'null';
+  if (typeof v === 'number') return 'number';
+  if (typeof v === 'boolean') return 'boolean';
+  if (typeof v === 'object') return 'object';
+  return 'string';
+}
+
+/** Une valeur qui « ressemble » a une geometrie exploitable par geo-field. */
+function looksGeo(v: unknown): boolean {
+  if (v === null || v === undefined) return false;
+  if (typeof v === 'string') {
+    const t = v.trim();
+    return t.startsWith('{') || t.startsWith('[');
+  }
+  if (Array.isArray(v)) {
+    return v.length === 2 && typeof v[0] === 'number' && typeof v[1] === 'number';
+  }
+  if (typeof v === 'object') {
+    const o = v as Record<string, unknown>;
+    return (
+      ('type' in o && ('coordinates' in o || 'geometry' in o)) ||
+      ('lat' in o && ('lon' in o || 'lng' in o))
+    );
+  }
+  return false;
+}
+
+function looksIsoDate(v: unknown): boolean {
+  return typeof v === 'string' && /^\d{4}(-\d{2})?(-\d{2})?([T ].*)?$/.test(v.trim());
+}
+
+function nameMatches(name: string, hints: string[]): boolean {
+  const n = name.toLowerCase();
+  return hints.some(
+    (h) => n === h || n.endsWith(`_${h}`) || n.startsWith(`${h}_`) || n.includes(h)
+  );
+}
+
+function inRange(v: unknown, min: number, max: number): boolean {
+  return typeof v === 'number' && v >= min && v <= max;
+}
+
+export function computeFields(records: Record<string, unknown>[]): FieldScanResult {
+  const n = records.length;
+  const names = new Set<string>();
+  for (const r of records) for (const k of Object.keys(r)) names.add(k);
+
+  const fields: FieldInfo[] = [];
+  const geoScores = new Map<string, number>();
+  const latScores = new Map<string, number>();
+  const lonScores = new Map<string, number>();
+  const timeScores = new Map<string, number>();
+
+  for (const name of names) {
+    const values = records.map((r) => r[name]);
+    const filled = values.filter((v) => v !== null && v !== undefined && v !== '');
+    const types = new Set(filled.map(valueType));
+    const type = types.size === 0 ? 'null' : types.size === 1 ? [...types][0] : 'mixed';
+    const fillRate = n ? filled.length / n : 0;
+    fields.push({ name, type, fillRate });
+
+    if (fillRate === 0) continue; // une colonne vide n'est jamais un bon candidat
+
+    const geoLike = filled.filter(looksGeo).length / filled.length;
+    if (geoLike > 0.8) {
+      geoScores.set(name, geoLike + (nameMatches(name, GEO_NAME_HINTS) ? 1 : 0) + fillRate);
+    }
+    if (filled.every((v) => inRange(v, -90, 90)) && nameMatches(name, LAT_NAME_HINTS)) {
+      latScores.set(name, 1 + fillRate);
+    }
+    if (filled.every((v) => inRange(v, -180, 180)) && nameMatches(name, LON_NAME_HINTS)) {
+      lonScores.set(name, 1 + fillRate);
+    }
+    const dateLike = filled.filter(looksIsoDate).length / filled.length;
+    if (dateLike > 0.8 && nameMatches(name, TIME_NAME_HINTS)) {
+      timeScores.set(name, dateLike + fillRate);
+    }
+  }
+
+  fields.sort((a, b) => b.fillRate - a.fillRate || a.name.localeCompare(b.name, 'fr'));
+
+  const best = (m: Map<string, number>) =>
+    [...m.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? '';
+
+  return {
+    fields,
+    suggestions: {
+      geo: best(geoScores),
+      lat: best(latScores),
+      lon: best(lonScores),
+      time: best(timeScores),
+    },
+    sampleSize: n,
+  };
+}
+
+/**
+ * Charge un echantillon de la source de la couche via un <dsfr-data-source>
+ * cache et calcule les champs. Rejette apres `timeoutMs` (defaut 20 s).
+ */
+export function scanLayerFields(layer: LayerConfig, timeoutMs = 20000): Promise<FieldScanResult> {
+  const s = layer.source;
+  if (!s) return Promise.reject(new Error('Aucune source configurée'));
+
+  // Source manuelle : les donnees sont deja la, pas de fetch.
+  if (s.type === 'manual' && Array.isArray(s.data) && s.data.length) {
+    return Promise.resolve(computeFields(s.data.slice(0, 50)));
+  }
+
+  const sampleId = `carto-scan-${layer.id}-${Date.now()}`;
+  const tag = buildSourceTag(layer, { id: sampleId, limit: 50 });
+  if (!tag) return Promise.reject(new Error('Source non exploitable'));
+
+  return new Promise<FieldScanResult>((resolve, reject) => {
+    const host = document.createElement('div');
+    host.style.display = 'none';
+    host.innerHTML = tag;
+    document.body.appendChild(host);
+
+    const cleanup = () => {
+      document.removeEventListener('dsfr-data-loaded', onLoaded as EventListener);
+      document.removeEventListener('dsfr-data-error', onError as EventListener);
+      clearTimeout(timer);
+      host.remove();
+    };
+
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('Délai dépassé lors du chargement des champs'));
+    }, timeoutMs);
+
+    const onLoaded = (e: CustomEvent<{ sourceId: string; data: Record<string, unknown>[] }>) => {
+      if (e.detail?.sourceId !== sampleId) return;
+      const records = Array.isArray(e.detail.data) ? e.detail.data.slice(0, 50) : [];
+      cleanup();
+      resolve(computeFields(records));
+    };
+
+    const onError = (e: CustomEvent<{ sourceId: string; error?: { message?: string } }>) => {
+      if (e.detail?.sourceId !== sampleId) return;
+      cleanup();
+      reject(new Error(e.detail.error?.message || 'Erreur de chargement de la source'));
+    };
+
+    document.addEventListener('dsfr-data-loaded', onLoaded as EventListener);
+    document.addEventListener('dsfr-data-error', onError as EventListener);
+  });
+}

--- a/apps/builder-carto/src/main.ts
+++ b/apps/builder-carto/src/main.ts
@@ -1,10 +1,24 @@
 /**
  * Builder Carto — Visual map builder for dsfr-data-map
+ *
+ * Colonnes : 1) couches + config carte · 2) config de la couche active
+ * (sections disclosure, basique → avancé) · 3) aperçu + code généré.
+ * L'état complet est persisté (reprise de session) et la saisie des champs
+ * est assistée par un échantillonnage réel de la source (field-service).
  */
 import './styles/carto.css';
-import { state, createLayer } from './state.js';
-import type { AnySource, LayerConfig, LayerType, PopupMode } from './state.js';
+import {
+  state,
+  createLayer,
+  persistState,
+  restoreState,
+  resetState,
+  INSET_TERRITORIES,
+  DROM_IDS,
+} from './state.js';
+import type { AnySource, FieldInfo, LayerConfig, LayerType, PopupMode } from './state.js';
 import { generateCode } from './ui/code-generator.js';
+import { scanLayerFields } from './field-service.js';
 import {
   loadFromStorage,
   saveToStorage,
@@ -39,9 +53,60 @@ interface Favorite {
   builderStateJson?: unknown;
 }
 
+/** Jeu d'exemple embarqué : chefs-lieux des régions métropolitaines. */
+const SAMPLE_DATA: Record<string, unknown>[] = [
+  { ville: 'Paris', region: 'Île-de-France', lat: 48.8566, lon: 2.3522, population: 2133111 },
+  { ville: 'Lyon', region: 'Auvergne-Rhône-Alpes', lat: 45.764, lon: 4.8357, population: 522250 },
+  {
+    ville: 'Marseille',
+    region: "Provence-Alpes-Côte d'Azur",
+    lat: 43.2965,
+    lon: 5.3698,
+    population: 873076,
+  },
+  { ville: 'Toulouse', region: 'Occitanie', lat: 43.6047, lon: 1.4442, population: 504078 },
+  {
+    ville: 'Bordeaux',
+    region: 'Nouvelle-Aquitaine',
+    lat: 44.8378,
+    lon: -0.5792,
+    population: 261804,
+  },
+  { ville: 'Nantes', region: 'Pays de la Loire', lat: 47.2184, lon: -1.5536, population: 320732 },
+  { ville: 'Rennes', region: 'Bretagne', lat: 48.1173, lon: -1.6778, population: 225081 },
+  { ville: 'Lille', region: 'Hauts-de-France', lat: 50.6292, lon: 3.0573, population: 236234 },
+  { ville: 'Strasbourg', region: 'Grand Est', lat: 48.5734, lon: 7.7521, population: 290576 },
+  {
+    ville: 'Dijon',
+    region: 'Bourgogne-Franche-Comté',
+    lat: 47.322,
+    lon: 5.0415,
+    population: 158002,
+  },
+  {
+    ville: 'Orléans',
+    region: 'Centre-Val de Loire',
+    lat: 47.9029,
+    lon: 1.9093,
+    population: 116685,
+  },
+  { ville: 'Rouen', region: 'Normandie', lat: 49.4431, lon: 1.0993, population: 112321 },
+  { ville: 'Ajaccio', region: 'Corse', lat: 41.9192, lon: 8.7386, population: 71361 },
+];
+
 function loadSavedSources(): AnySource[] {
   const raw = loadFromStorage<AnySource[]>(STORAGE_KEYS.SOURCES, []);
   return raw.map((s) => migrateSource(s as Partial<Source>) as unknown as AnySource);
+}
+
+/**
+ * Copie « légère » d'une source enregistrée : les données chargées par l'app
+ * Sources (data/rawRecords) peuvent peser des Mo — inutiles au générateur et
+ * fatales à la persistance localStorage de l'état du builder.
+ */
+function lightweightSource(s: AnySource): AnySource {
+  const { data: _d, rawRecords: _r, ...rest } = s;
+  return rest;
 }
 
 // Expose state for E2E tests
@@ -139,6 +204,49 @@ function escapeAttr(val: string): string {
   return val.replace(/"/g, '&quot;').replace(/</g, '&lt;');
 }
 
+const LAYER_TYPE_LABELS: Record<LayerType, string> = {
+  marker: 'marqueurs',
+  geoshape: 'zones',
+  circle: 'cercles',
+  heatmap: 'chaleur',
+};
+
+/**
+ * Input texte assisté par datalist : suggestions = champs détectés de la
+ * couche (avec type et taux de remplissage), saisie libre toujours possible.
+ */
+function fieldInput(opts: {
+  id: string;
+  label: string;
+  value: string;
+  fields: FieldInfo[];
+  hint?: string;
+  placeholder?: string;
+  numericOnly?: boolean;
+}): string {
+  const candidates = opts.numericOnly
+    ? opts.fields.filter((f) => f.type === 'number')
+    : opts.fields;
+  const options = candidates
+    .map(
+      (f) =>
+        `<option value="${escapeAttr(f.name)}" label="${escapeAttr(
+          `${f.name} — ${f.type}, ${Math.round(f.fillRate * 100)} % renseigné`
+        )}"></option>`
+    )
+    .join('');
+  return `
+    <div class="carto-field">
+      <label for="${opts.id}">${opts.label}
+        ${opts.hint ? `<span class="fr-hint-text">${opts.hint}</span>` : ''}
+      </label>
+      <input type="text" id="${opts.id}" value="${escapeAttr(opts.value)}"
+             list="${opts.id}-list" ${opts.placeholder ? `placeholder="${escapeAttr(opts.placeholder)}"` : ''}
+             autocomplete="off">
+      <datalist id="${opts.id}-list">${options}</datalist>
+    </div>`;
+}
+
 // ---------------------------------------------------------------------------
 // Col 1: Layers list
 // ---------------------------------------------------------------------------
@@ -154,9 +262,9 @@ function renderLayersList() {
       <div class="carto-layers__item-info">
         <div class="carto-layers__item-header">
           <span class="carto-layers__item-name">${escapeAttr(layer.name)}</span>
-          <span class="carto-layers__item-type">${layer.type}</span>
+          <span class="carto-layers__item-type">${LAYER_TYPE_LABELS[layer.type]}${layer.noInteractive ? ' · décor' : ''}</span>
         </div>
-        <span class="carto-layers__item-source">${layer.source ? layer.source.name || layer.source.datasetId || 'Source configuree' : '<span style="color:var(--text-default-warning)">Aucune source</span>'}</span>
+        <span class="carto-layers__item-source">${layer.source ? escapeAttr(String(layer.source.name || layer.source.datasetId || 'Source configurée')) : '<span style="color:var(--text-default-warning)">Aucune source</span>'}</span>
       </div>
       <div class="carto-layers__item-actions">
         <button class="carto-layers__btn-eye ${layer.visible ? '' : 'carto-layers__btn-eye--hidden'}"
@@ -181,6 +289,7 @@ function renderLayersList() {
       state.activeLayerId = el.getAttribute('data-layer-id')!;
       renderLayersList();
       renderLayerConfig();
+      persistState();
     });
   });
 
@@ -209,6 +318,11 @@ function renderLayersList() {
 function renderMapConfig() {
   const m = state.map;
   const container = document.getElementById('map-config')!;
+  const hasTimeline = state.layers.some((l) => l.visible && l.timeField);
+  const insetCount = m.insets.length;
+  const otherTerritories = INSET_TERRITORIES.filter((t) => !t.drom);
+  const allDromChecked = DROM_IDS.every((id) => m.insets.includes(id));
+
   container.innerHTML = `
     <div class="config-section" id="section-map-config">
       <div class="config-section-header" onclick="toggleSection('section-map-config')">
@@ -217,42 +331,89 @@ function renderMapConfig() {
       </div>
       <div class="config-section-content">
         <div class="carto-field">
-          <label for="map-name">Nom</label>
+          <label for="map-name">Nom (accessibilité)
+            <span class="fr-hint-text">Décrit la carte aux lecteurs d'écran</span>
+          </label>
           <input type="text" id="map-name" value="${escapeAttr(m.name)}" placeholder="Ma carte">
         </div>
         <div class="carto-field">
           <label for="map-tiles">Fond de carte</label>
           <select id="map-tiles" class="fr-select fr-select--sm">
-            <option value="ign-plan" ${m.tiles === 'ign-plan' || m.tiles === 'ign-topo' ? 'selected' : ''}>IGN Plan</option>
-            <option value="ign-ortho" ${m.tiles === 'ign-ortho' ? 'selected' : ''}>IGN Ortho</option>
-            <option value="ign-cadastre" ${m.tiles === 'ign-cadastre' ? 'selected' : ''}>IGN Cadastre</option>
-            <option value="osm" ${m.tiles === 'osm' ? 'selected' : ''}>OpenStreetMap France</option>
-            <option value="osm-standard" ${m.tiles === 'osm-standard' ? 'selected' : ''}>OpenStreetMap</option>
-            <option value="carto-positron" ${m.tiles === 'carto-positron' ? 'selected' : ''}>CARTO clair (dataviz)</option>
-            <option value="carto-dark" ${m.tiles === 'carto-dark' ? 'selected' : ''}>CARTO sombre</option>
-            <option value="opentopomap" ${m.tiles === 'opentopomap' ? 'selected' : ''}>OpenTopoMap</option>
+            <optgroup label="IGN (souverain)">
+              <option value="ign-plan" ${m.tiles === 'ign-plan' || m.tiles === 'ign-topo' ? 'selected' : ''}>IGN Plan</option>
+              <option value="ign-ortho" ${m.tiles === 'ign-ortho' ? 'selected' : ''}>IGN Ortho (satellite)</option>
+              <option value="ign-cadastre" ${m.tiles === 'ign-cadastre' ? 'selected' : ''}>IGN Cadastre</option>
+            </optgroup>
+            <optgroup label="Autres">
+              <option value="osm" ${m.tiles === 'osm' ? 'selected' : ''}>OpenStreetMap France</option>
+              <option value="osm-standard" ${m.tiles === 'osm-standard' ? 'selected' : ''}>OpenStreetMap</option>
+              <option value="carto-positron" ${m.tiles === 'carto-positron' ? 'selected' : ''}>CARTO clair (dataviz)</option>
+              <option value="carto-dark" ${m.tiles === 'carto-dark' ? 'selected' : ''}>CARTO sombre</option>
+              <option value="opentopomap" ${m.tiles === 'opentopomap' ? 'selected' : ''}>OpenTopoMap (relief)</option>
+            </optgroup>
           </select>
         </div>
         <div class="carto-inline">
           <div class="carto-field">
             <label for="map-center">Centre (lat,lon)
-              <span class="fr-hint-text">Ex : 46.6,2.4 (France) ou 48.86,2.35 (Paris)</span>
+              <span class="fr-hint-text">46.6,2.4 = France entière</span>
             </label>
             <input type="text" id="map-center" value="${escapeAttr(m.center)}">
           </div>
           <div class="carto-field">
             <label for="map-zoom">Zoom
-              <span class="fr-hint-text">1 = monde, 6 = France, 12 = ville</span>
+              <span class="fr-hint-text">6 = France, 12 = ville</span>
             </label>
             <input type="number" id="map-zoom" value="${m.zoom}" min="1" max="18">
           </div>
         </div>
         <div class="carto-field">
           <label for="map-height">Hauteur
-            <span class="fr-hint-text">px, vh, ou % de la largeur (ex: 500px, 60vh, 60%)</span>
+            <span class="fr-hint-text">px, vh, ou % de la largeur (ex : 500px, 60%)</span>
           </label>
           <input type="text" id="map-height" value="${escapeAttr(m.height)}" placeholder="500px">
         </div>
+        <div class="carto-checkbox">
+          <input type="checkbox" id="map-fit-bounds" ${m.fitBounds ? 'checked' : ''}>
+          <label for="map-fit-bounds">Cadrer automatiquement sur les données (fit-bounds)</label>
+        </div>
+      </div>
+    </div>
+
+    <div class="config-section collapsed" id="section-insets">
+      <div class="config-section-header" onclick="toggleSection('section-insets')">
+        <h3><i class="ri-collage-line"></i> Encarts territoriaux${insetCount ? ` <span class="carto-badge">${insetCount}</span>` : ''}</h3>
+        <i class="ri-arrow-down-s-line collapse-icon"></i>
+      </div>
+      <div class="config-section-content">
+        <p class="fr-text--xs fr-mb-1w" style="color:var(--text-mention-grey)">
+          Affiche les territoires ultramarins et la Corse en vignettes à côté de la carte.
+          Les couches y sont automatiquement reprises.
+        </p>
+        <div class="carto-checkbox">
+          <input type="checkbox" id="inset-drom" ${allDromChecked ? 'checked' : ''}>
+          <label for="inset-drom"><strong>Les 5 DROM</strong> (Guadeloupe, Martinique, Guyane, La Réunion, Mayotte)</label>
+        </div>
+        <details class="carto-advanced" ${m.insets.some((id) => !DROM_IDS.includes(id)) ? 'open' : ''}>
+          <summary>Territoire par territoire</summary>
+          ${INSET_TERRITORIES.map(
+            (t) => `
+          <div class="carto-checkbox">
+            <input type="checkbox" id="inset-${t.id}" data-inset="${t.id}" ${m.insets.includes(t.id) ? 'checked' : ''}>
+            <label for="inset-${t.id}">${t.label}</label>
+          </div>`
+          ).join('')}
+        </details>
+        ${otherTerritories.length ? '' : ''}
+      </div>
+    </div>
+
+    <div class="config-section collapsed" id="section-map-advanced">
+      <div class="config-section-header" onclick="toggleSection('section-map-advanced')">
+        <h3><i class="ri-equalizer-line"></i> Réglages avancés</h3>
+        <i class="ri-arrow-down-s-line collapse-icon"></i>
+      </div>
+      <div class="config-section-content">
         <div class="carto-inline">
           <div class="carto-field">
             <label for="map-min-zoom">Zoom min</label>
@@ -265,32 +426,66 @@ function renderMapConfig() {
         </div>
         <div class="carto-field">
           <label for="map-max-bounds">Limites (max-bounds)
-            <span class="fr-hint-text">Zone de navigation autorisee : lat-sud,lon-ouest,lat-nord,lon-est</span>
+            <span class="fr-hint-text">Borne la navigation ET le cadrage automatique : lat-sud,lon-ouest,lat-nord,lon-est</span>
           </label>
-          <input type="text" id="map-max-bounds" value="${escapeAttr(m.maxBounds)}" placeholder="43.0,-5.0,51.5,10.0">
-        </div>
-        <div class="carto-checkbox">
-          <input type="checkbox" id="map-fit-bounds" ${m.fitBounds ? 'checked' : ''}>
-          <label for="map-fit-bounds">Ajuster aux données (fit-bounds)</label>
+          <input type="text" id="map-max-bounds" value="${escapeAttr(m.maxBounds)}" placeholder="41.0,-5.5,51.5,10.0">
         </div>
         <div class="carto-checkbox">
           <input type="checkbox" id="map-no-controls" ${m.noControls ? 'checked' : ''}>
-          <label for="map-no-controls">Masquer les controles (no-controls)</label>
+          <label for="map-no-controls">Masquer les contrôles de zoom (no-controls)</label>
         </div>
+        <div class="carto-checkbox">
+          <input type="checkbox" id="map-locked" ${m.locked ? 'checked' : ''}>
+          <label for="map-locked">Carte figée, aucune interaction (locked)
+            <span class="fr-hint-text">Pour une vignette ou une carte purement illustrative</span>
+          </label>
+        </div>
+        <div class="carto-checkbox">
+          <input type="checkbox" id="map-sovereign" ${m.sovereignOnly ? 'checked' : ''}>
+          <label for="map-sovereign">Fonds souverains uniquement (sovereign-only)
+            <span class="fr-hint-text">Restreint aux fonds IGN, exigence de certaines administrations</span>
+          </label>
+        </div>
+        <div class="carto-checkbox">
+          <input type="checkbox" id="map-a11y" ${m.a11y ? 'checked' : ''}>
+          <label for="map-a11y">Compagnon d'accessibilité (recommandé)
+            <span class="fr-hint-text">Ajoute le tableau des données et l'export CSV sous la carte</span>
+          </label>
+        </div>
+        ${
+          hasTimeline
+            ? `
+        <hr class="fr-mt-1w fr-mb-1w">
+        <p class="fr-text--sm fr-mb-1w"><i class="ri-play-circle-line"></i> Lecture temporelle</p>
+        <div class="carto-inline">
+          <div class="carto-field">
+            <label for="map-timeline-speed">Vitesse</label>
+            <select id="map-timeline-speed" class="fr-select fr-select--sm">
+              ${[0.5, 1, 2, 4].map((v) => `<option value="${v}" ${m.timelineSpeed === v ? 'selected' : ''}>× ${v}</option>`).join('')}
+            </select>
+          </div>
+          <div class="carto-field">
+            <label for="map-timeline-interval">Intervalle (ms)</label>
+            <input type="number" id="map-timeline-interval" value="${m.timelineInterval}" min="50" max="10000" step="50">
+          </div>
+        </div>
+        `
+            : ''
+        }
       </div>
     </div>
 
-    <div class="config-section" id="section-gen-mode">
+    <div class="config-section collapsed" id="section-gen-mode">
       <div class="config-section-header" onclick="toggleSection('section-gen-mode')">
-        <h3><i class="ri-code-s-slash-line"></i> Mode de generation</h3>
+        <h3><i class="ri-code-s-slash-line"></i> Mode de génération</h3>
         <i class="ri-arrow-down-s-line collapse-icon"></i>
       </div>
       <div class="config-section-content">
         <div class="carto-field">
           <label class="fr-label fr-label--sm" for="gen-mode">Mode</label>
           <select id="gen-mode" class="fr-select fr-select--sm">
-            <option value="embedded" ${state.generationMode === 'embedded' ? 'selected' : ''}>Embarque (composants seuls)</option>
-            <option value="dynamic" ${state.generationMode === 'dynamic' ? 'selected' : ''}>Dynamique (avec scripts/CSS)</option>
+            <option value="embedded" ${state.generationMode === 'embedded' ? 'selected' : ''}>Embarqué (composants seuls)</option>
+            <option value="dynamic" ${state.generationMode === 'dynamic' ? 'selected' : ''}>Autonome (avec scripts/CSS)</option>
           </select>
         </div>
       </div>
@@ -303,7 +498,7 @@ function renderMapConfig() {
     if (!el) return;
     el.addEventListener('change', () => {
       const val =
-        el.type === 'checkbox'
+        (el as HTMLInputElement).type === 'checkbox'
           ? (el as HTMLInputElement).checked
           : transform
             ? transform(el.value)
@@ -323,6 +518,37 @@ function renderMapConfig() {
   bindMap('map-max-bounds', 'maxBounds');
   bindMap('map-fit-bounds', 'fitBounds');
   bindMap('map-no-controls', 'noControls');
+  bindMap('map-locked', 'locked');
+  bindMap('map-sovereign', 'sovereignOnly');
+  bindMap('map-a11y', 'a11y');
+  bindMap('map-timeline-speed', 'timelineSpeed', Number);
+  bindMap('map-timeline-interval', 'timelineInterval', Number);
+
+  // Encarts : groupe DROM + territoires individuels
+  const dromEl = document.getElementById('inset-drom') as HTMLInputElement | null;
+  dromEl?.addEventListener('change', () => {
+    if (dromEl.checked) {
+      for (const id of DROM_IDS) if (!m.insets.includes(id)) m.insets.push(id);
+    } else {
+      m.insets = m.insets.filter((id) => !DROM_IDS.includes(id));
+    }
+    renderMapConfig();
+    keepSectionOpen('section-insets');
+    updateCodePreview();
+  });
+  container.querySelectorAll('[data-inset]').forEach((el) => {
+    el.addEventListener('change', () => {
+      const id = (el as HTMLInputElement).getAttribute('data-inset')!;
+      if ((el as HTMLInputElement).checked) {
+        if (!m.insets.includes(id)) m.insets.push(id);
+      } else {
+        m.insets = m.insets.filter((i) => i !== id);
+      }
+      renderMapConfig();
+      keepSectionOpen('section-insets');
+      updateCodePreview();
+    });
+  });
 
   const genEl = document.getElementById('gen-mode') as HTMLSelectElement;
   genEl?.addEventListener('change', () => {
@@ -331,11 +557,26 @@ function renderMapConfig() {
   });
 }
 
+/** Après un re-render de colonne, rouvre la section demandée (UX accordéon). */
+function keepSectionOpen(sectionId: string) {
+  const section = document.getElementById(sectionId);
+  if (!section) return;
+  const parent = section.parentElement;
+  parent?.querySelectorAll('.config-section').forEach((s) => s.classList.add('collapsed'));
+  section.classList.remove('collapsed');
+}
+
 // ---------------------------------------------------------------------------
 // Col 2: Active layer config (accordions)
 // ---------------------------------------------------------------------------
 
-function renderLayerConfig() {
+/** Section actuellement ouverte dans la colonne couche (persistée au re-render). */
+function currentOpenLayerSection(): string | null {
+  const open = document.querySelector('#layer-config .config-section:not(.collapsed)');
+  return open?.id ?? null;
+}
+
+function renderLayerConfig(openSection?: string | null) {
   const container = document.getElementById('layer-config')!;
   const layer = getActiveLayer();
   if (!layer) {
@@ -349,27 +590,46 @@ function renderLayerConfig() {
     layer.popupMode === 'popup' ||
     layer.popupMode === 'panel-right' ||
     layer.popupMode === 'panel-left';
+  const isPanel = layer.popupMode === 'panel-right' || layer.popupMode === 'panel-left';
+  const fields = layer.fields;
+  const fieldsBadge = fields.length
+    ? `<span class="carto-badge carto-badge--ok">${fields.length} champs</span>`
+    : '';
 
   container.innerHTML = `
-    <!-- Section: Source -->
+    <!-- Section: Données -->
     <div class="config-section" id="section-source">
       <div class="config-section-header" onclick="toggleSection('section-source')">
-        <h3><i class="ri-database-2-line"></i> Source</h3>
+        <h3><i class="ri-database-2-line"></i> Données ${fieldsBadge}</h3>
         <i class="ri-arrow-down-s-line collapse-icon"></i>
       </div>
       <div class="config-section-content">
         <div class="carto-field">
-          <label for="layer-source">Source enregistree</label>
+          <label for="layer-source">Source enregistrée
+            <span class="fr-hint-text">Créées dans l'application Sources</span>
+          </label>
           <select id="layer-source" class="fr-select fr-select--sm">
             <option value="">-- Choisir une source --</option>
             ${savedSources.map((s: AnySource) => `<option value="${s.id}" ${layer.source?.id === s.id ? 'selected' : ''}>${escapeAttr(String(s.name || s.datasetId || s.url || ''))}</option>`).join('')}
           </select>
         </div>
         <div class="carto-field">
+          <label for="layer-source-url">…ou URL d'un jeu de données
+            <span class="fr-hint-text">Lien OpenDataSoft, data.gouv (tabular), Grist ou API JSON</span>
+          </label>
+          <div class="carto-url-row">
+            <input type="text" id="layer-source-url" value="${escapeAttr(layer.source?.adHoc && layer.source?.apiUrl ? layer.source.apiUrl : '')}" placeholder="https://data.economie.gouv.fr/explore/dataset/…">
+            <button class="fr-btn fr-btn--sm fr-btn--secondary" id="btn-source-url" title="Utiliser cette URL">OK</button>
+          </div>
+        </div>
+        <button class="fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-left fr-icon-lightbulb-line fr-mb-1w" id="btn-source-sample">Essayer avec le jeu d'exemple</button>
+        <div id="source-scan-status" class="carto-scan-status" aria-live="polite"></div>
+        <hr class="fr-mt-1w fr-mb-1w">
+        <div class="carto-field">
           <label for="layer-type">Type de couche</label>
           <select id="layer-type" class="fr-select fr-select--sm">
-            <option value="marker" ${layer.type === 'marker' ? 'selected' : ''}>Marqueurs (POI)</option>
-            <option value="geoshape" ${layer.type === 'geoshape' ? 'selected' : ''}>Zones (geoshape)</option>
+            <option value="marker" ${layer.type === 'marker' ? 'selected' : ''}>Marqueurs (points d'intérêt)</option>
+            <option value="geoshape" ${layer.type === 'geoshape' ? 'selected' : ''}>Zones colorées (contours, choroplèthe)</option>
             <option value="circle" ${layer.type === 'circle' ? 'selected' : ''}>Cercles proportionnels</option>
             <option value="heatmap" ${layer.type === 'heatmap' ? 'selected' : ''}>Carte de chaleur</option>
           </select>
@@ -378,122 +638,178 @@ function renderLayerConfig() {
           <label for="layer-name">Nom de la couche</label>
           <input type="text" id="layer-name" value="${escapeAttr(layer.name)}">
         </div>
-        <hr class="fr-mt-1w fr-mb-1w">
-        <div class="carto-field">
-          <label for="layer-geo-field">Champ geo (GeoJSON)
-            <span class="fr-hint-text">Colonne contenant les coordonnees ou la geometrie</span>
-          </label>
-          <input type="text" id="layer-geo-field" value="${escapeAttr(layer.geoField)}" placeholder="geo_point_2d, geo_shape...">
-        </div>
-        <p class="fr-text--xs fr-mb-1w" style="color:var(--text-mention-grey)">ou coordonnees separees :</p>
-        <div class="carto-inline">
-          <div class="carto-field">
-            <label for="layer-lat">Latitude</label>
-            <input type="text" id="layer-lat" value="${escapeAttr(layer.latField)}" placeholder="latitude">
-          </div>
-          <div class="carto-field">
-            <label for="layer-lon">Longitude</label>
-            <input type="text" id="layer-lon" value="${escapeAttr(layer.lonField)}" placeholder="longitude">
-          </div>
-        </div>
       </div>
     </div>
 
-    <!-- Section: Information display -->
+    <!-- Section: Localisation -->
+    <div class="config-section collapsed" id="section-geo">
+      <div class="config-section-header" onclick="toggleSection('section-geo')">
+        <h3><i class="ri-map-pin-2-line"></i> Localisation</h3>
+        <i class="ri-arrow-down-s-line collapse-icon"></i>
+      </div>
+      <div class="config-section-content">
+        ${fieldInput({
+          id: 'layer-geo-field',
+          label: 'Champ géographique',
+          value: layer.geoField,
+          fields,
+          hint: 'Colonne contenant la géométrie (GeoJSON, point, texte JSON)',
+          placeholder: 'geo_point_2d, geo_shape…',
+        })}
+        <p class="fr-text--xs fr-mb-1w" style="color:var(--text-mention-grey)">ou coordonnées séparées :</p>
+        <div class="carto-inline">
+          ${fieldInput({ id: 'layer-lat', label: 'Latitude', value: layer.latField, fields, numericOnly: true, placeholder: 'latitude' })}
+          ${fieldInput({ id: 'layer-lon', label: 'Longitude', value: layer.lonField, fields, numericOnly: true, placeholder: 'longitude' })}
+        </div>
+        <p class="fr-text--xs" style="color:var(--text-mention-grey)">
+          <i class="ri-magic-line"></i> Ces champs sont proposés automatiquement après l'analyse de la source.
+        </p>
+      </div>
+    </div>
+
+    <!-- Section: Informations -->
     <div class="config-section collapsed" id="section-info">
       <div class="config-section-header" onclick="toggleSection('section-info')">
         <h3><i class="ri-information-line"></i> Informations</h3>
         <i class="ri-arrow-down-s-line collapse-icon"></i>
       </div>
       <div class="config-section-content">
+        ${
+          layer.noInteractive
+            ? `<p class="fr-text--sm" style="color:var(--text-mention-grey)"><i class="ri-eye-off-line"></i>
+               Couche décorative : aucune interaction (voir Apparence &gt; Avancé).</p>`
+            : `
         <div class="carto-field">
-          <label for="layer-popup-mode">Type d'information</label>
+          <label for="layer-popup-mode">Au clic ou au survol, afficher…</label>
           <select id="layer-popup-mode" class="fr-select fr-select--sm">
-            <option value="none" ${layer.popupMode === 'none' ? 'selected' : ''}>Aucun</option>
-            <option value="tooltip" ${layer.popupMode === 'tooltip' ? 'selected' : ''}>Tooltip (survol)</option>
-            <option value="popup" ${layer.popupMode === 'popup' ? 'selected' : ''}>Popup (clic)</option>
-            <option value="panel-right" ${layer.popupMode === 'panel-right' ? 'selected' : ''}>Panneau droit</option>
-            <option value="panel-left" ${layer.popupMode === 'panel-left' ? 'selected' : ''}>Panneau gauche</option>
+            <option value="none" ${layer.popupMode === 'none' ? 'selected' : ''}>Rien</option>
+            <option value="tooltip" ${layer.popupMode === 'tooltip' ? 'selected' : ''}>Une infobulle au survol</option>
+            <option value="popup" ${layer.popupMode === 'popup' ? 'selected' : ''}>Une popup au clic</option>
+            <option value="panel-right" ${layer.popupMode === 'panel-right' ? 'selected' : ''}>Un panneau latéral droit</option>
+            <option value="panel-left" ${layer.popupMode === 'panel-left' ? 'selected' : ''}>Un panneau latéral gauche</option>
           </select>
         </div>
 
         ${
           layer.popupMode === 'tooltip'
-            ? `
-        <div class="carto-field">
-          <label for="layer-tooltip">Champ tooltip
-            <span class="fr-hint-text">Texte affiche au survol d'un element</span>
-          </label>
-          <input type="text" id="layer-tooltip" value="${escapeAttr(layer.tooltipField)}" placeholder="nom, denomination...">
-        </div>
-        `
+            ? fieldInput({
+                id: 'layer-tooltip',
+                label: 'Champ affiché en infobulle',
+                value: layer.tooltipField,
+                fields,
+                placeholder: 'nom, denomination…',
+              })
             : ''
         }
 
         ${
           isPopupOrPanel
             ? `
+        ${fieldInput({
+          id: 'layer-title-field',
+          label: 'Champ titre',
+          value: layer.titleField,
+          fields,
+          hint: 'Titre en haut de la popup ou du panneau',
+          placeholder: 'nom',
+        })}
         <div class="carto-field">
-          <label for="layer-popup-fields">Champs affiches (virgules)
-            <span class="fr-hint-text">Si vide, tableau auto de tous les champs</span>
+          <label for="layer-popup-fields">Champs affichés
+            <span class="fr-hint-text">Noms de colonnes séparés par des virgules. Vide = toutes les colonnes.</span>
           </label>
           <input type="text" id="layer-popup-fields" value="${escapeAttr(layer.popupFields)}" placeholder="nom,adresse,prix">
         </div>
-        <div class="carto-field">
-          <label for="layer-title-field">Champ titre
-            <span class="fr-hint-text">Titre en haut du popup ou du panneau</span>
-          </label>
-          <input type="text" id="layer-title-field" value="${escapeAttr(layer.titleField)}" placeholder="nom">
-        </div>
-        <div class="carto-field">
-          <label for="layer-popup-template">Template HTML
-            <span class="fr-hint-text">Utiliser {{champ}} pour les valeurs</span>
-          </label>
-          <textarea id="layer-popup-template" placeholder="<h3>{{nom}}</h3>\n<p>{{adresse}}</p>">${escapeAttr(layer.popupTemplate)}</textarea>
-        </div>
-        <div class="carto-field">
-          <label for="layer-popup-width">Largeur du panneau
-            <span class="fr-hint-text">px, % (ex: 350px, 33%, 50%)</span>
-          </label>
-          <input type="text" id="layer-popup-width" value="${escapeAttr(layer.popupWidth)}" placeholder="350px">
-        </div>
+        <details class="carto-advanced" ${layer.popupTemplate ? 'open' : ''}>
+          <summary>Mise en forme avancée (template HTML)</summary>
+          <div class="carto-field">
+            <label for="layer-popup-template">Template
+              <span class="fr-hint-text">{{champ}} insère la valeur, {{champ:number}} formate un nombre</span>
+            </label>
+            <textarea id="layer-popup-template" placeholder="&lt;h3&gt;{{nom}}&lt;/h3&gt;&#10;&lt;p&gt;{{adresse}}&lt;/p&gt;">${escapeAttr(layer.popupTemplate)}</textarea>
+          </div>
+          ${
+            isPanel
+              ? `
+          <div class="carto-field">
+            <label for="layer-popup-width">Largeur du panneau</label>
+            <input type="text" id="layer-popup-width" value="${escapeAttr(layer.popupWidth)}" placeholder="350px">
+          </div>`
+              : ''
+          }
+        </details>
         `
             : ''
+        }`
         }
       </div>
     </div>
 
-    <!-- Section: Options (type-specific) -->
-    <div class="config-section collapsed" id="section-options">
-      <div class="config-section-header" onclick="toggleSection('section-options')">
-        <h3><i class="ri-settings-3-line"></i> Options</h3>
+    <!-- Section: Apparence -->
+    <div class="config-section collapsed" id="section-style">
+      <div class="config-section-header" onclick="toggleSection('section-style')">
+        <h3><i class="ri-palette-line"></i> Apparence</h3>
         <i class="ri-arrow-down-s-line collapse-icon"></i>
       </div>
       <div class="config-section-content">
         <div class="carto-field">
-          <label for="layer-color">Couleur ${layer.colorField ? '(fallback)' : ''}
-            <span class="fr-hint-text">Couleur unique ou couleur par défaut si mapping actif</span>
-          </label>
+          <label for="layer-color">Couleur ${layer.colorField ? '(par défaut)' : ''}</label>
           <input type="color" id="layer-color" value="${layer.color}">
         </div>
 
+        ${
+          layer.type === 'geoshape'
+            ? `
+        ${fieldInput({
+          id: 'layer-fill-field',
+          label: 'Colorer selon un champ numérique (choroplèthe)',
+          value: layer.fillField,
+          fields,
+          numericOnly: true,
+          hint: 'Chaque zone prend une teinte selon sa valeur',
+        })}
+        ${
+          layer.fillField
+            ? `
         <div class="carto-field">
-          <label for="layer-color-field">Champ couleur (mapping catégoriel)
-            <span class="fr-hint-text">Champ dont la valeur determine la couleur de chaque element</span>
-          </label>
-          <input type="text" id="layer-color-field" value="${escapeAttr(layer.colorField)}" placeholder="">
-        </div>
+          <label for="layer-palette">Palette</label>
+          <select id="layer-palette" class="fr-select fr-select--sm">
+            <option value="" ${!layer.selectedPalette ? 'selected' : ''}>Séquentielle (clair → foncé) — défaut</option>
+            <option value="sequentialAscending" ${layer.selectedPalette === 'sequentialAscending' ? 'selected' : ''}>Séquentielle (clair → foncé)</option>
+            <option value="sequentialDescending" ${layer.selectedPalette === 'sequentialDescending' ? 'selected' : ''}>Séquentielle (foncé → clair)</option>
+            <option value="divergentAscending" ${layer.selectedPalette === 'divergentAscending' ? 'selected' : ''}>Divergente (négatif ↔ positif)</option>
+            <option value="divergentDescending" ${layer.selectedPalette === 'divergentDescending' ? 'selected' : ''}>Divergente inversée</option>
+            <option value="neutral" ${layer.selectedPalette === 'neutral' ? 'selected' : ''}>Neutre (gris)</option>
+            <option value="categorical" ${layer.selectedPalette === 'categorical' ? 'selected' : ''}>Catégorielle</option>
+          </select>
+        </div>`
+            : ''
+        }
+        `
+            : ''
+        }
 
+        ${
+          layer.type !== 'heatmap'
+            ? `
+        ${fieldInput({
+          id: 'layer-color-field',
+          label: 'Colorer par catégorie',
+          value: layer.colorField,
+          fields,
+          hint: 'Champ dont chaque valeur reçoit sa couleur',
+        })}
         ${
           layer.colorField
             ? `
         <div class="carto-field">
-          <label for="layer-color-map">Mapping couleurs
-            <span class="fr-hint-text">Paires valeur:#couleur separees par virgule. Ex: 1:#00A95F,2:#FF9940,3:#E1000F</span>
+          <label for="layer-color-map">Couleur par valeur
+            <span class="fr-hint-text">valeur:#couleur séparées par des virgules. Ex : EPCI:#000091,Commune:#00A95F</span>
           </label>
           <textarea id="layer-color-map" rows="3" class="fr-input" placeholder="val1:#couleur1,val2:#couleur2">${escapeAttr(layer.colorMap)}</textarea>
         </div>
         `
+            : ''
+        }`
             : ''
         }
 
@@ -502,40 +818,11 @@ function renderLayerConfig() {
             ? `
         <div class="carto-checkbox">
           <input type="checkbox" id="layer-cluster" ${layer.cluster ? 'checked' : ''}>
-          <label for="layer-cluster">Activer le clustering</label>
+          <label for="layer-cluster">Regrouper les marqueurs proches (clustering)</label>
         </div>
         <div class="carto-field" ${!layer.cluster ? 'style="display:none"' : ''} id="cluster-radius-group">
-          <label for="layer-cluster-radius">Rayon de cluster (px)</label>
+          <label for="layer-cluster-radius">Rayon de regroupement (px)</label>
           <input type="number" id="layer-cluster-radius" value="${layer.clusterRadius}" min="10" max="200">
-        </div>
-        `
-            : ''
-        }
-
-        ${
-          layer.type === 'geoshape'
-            ? `
-        <div class="carto-field">
-          <label for="layer-fill-field">Champ valeur (coloration)
-            <span class="fr-hint-text">Colore les zones selon ce champ numérique</span>
-          </label>
-          <input type="text" id="layer-fill-field" value="${escapeAttr(layer.fillField)}">
-        </div>
-        <div class="carto-field">
-          <label for="layer-fill-opacity">Opacite de remplissage
-            <span class="fr-hint-text">0 = transparent, 1 = opaque</span>
-          </label>
-          <input type="number" id="layer-fill-opacity" value="${layer.fillOpacity}" min="0" max="1" step="0.1">
-        </div>
-        <div class="carto-field">
-          <label for="layer-palette">Palette</label>
-          <select id="layer-palette" class="fr-select fr-select--sm">
-            <option value="">Aucune</option>
-            <option value="sequentialAscending" ${layer.selectedPalette === 'sequentialAscending' ? 'selected' : ''}>Sequentielle (clair → fonce)</option>
-            <option value="sequentialDescending" ${layer.selectedPalette === 'sequentialDescending' ? 'selected' : ''}>Sequentielle (fonce → clair)</option>
-            <option value="divergentAscending" ${layer.selectedPalette === 'divergentAscending' ? 'selected' : ''}>Divergente (bleu → rouge)</option>
-            <option value="neutral" ${layer.selectedPalette === 'neutral' ? 'selected' : ''}>Neutre (gris)</option>
-          </select>
         </div>
         `
             : ''
@@ -544,33 +831,42 @@ function renderLayerConfig() {
         ${
           layer.type === 'circle'
             ? `
-        <div class="carto-field">
-          <label for="layer-radius">Rayon fixe</label>
-          <input type="number" id="layer-radius" value="${layer.radius}" min="1" max="100">
-        </div>
-        <div class="carto-field">
-          <label for="layer-radius-field">Champ rayon (proportionnel)
-            <span class="fr-hint-text">La taille du cercle varie selon la valeur de ce champ</span>
-          </label>
-          <input type="text" id="layer-radius-field" value="${escapeAttr(layer.radiusField)}">
-        </div>
-        <div class="carto-field">
-          <label for="layer-radius-unit">Unite</label>
-          <select id="layer-radius-unit" class="fr-select fr-select--sm">
-            <option value="px" ${layer.radiusUnit === 'px' ? 'selected' : ''}>Pixels (px)</option>
-            <option value="m" ${layer.radiusUnit === 'm' ? 'selected' : ''}>Metres (m)</option>
-          </select>
-        </div>
+        ${fieldInput({
+          id: 'layer-radius-field',
+          label: 'Taille selon un champ numérique',
+          value: layer.radiusField,
+          fields,
+          numericOnly: true,
+          hint: 'La taille du cercle varie selon la valeur',
+        })}
         <div class="carto-inline">
           <div class="carto-field">
-            <label for="layer-radius-min">Rayon min</label>
+            <label for="layer-radius-unit">Unité</label>
+            <select id="layer-radius-unit" class="fr-select fr-select--sm">
+              <option value="px" ${layer.radiusUnit === 'px' ? 'selected' : ''}>Pixels (px)</option>
+              <option value="m" ${layer.radiusUnit === 'm' ? 'selected' : ''}>Mètres réels (m)</option>
+            </select>
+          </div>
+          <div class="carto-field">
+            <label for="layer-radius">Rayon fixe</label>
+            <input type="number" id="layer-radius" value="${layer.radius}" min="1">
+          </div>
+        </div>
+        ${
+          layer.radiusUnit === 'px'
+            ? `
+        <div class="carto-inline">
+          <div class="carto-field">
+            <label for="layer-radius-min">Rayon min (px)</label>
             <input type="number" id="layer-radius-min" value="${layer.radiusMin}" min="1" max="100">
           </div>
           <div class="carto-field">
-            <label for="layer-radius-max">Rayon max</label>
+            <label for="layer-radius-max">Rayon max (px)</label>
             <input type="number" id="layer-radius-max" value="${layer.radiusMax}" min="1" max="200">
           </div>
-        </div>
+        </div>`
+            : ''
+        }
         `
             : ''
         }
@@ -578,6 +874,14 @@ function renderLayerConfig() {
         ${
           layer.type === 'heatmap'
             ? `
+        ${fieldInput({
+          id: 'layer-heat-field',
+          label: 'Champ de pondération',
+          value: layer.heatField,
+          fields,
+          numericOnly: true,
+          hint: 'Intensité de chaleur selon ce champ (vide = chaque point compte 1)',
+        })}
         <div class="carto-inline">
           <div class="carto-field">
             <label for="layer-heat-radius">Rayon</label>
@@ -588,106 +892,145 @@ function renderLayerConfig() {
             <input type="number" id="layer-heat-blur" value="${layer.heatBlur}" min="1" max="100">
           </div>
         </div>
-        <div class="carto-field">
-          <label for="layer-heat-field">Champ ponderation
-            <span class="fr-hint-text">Champ numérique pour l'intensite de la chaleur</span>
-          </label>
-          <input type="text" id="layer-heat-field" value="${escapeAttr(layer.heatField)}">
-        </div>
         `
             : ''
         }
 
-        <hr class="fr-mt-1w fr-mb-1w">
+        ${
+          layer.type !== 'heatmap'
+            ? `
+        <details class="carto-advanced" ${layer.shapeClass || layer.noInteractive || layer.fillOpacity !== 0.6 ? 'open' : ''}>
+          <summary>Avancé</summary>
+          ${
+            layer.type !== 'marker'
+              ? `
+          <div class="carto-field">
+            <label for="layer-fill-opacity">Opacité de remplissage
+              <span class="fr-hint-text">0 = contours seuls, 1 = opaque</span>
+            </label>
+            <input type="number" id="layer-fill-opacity" value="${layer.fillOpacity}" min="0" max="1" step="0.1">
+          </div>
+          <div class="carto-field">
+            <label for="layer-shape-class">Classe CSS des tracés (shape-class)
+              <span class="fr-hint-text">Pour appliquer un style de la page (hachures, pointillés…)</span>
+            </label>
+            <input type="text" id="layer-shape-class" value="${escapeAttr(layer.shapeClass)}" placeholder="territoire-hachure">
+          </div>`
+              : ''
+          }
+          <div class="carto-checkbox">
+            <input type="checkbox" id="layer-no-interactive" ${layer.noInteractive ? 'checked' : ''}>
+            <label for="layer-no-interactive">Couche décorative (no-interactive)
+              <span class="fr-hint-text">Habillage : ni clic, ni infobulle, ignorée par le cadrage automatique</span>
+            </label>
+          </div>
+        </details>`
+            : ''
+        }
+      </div>
+    </div>
 
-        <div class="carto-field">
-          <label for="layer-time-field">Champ temporel (animation)
-            <span class="fr-hint-text">Colonne date/heure pour animer la carte dans le temps</span>
-          </label>
-          <input type="text" id="layer-time-field" value="${escapeAttr(layer.timeField)}" placeholder="">
-        </div>
-
+    <!-- Section: Animation temporelle -->
+    <div class="config-section collapsed" id="section-time">
+      <div class="config-section-header" onclick="toggleSection('section-time')">
+        <h3><i class="ri-history-line"></i> Animation temporelle${layer.timeField ? ' <span class="carto-badge carto-badge--ok">active</span>' : ''}</h3>
+        <i class="ri-arrow-down-s-line collapse-icon"></i>
+      </div>
+      <div class="config-section-content">
+        ${fieldInput({
+          id: 'layer-time-field',
+          label: 'Champ date/heure',
+          value: layer.timeField,
+          fields,
+          hint: 'Renseigner ce champ active les contrôles de lecture sous la carte',
+        })}
         ${
           layer.timeField
             ? `
         <div class="carto-inline">
           <div class="carto-field">
-            <label for="layer-time-bucket">Granularite</label>
+            <label for="layer-time-bucket">Granularité</label>
             <select id="layer-time-bucket" class="fr-select fr-select--sm">
               <option value="none" ${layer.timeBucket === 'none' ? 'selected' : ''}>Valeurs brutes</option>
               <option value="hour" ${layer.timeBucket === 'hour' ? 'selected' : ''}>Heure</option>
               <option value="day" ${layer.timeBucket === 'day' ? 'selected' : ''}>Jour</option>
               <option value="month" ${layer.timeBucket === 'month' ? 'selected' : ''}>Mois</option>
-              <option value="year" ${layer.timeBucket === 'year' ? 'selected' : ''}>Annee</option>
+              <option value="year" ${layer.timeBucket === 'year' ? 'selected' : ''}>Année</option>
             </select>
           </div>
           <div class="carto-field">
             <label for="layer-time-mode">Mode</label>
             <select id="layer-time-mode" class="fr-select fr-select--sm">
-              <option value="snapshot" ${layer.timeMode === 'snapshot' ? 'selected' : ''}>Instantane</option>
-              <option value="cumulative" ${layer.timeMode === 'cumulative' ? 'selected' : ''}>Cumulatif</option>
+              <option value="snapshot" ${layer.timeMode === 'snapshot' ? 'selected' : ''}>Instantané (pas à pas)</option>
+              <option value="cumulative" ${layer.timeMode === 'cumulative' ? 'selected' : ''}>Cumulatif (tout jusqu'à la date)</option>
             </select>
           </div>
         </div>
+        <p class="fr-text--xs" style="color:var(--text-mention-grey)">Vitesse et intervalle : colonne de gauche, Réglages avancés.</p>
         `
             : ''
         }
+      </div>
+    </div>
 
-        <hr class="fr-mt-1w fr-mb-1w">
-
+    <!-- Section: Filtres & performances -->
+    <div class="config-section collapsed" id="section-perf">
+      <div class="config-section-header" onclick="toggleSection('section-perf')">
+        <h3><i class="ri-filter-3-line"></i> Filtres &amp; performances</h3>
+        <i class="ri-arrow-down-s-line collapse-icon"></i>
+      </div>
+      <div class="config-section-content">
         <div class="carto-field">
-          <label for="layer-filter">Filtre (expression)
-            <span class="fr-hint-text">Ex: status = 'active'</span>
+          <label for="layer-filter">Filtrer les données
+            <span class="fr-hint-text">Syntaxe champ:opérateur:valeur — ex : type:eq:Commune, prix:gt:100</span>
           </label>
           <input type="text" id="layer-filter" value="${escapeAttr(layer.filter)}" placeholder="champ:eq:valeur, champ2:gt:100">
         </div>
 
-        <div class="carto-checkbox">
-          <input type="checkbox" id="layer-bbox" ${layer.bbox ? 'checked' : ''}>
-          <label for="layer-bbox">Chargement par viewport (bbox)</label>
-        </div>
-
-        ${
-          layer.bbox
-            ? `
-        <div class="carto-inline">
-          <div class="carto-field">
-            <label for="layer-bbox-debounce">Delai de chargement (ms)
-              <span class="fr-hint-text">Temps d'attente apres un deplacement avant de recharger les données</span>
-            </label>
-            <input type="number" id="layer-bbox-debounce" value="${layer.bboxDebounce}" min="0" max="2000">
-          </div>
-          <div class="carto-field">
-            <label for="layer-bbox-field">Champ geographique pour le viewport
-              <span class="fr-hint-text">Colonne utilisee pour filtrer par zone visible</span>
-            </label>
-            <input type="text" id="layer-bbox-field" value="${escapeAttr(layer.bboxField)}" placeholder="">
-          </div>
-        </div>
-        `
-            : ''
-        }
-
-        <div class="carto-inline">
-          <div class="carto-field">
-            <label for="layer-min-zoom">Zoom min</label>
-            <input type="number" id="layer-min-zoom" value="${layer.minZoom}" min="0" max="18">
-          </div>
-          <div class="carto-field">
-            <label for="layer-max-zoom">Zoom max</label>
-            <input type="number" id="layer-max-zoom" value="${layer.maxZoom}" min="0" max="18">
-          </div>
-        </div>
-
         <div class="carto-field">
-          <label for="layer-max-items">Nombre max d'elements
-            <span class="fr-hint-text">Limite les données chargees (performance)</span>
+          <label for="layer-max-items">Nombre max d'éléments affichés
+            <span class="fr-hint-text">Au-delà, un bandeau « N affichés sur M » apparaît</span>
           </label>
           <input type="number" id="layer-max-items" value="${layer.maxItems}" min="1" max="100000">
         </div>
+
+        <details class="carto-advanced" ${layer.bbox || layer.minZoom !== 0 || layer.maxZoom !== 18 ? 'open' : ''}>
+          <summary>Chargement et zoom (avancé)</summary>
+          <div class="carto-checkbox">
+            <input type="checkbox" id="layer-bbox" ${layer.bbox ? 'checked' : ''}>
+            <label for="layer-bbox">Charger selon la zone visible (bbox)
+              <span class="fr-hint-text">Pour les très gros jeux de données : seuls les éléments visibles sont chargés</span>
+            </label>
+          </div>
+          ${
+            layer.bbox
+              ? `
+          <div class="carto-inline">
+            <div class="carto-field">
+              <label for="layer-bbox-debounce">Délai après déplacement (ms)</label>
+              <input type="number" id="layer-bbox-debounce" value="${layer.bboxDebounce}" min="0" max="2000">
+            </div>
+            ${fieldInput({ id: 'layer-bbox-field', label: 'Champ géo du filtre', value: layer.bboxField, fields, hint: 'Vide = champ géo de la couche' })}
+          </div>
+          `
+              : ''
+          }
+          <div class="carto-inline">
+            <div class="carto-field">
+              <label for="layer-min-zoom">Visible à partir du zoom</label>
+              <input type="number" id="layer-min-zoom" value="${layer.minZoom}" min="0" max="18">
+            </div>
+            <div class="carto-field">
+              <label for="layer-max-zoom">Jusqu'au zoom</label>
+              <input type="number" id="layer-max-zoom" value="${layer.maxZoom}" min="0" max="18">
+            </div>
+          </div>
+        </details>
       </div>
     </div>
   `;
+
+  if (openSection) keepSectionOpen(openSection);
 
   // Bind change events
   bindLayerInputs(layer);
@@ -697,6 +1040,11 @@ function renderLayerConfig() {
 // Bind layer inputs
 // ---------------------------------------------------------------------------
 
+/** Re-render la config couche en conservant la section ouverte. */
+function rerenderLayerConfig() {
+  renderLayerConfig(currentOpenLayerSection());
+}
+
 function bindLayerInputs(layer: LayerConfig) {
   const bind = (id: string, key: keyof LayerConfig, transform?: (v: string) => unknown) => {
     const el = document.getElementById(id) as
@@ -705,7 +1053,7 @@ function bindLayerInputs(layer: LayerConfig) {
     const eventType = el.tagName === 'TEXTAREA' ? 'input' : 'change';
     el.addEventListener(eventType, () => {
       const val =
-        el.type === 'checkbox'
+        (el as HTMLInputElement).type === 'checkbox'
           ? (el as HTMLInputElement).checked
           : transform
             ? transform(el.value)
@@ -715,21 +1063,62 @@ function bindLayerInputs(layer: LayerConfig) {
     });
   };
 
-  // Source
+  // Source enregistrée
   const sourceEl = document.getElementById('layer-source') as HTMLSelectElement | null;
   sourceEl?.addEventListener('change', () => {
     const savedSources = loadSavedSources();
     const found = savedSources.find((s: AnySource) => s.id === sourceEl.value);
-    layer.source = found || null;
+    layer.source = found ? lightweightSource(found) : null;
+    layer.fields = [];
     renderLayersList();
     updateCodePreview();
+    if (layer.source) void scanAndSuggest(layer);
+    else rerenderLayerConfig();
+  });
+
+  // Source par URL directe
+  const urlBtn = document.getElementById('btn-source-url');
+  const urlInput = document.getElementById('layer-source-url') as HTMLInputElement | null;
+  const applyUrl = () => {
+    const url = urlInput?.value.trim();
+    if (!url) return;
+    layer.source = {
+      id: `url-${layer.id}`,
+      name: url.replace(/^https?:\/\//, '').slice(0, 60),
+      type: 'api',
+      apiUrl: url,
+      adHoc: true,
+    };
+    layer.fields = [];
+    renderLayersList();
+    updateCodePreview();
+    void scanAndSuggest(layer);
+  };
+  urlBtn?.addEventListener('click', applyUrl);
+  urlInput?.addEventListener('keydown', (e) => {
+    if ((e as KeyboardEvent).key === 'Enter') applyUrl();
+  });
+
+  // Jeu d'exemple
+  document.getElementById('btn-source-sample')?.addEventListener('click', () => {
+    layer.source = {
+      id: `sample-${layer.id}`,
+      name: "Jeu d'exemple — chefs-lieux",
+      type: 'manual',
+      data: SAMPLE_DATA,
+      adHoc: true,
+    };
+    layer.fields = [];
+    renderLayersList();
+    updateCodePreview();
+    void scanAndSuggest(layer);
   });
 
   // Type change re-renders entire config (different options sections)
   const typeEl = document.getElementById('layer-type');
   typeEl?.addEventListener('change', () => {
     layer.type = (typeEl as HTMLSelectElement).value as LayerType;
-    renderLayerConfig();
+    rerenderLayerConfig();
     renderLayersList();
     updateCodePreview();
   });
@@ -751,7 +1140,7 @@ function bindLayerInputs(layer: LayerConfig) {
   const popupModeEl = document.getElementById('layer-popup-mode') as HTMLSelectElement | null;
   popupModeEl?.addEventListener('change', () => {
     layer.popupMode = popupModeEl.value as PopupMode;
-    renderLayerConfig();
+    rerenderLayerConfig();
     updateCodePreview();
   });
 
@@ -761,16 +1150,26 @@ function bindLayerInputs(layer: LayerConfig) {
   bind('layer-popup-template', 'popupTemplate');
   bind('layer-popup-width', 'popupWidth');
 
-  // Options
+  // Apparence
   bind('layer-color', 'color');
   const colorFieldEl = document.getElementById('layer-color-field') as HTMLInputElement | null;
   colorFieldEl?.addEventListener('change', () => {
     layer.colorField = colorFieldEl.value;
-    renderLayerConfig(); // show/hide color-map textarea
+    rerenderLayerConfig(); // show/hide color-map textarea
     updateCodePreview();
   });
   bind('layer-color-map', 'colorMap');
   bind('layer-filter', 'filter');
+  bind('layer-shape-class', 'shapeClass');
+  const noInteractiveEl = document.getElementById(
+    'layer-no-interactive'
+  ) as HTMLInputElement | null;
+  noInteractiveEl?.addEventListener('change', () => {
+    layer.noInteractive = noInteractiveEl.checked;
+    rerenderLayerConfig();
+    renderLayersList();
+    updateCodePreview();
+  });
 
   // Marker
   const clusterEl = document.getElementById('layer-cluster') as HTMLInputElement | null;
@@ -783,14 +1182,24 @@ function bindLayerInputs(layer: LayerConfig) {
   bind('layer-cluster-radius', 'clusterRadius', Number);
 
   // Geoshape
-  bind('layer-fill-field', 'fillField');
+  const fillFieldEl = document.getElementById('layer-fill-field') as HTMLInputElement | null;
+  fillFieldEl?.addEventListener('change', () => {
+    layer.fillField = fillFieldEl.value;
+    rerenderLayerConfig(); // show/hide palette
+    updateCodePreview();
+  });
   bind('layer-fill-opacity', 'fillOpacity', Number);
   bind('layer-palette', 'selectedPalette');
 
   // Circle
   bind('layer-radius', 'radius', Number);
   bind('layer-radius-field', 'radiusField');
-  bind('layer-radius-unit', 'radiusUnit');
+  const radiusUnitEl = document.getElementById('layer-radius-unit') as HTMLSelectElement | null;
+  radiusUnitEl?.addEventListener('change', () => {
+    layer.radiusUnit = radiusUnitEl.value as 'px' | 'm';
+    rerenderLayerConfig(); // min/max seulement en px
+    updateCodePreview();
+  });
   bind('layer-radius-min', 'radiusMin', Number);
   bind('layer-radius-max', 'radiusMax', Number);
 
@@ -803,7 +1212,8 @@ function bindLayerInputs(layer: LayerConfig) {
   const timeFieldEl = document.getElementById('layer-time-field') as HTMLInputElement | null;
   timeFieldEl?.addEventListener('change', () => {
     layer.timeField = timeFieldEl.value;
-    renderLayerConfig(); // show/hide bucket+mode fields
+    rerenderLayerConfig(); // show/hide bucket+mode fields
+    renderMapConfig(); // section timeline des réglages avancés carte
     updateCodePreview();
   });
   bind('layer-time-bucket', 'timeBucket');
@@ -813,7 +1223,7 @@ function bindLayerInputs(layer: LayerConfig) {
   const bboxEl = document.getElementById('layer-bbox') as HTMLInputElement | null;
   bboxEl?.addEventListener('change', () => {
     layer.bbox = bboxEl.checked;
-    renderLayerConfig();
+    rerenderLayerConfig();
     updateCodePreview();
   });
   bind('layer-bbox-debounce', 'bboxDebounce', Number);
@@ -825,6 +1235,51 @@ function bindLayerInputs(layer: LayerConfig) {
 }
 
 // ---------------------------------------------------------------------------
+// Assistance : analyse des champs de la source
+// ---------------------------------------------------------------------------
+
+function setScanStatus(html: string) {
+  const el = document.getElementById('source-scan-status');
+  if (el) el.innerHTML = html;
+}
+
+async function scanAndSuggest(layer: LayerConfig) {
+  setScanStatus('<i class="ri-loader-4-line carto-spin"></i> Analyse des champs de la source…');
+  try {
+    const result = await scanLayerFields(layer);
+    layer.fields = result.fields;
+
+    // Suggestions automatiques si rien n'est encore configuré
+    const s = result.suggestions;
+    let suggested = '';
+    if (!layer.geoField && !layer.latField && !layer.lonField) {
+      if (s.geo) {
+        layer.geoField = s.geo;
+        suggested = `champ géo détecté : <code>${escapeAttr(s.geo)}</code>`;
+      } else if (s.lat && s.lon) {
+        layer.latField = s.lat;
+        layer.lonField = s.lon;
+        suggested = `coordonnées détectées : <code>${escapeAttr(s.lat)}</code> / <code>${escapeAttr(s.lon)}</code>`;
+      }
+    }
+
+    rerenderLayerConfig();
+    setScanStatus(
+      `<i class="ri-check-line" style="color:var(--text-default-success)"></i> ${result.fields.length} champs (échantillon de ${result.sampleSize})${suggested ? ' — ' + suggested : ''}`
+    );
+    updateCodePreview();
+    // Aperçu immédiat dès qu'une localisation est connue
+    if (layer.geoField || (layer.latField && layer.lonField)) executePreview();
+  } catch (err) {
+    layer.fields = [];
+    rerenderLayerConfig();
+    setScanStatus(
+      `<i class="ri-error-warning-line" style="color:var(--text-default-error)"></i> ${escapeAttr((err as Error).message)}`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Code preview
 // ---------------------------------------------------------------------------
 
@@ -833,6 +1288,7 @@ function updateCodePreview() {
   if (codeEl) {
     codeEl.textContent = generateCode();
   }
+  persistState();
 }
 
 // ---------------------------------------------------------------------------
@@ -855,6 +1311,20 @@ function removeActiveLayer() {
   renderLayersList();
   renderLayerConfig();
   updateCodePreview();
+}
+
+function resetBuilder() {
+  if (!confirm('Repartir de zéro ? La configuration actuelle sera perdue.')) return;
+  resetState();
+  renderLayersList();
+  renderLayerConfig();
+  renderMapConfig();
+  updateCodePreview();
+  const preview = document.getElementById('map-preview');
+  if (preview)
+    preview.innerHTML =
+      '<p class="fr-text--sm" style="text-align:center;padding:2rem;color:var(--text-mention-grey)">Cliquez sur « Exécuter » pour afficher l\'aperçu de la carte.</p>';
+  setPreviewStatus('');
 }
 
 function copyCode() {
@@ -880,7 +1350,7 @@ function saveFavorite() {
   const code = generateCode();
   if (!code.trim()) {
     toastWarning(
-      'Cliquez d\u2019abord sur \u00ab\u00a0Ex\u00e9cuter\u00a0\u00bb pour g\u00e9n\u00e9rer la carte, puis vous pourrez la sauvegarder en favori.'
+      'Cliquez d’abord sur « Exécuter » pour générer la carte, puis vous pourrez la sauvegarder en favori.'
     );
     return;
   }
@@ -916,6 +1386,78 @@ function saveFavorite() {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Aperçu + diagnostic
+// ---------------------------------------------------------------------------
+
+function setPreviewStatus(html: string, tone: 'ok' | 'warn' | 'err' | '' = '') {
+  const el = document.getElementById('preview-status');
+  if (!el) return;
+  el.innerHTML = html;
+  el.className = `carto-preview-status${tone ? ` carto-preview-status--${tone}` : ''}`;
+}
+
+let statusTimers: ReturnType<typeof setTimeout>[] = [];
+
+/**
+ * Diagnostic post-exécution : compare les éléments dessinés par Leaflet aux
+ * enregistrements chargés — c'est LE signal qui manquait quand un champ géo
+ * était mal choisi (carte vide silencieuse).
+ */
+function updatePreviewStatus() {
+  statusTimers.forEach(clearTimeout);
+  statusTimers = [];
+
+  const check = (attempt: number) => {
+    const preview = document.getElementById('map-preview');
+    if (!preview) return;
+
+    const sources = [...preview.querySelectorAll('dsfr-data-source')] as (HTMLElement & {
+      getData?: () => unknown[];
+      getError?: () => Error | null;
+      isLoading?: () => boolean;
+    })[];
+    const errors = sources.map((s) => s.getError?.()).filter(Boolean) as Error[];
+    const loading = sources.some((s) => s.isLoading?.());
+    const records = sources.reduce((acc, s) => {
+      const d = s.getData?.();
+      return acc + (Array.isArray(d) ? d.length : 0);
+    }, 0);
+
+    const drawn =
+      preview.querySelectorAll('.leaflet-marker-icon').length +
+      preview.querySelectorAll('.leaflet-overlay-pane path').length +
+      preview.querySelectorAll('.leaflet-heatmap-layer, .leaflet-overlay-pane canvas').length;
+
+    if (errors.length) {
+      setPreviewStatus(
+        `<i class="ri-error-warning-line"></i> Erreur de chargement : ${escapeAttr(errors[0].message ?? String(errors[0]))}`,
+        'err'
+      );
+      return;
+    }
+    if (loading && attempt < 4) return; // on laisse les timers suivants re-vérifier
+
+    if (records > 0 && drawn === 0) {
+      setPreviewStatus(
+        `<i class="ri-alert-line"></i> ${records} enregistrements chargés mais aucun élément dessiné — vérifiez le champ de localisation (section Localisation).`,
+        'warn'
+      );
+    } else if (records === 0 && sources.length && attempt >= 4) {
+      setPreviewStatus(`<i class="ri-alert-line"></i> Aucune donnée reçue de la source.`, 'warn');
+    } else if (drawn > 0) {
+      setPreviewStatus(
+        `<i class="ri-check-line"></i> ${drawn.toLocaleString('fr-FR')} éléments affichés (${records.toLocaleString('fr-FR')} enregistrements)`,
+        'ok'
+      );
+    }
+  };
+
+  [800, 2000, 4000, 8000, 15000].forEach((ms, i) => {
+    statusTimers.push(setTimeout(() => check(i + 1), ms));
+  });
+}
+
 function executePreview() {
   const preview = document.getElementById('map-preview');
   if (!preview) return;
@@ -927,6 +1469,8 @@ function executePreview() {
   state.generationMode = savedMode;
 
   preview.innerHTML = code;
+  setPreviewStatus('<i class="ri-loader-4-line carto-spin"></i> Chargement…');
+  updatePreviewStatus();
 }
 
 // ---------------------------------------------------------------------------
@@ -939,6 +1483,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   // ApiStorageAdapter prefetch the next time another app loads.
   await initAuth();
 
+  const restored = restoreState();
+
   renderLayersList();
   renderLayerConfig();
   renderMapConfig();
@@ -946,6 +1492,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   document.getElementById('btn-add-layer')?.addEventListener('click', addLayer);
   document.getElementById('btn-remove-layer')?.addEventListener('click', removeActiveLayer);
+  document.getElementById('btn-reset')?.addEventListener('click', resetBuilder);
   document.getElementById('btn-copy')?.addEventListener('click', copyCode);
   document.getElementById('btn-execute')?.addEventListener('click', executePreview);
 
@@ -954,6 +1501,18 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (previewPanel) {
     previewPanel.addEventListener('save-favorite', saveFavorite);
     previewPanel.addEventListener('open-playground', sendToPlayground);
+  }
+
+  // Reprise de session : re-analyse les champs de la couche active et relance
+  // l'aperçu pour retrouver l'écran tel qu'on l'avait laissé. Attendre que
+  // app-preview-panel soit rendu : une carte injectée dans un conteneur encore
+  // à 0×0 ne déclenche jamais l'init Leaflet (IntersectionObserver).
+  if (restored) {
+    const layer = getActiveLayer();
+    if (layer?.source) {
+      await customElements.whenDefined('app-preview-panel');
+      setTimeout(() => void scanAndSuggest(layer), 150);
+    }
   }
 
   // Product tour

--- a/apps/builder-carto/src/state.ts
+++ b/apps/builder-carto/src/state.ts
@@ -1,7 +1,11 @@
 /**
  * Application state for the Builder Carto app.
  * Manages map config and multiple layers, each with its own source.
+ * The whole state is persisted to localStorage (BUILDER_CARTO_STATE_KEY)
+ * so a reload does not lose the work in progress.
  */
+
+import { loadFromStorage, saveToStorageQuiet } from '@dsfr-data/shared';
 
 export { PROXY_BASE_URL, LIB_URL } from '@dsfr-data/shared';
 
@@ -31,6 +35,37 @@ export type TilePreset =
   // Deprecie (redirige vers ign-plan) — conserve pour les etats sauvegardes
   | 'ign-topo';
 
+/**
+ * Les 12 territoires d'encart supportes par <dsfr-data-map-inset>
+ * (presets de packages/core/src/utils/territories.ts — liste stable,
+ * dupliquee ici car l'app consomme la lib buildee, pas ses sources TS).
+ */
+export const INSET_TERRITORIES: { id: string; label: string; drom: boolean }[] = [
+  { id: 'guadeloupe', label: 'Guadeloupe', drom: true },
+  { id: 'martinique', label: 'Martinique', drom: true },
+  { id: 'guyane', label: 'Guyane', drom: true },
+  { id: 'la-reunion', label: 'La Réunion', drom: true },
+  { id: 'mayotte', label: 'Mayotte', drom: true },
+  { id: 'corse', label: 'Corse', drom: false },
+  { id: 'saint-pierre-et-miquelon', label: 'Saint-Pierre-et-Miquelon', drom: false },
+  { id: 'saint-martin', label: 'Saint-Martin', drom: false },
+  { id: 'saint-barthelemy', label: 'Saint-Barthélemy', drom: false },
+  { id: 'nouvelle-caledonie', label: 'Nouvelle-Calédonie', drom: false },
+  { id: 'polynesie-francaise', label: 'Polynésie française', drom: false },
+  { id: 'wallis-et-futuna', label: 'Wallis-et-Futuna', drom: false },
+];
+
+export const DROM_IDS = INSET_TERRITORIES.filter((t) => t.drom).map((t) => t.id);
+
+/** Champ detecte sur la source d'une couche (assistance de saisie). */
+export interface FieldInfo {
+  name: string;
+  /** number | string | object | mixed */
+  type: string;
+  /** Part de valeurs renseignees sur l'echantillon, 0..1 */
+  fillRate: number;
+}
+
 export interface LayerConfig {
   id: string;
   name: string;
@@ -56,8 +91,12 @@ export interface LayerConfig {
   colorField: string;
   colorMap: string;
   filter: string;
+  /** Classe CSS appliquee aux traces SVG (motifs, hachures) — geoshape/circle */
+  shapeClass: string;
+  /** Couche decorative : ni clic, ni tooltip, exclue du fit-bounds */
+  noInteractive: boolean;
 
-  // Geoshape
+  // Geoshape / circle
   fillField: string;
   fillOpacity: number;
   selectedPalette: string;
@@ -91,8 +130,8 @@ export interface LayerConfig {
   bboxField: string;
   maxItems: number;
 
-  /** Resolved fields from source data */
-  fields: { name: string; type: string }[];
+  /** Resolved fields from source data (assistance de saisie) */
+  fields: FieldInfo[];
   /** Preview data */
   data: Record<string, unknown>[];
 }
@@ -108,6 +147,18 @@ export interface MapConfig {
   fitBounds: boolean;
   noControls: boolean;
   maxBounds: string;
+  /** Carte figee : aucune interaction (vignettes, encarts) */
+  locked: boolean;
+  /** Restreint les fonds de carte aux presets souverains IGN */
+  sovereignOnly: boolean;
+  /** Territoires d'encart selectionnes (ids de INSET_TERRITORIES) */
+  insets: string[];
+  /** Vitesse de lecture de la timeline (0.5, 1, 2, 4) */
+  timelineSpeed: number;
+  /** Intervalle de base entre deux pas de temps (ms) */
+  timelineInterval: number;
+  /** Genere le compagnon d'accessibilite <dsfr-data-a11y> */
+  a11y: boolean;
 }
 
 export interface CartoState {
@@ -143,6 +194,8 @@ export function createLayer(): LayerConfig {
     colorField: '',
     colorMap: '',
     filter: '',
+    shapeClass: '',
+    noInteractive: false,
 
     fillField: '',
     fillOpacity: 0.6,
@@ -177,8 +230,8 @@ export function createLayer(): LayerConfig {
   };
 }
 
-export const state: CartoState = {
-  map: {
+function createDefaultMap(): MapConfig {
+  return {
     center: '46.603,2.888',
     zoom: 6,
     minZoom: 2,
@@ -189,8 +242,65 @@ export const state: CartoState = {
     fitBounds: false,
     noControls: false,
     maxBounds: '',
-  },
+    locked: false,
+    sovereignOnly: false,
+    insets: [],
+    timelineSpeed: 1,
+    timelineInterval: 1000,
+    a11y: true,
+  };
+}
+
+export const state: CartoState = {
+  map: createDefaultMap(),
   layers: [createLayer()],
   activeLayerId: 'layer-1',
   generationMode: 'embedded',
 };
+
+// ---------------------------------------------------------------------------
+// Persistance de l'etat du builder (reprise de session)
+// ---------------------------------------------------------------------------
+
+export const BUILDER_CARTO_STATE_KEY = 'dsfr-data-builder-carto-state';
+
+export function persistState(): void {
+  saveToStorageQuiet(BUILDER_CARTO_STATE_KEY, state);
+}
+
+/**
+ * Restaure l'etat sauvegarde (localStorage). Merge defensif : les champs
+ * ajoutes par les versions ulterieures gardent leur defaut si absents de
+ * l'etat sauvegarde (anciens enregistrements).
+ */
+export function restoreState(): boolean {
+  const saved = loadFromStorage<Partial<CartoState> | null>(BUILDER_CARTO_STATE_KEY, null);
+  if (!saved || !Array.isArray(saved.layers) || saved.layers.length === 0) return false;
+
+  state.map = { ...createDefaultMap(), ...(saved.map ?? {}) };
+  if (!Array.isArray(state.map.insets)) state.map.insets = [];
+
+  state.layers = saved.layers.map((l) => ({ ...createLayer(), ...l }));
+  // layerCounter doit depasser tous les ids restaures (layer-N)
+  layerCounter = state.layers.reduce((max, l) => {
+    const n = Number(String(l.id).replace('layer-', ''));
+    return Number.isFinite(n) && n > max ? n : max;
+  }, layerCounter);
+
+  state.activeLayerId =
+    saved.activeLayerId && state.layers.some((l) => l.id === saved.activeLayerId)
+      ? saved.activeLayerId
+      : state.layers[0].id;
+  state.generationMode = saved.generationMode === 'dynamic' ? 'dynamic' : 'embedded';
+  return true;
+}
+
+/** Reinitialise completement l'etat (bouton « Repartir de zero »). */
+export function resetState(): void {
+  layerCounter = 0;
+  state.map = createDefaultMap();
+  state.layers = [createLayer()];
+  state.activeLayerId = state.layers[0].id;
+  state.generationMode = 'embedded';
+  persistState();
+}

--- a/apps/builder-carto/src/styles/carto.css
+++ b/apps/builder-carto/src/styles/carto.css
@@ -49,7 +49,9 @@
   border-radius: 4px;
   margin-bottom: 0.5rem;
   cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -186,7 +188,9 @@
 .config-section-content {
   overflow: hidden;
   max-height: 2000px;
-  transition: max-height 0.3s ease, padding 0.3s ease;
+  transition:
+    max-height 0.3s ease,
+    padding 0.3s ease;
 }
 
 .config-section.collapsed .config-section-content {
@@ -234,8 +238,8 @@
 }
 
 .carto-field select,
-.carto-field input[type="text"],
-.carto-field input[type="number"] {
+.carto-field input[type='text'],
+.carto-field input[type='number'] {
   width: 100%;
   padding: 0.375rem 0.5rem;
   border: 1px solid var(--border-default-grey);
@@ -254,7 +258,7 @@
   min-height: 80px;
 }
 
-.carto-field input[type="color"] {
+.carto-field input[type='color'] {
   width: 40px;
   height: 32px;
   border: 1px solid var(--border-default-grey);
@@ -289,4 +293,85 @@
   text-align: center;
   padding: 2rem 1rem;
   color: var(--text-mention-grey);
+}
+
+/* --- Réalignement #461 : assistance, disclosures, statut d'aperçu --- */
+
+.carto-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 0 0.4rem;
+  border-radius: 0.75rem;
+  background: var(--background-contrast-grey);
+  color: var(--text-mention-grey);
+  vertical-align: middle;
+}
+.carto-badge--ok {
+  background: var(--background-contrast-success, #dffee6);
+  color: var(--text-default-success, #18753c);
+}
+
+.carto-advanced {
+  margin: 0.5rem 0;
+  border-left: 2px solid var(--border-default-grey, #ddd);
+  padding-left: 0.75rem;
+}
+.carto-advanced > summary {
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--text-action-high-blue-france, #000091);
+  padding: 0.25rem 0;
+  list-style-position: inside;
+}
+.carto-advanced[open] > summary {
+  margin-bottom: 0.5rem;
+}
+
+.carto-url-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+.carto-url-row input {
+  flex: 1;
+  min-width: 0;
+}
+
+.carto-scan-status {
+  font-size: 0.8125rem;
+  min-height: 1.25rem;
+  color: var(--text-mention-grey);
+}
+.carto-scan-status code {
+  font-size: 0.75rem;
+  background: var(--background-contrast-grey);
+  padding: 0 0.25rem;
+  border-radius: 2px;
+}
+
+.carto-preview-status {
+  font-size: 0.8125rem;
+  padding: 0.375rem 0.25rem;
+  min-height: 1.5rem;
+  color: var(--text-mention-grey);
+}
+.carto-preview-status--ok {
+  color: var(--text-default-success, #18753c);
+}
+.carto-preview-status--warn {
+  color: var(--text-default-warning, #b34000);
+}
+.carto-preview-status--err {
+  color: var(--text-default-error, #ce0500);
+}
+
+.carto-spin {
+  display: inline-block;
+  animation: carto-spin 1s linear infinite;
+}
+@keyframes carto-spin {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/apps/builder-carto/src/ui/code-generator.ts
+++ b/apps/builder-carto/src/ui/code-generator.ts
@@ -1,7 +1,7 @@
 /**
  * Generates dsfr-data-map HTML code from the current state.
  */
-import { state } from '../state.js';
+import { state, DROM_IDS, INSET_TERRITORIES } from '../state.js';
 import type { LayerConfig } from '../state.js';
 import { LIB_URL } from '../state.js';
 import {
@@ -10,6 +10,8 @@ import {
   getProvider,
   PROXY_BASE_URL_EMBED,
 } from '@dsfr-data/shared';
+
+const MAP_A11Y_ID = 'carte';
 
 function layerAttrs(layer: LayerConfig): string {
   const attrs: string[] = [];
@@ -21,14 +23,12 @@ function layerAttrs(layer: LayerConfig): string {
   if (layer.lonField) attrs.push(`lon-field="${layer.lonField}"`);
   if (layer.geoField) attrs.push(`geo-field="${layer.geoField}"`);
 
-  // Tooltip (only if popupMode is tooltip)
-  if (layer.popupMode === 'tooltip' && layer.tooltipField) {
-    attrs.push(`tooltip-field="${layer.tooltipField}"`);
-  }
+  // Couche decorative : aucune interaction, exclue du fit-bounds
+  if (layer.noInteractive) attrs.push('no-interactive');
 
-  // Popup fields on layer (for popup mode without template)
-  if (layer.popupMode === 'popup' && layer.popupFields && !layer.popupTemplate) {
-    attrs.push(`popup-fields="${layer.popupFields}"`);
+  // Tooltip (only if popupMode is tooltip, pointless on a decorative layer)
+  if (!layer.noInteractive && layer.popupMode === 'tooltip' && layer.tooltipField) {
+    attrs.push(`tooltip-field="${layer.tooltipField}"`);
   }
 
   if (layer.color !== '#000091') attrs.push(`color="${layer.color}"`);
@@ -37,8 +37,11 @@ function layerAttrs(layer: LayerConfig): string {
 
   if (layer.type === 'geoshape') {
     if (layer.fillField) attrs.push(`fill-field="${layer.fillField}"`);
-    if (layer.fillOpacity !== 0.6) attrs.push(`fill-opacity="${layer.fillOpacity}"`);
     if (layer.selectedPalette) attrs.push(`selected-palette="${layer.selectedPalette}"`);
+  }
+  if (layer.type === 'geoshape' || layer.type === 'circle') {
+    if (layer.fillOpacity !== 0.6) attrs.push(`fill-opacity="${layer.fillOpacity}"`);
+    if (layer.shapeClass) attrs.push(`shape-class="${layer.shapeClass}"`);
   }
 
   if (layer.type === 'circle') {
@@ -79,27 +82,51 @@ function layerAttrs(layer: LayerConfig): string {
   return attrs.join('\n    ');
 }
 
+/**
+ * Template genere depuis la liste « Champs affiches » quand aucun template
+ * n'est fourni : sans lui, le compagnon popup affiche TOUTES les colonnes.
+ */
+function autoTemplateFromFields(layer: LayerConfig): string {
+  const fields = layer.popupFields
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean);
+  if (!fields.length) return '';
+  return fields
+    .map((f) => `<p class="fr-mb-1v"><strong>${f} :</strong> {{${f}}}</p>`)
+    .join('\n        ');
+}
+
 function popupTag(layer: LayerConfig): string {
   const mode = layer.popupMode;
-  if (mode === 'none' || mode === 'tooltip') return '';
+  if (layer.noInteractive || mode === 'none' || mode === 'tooltip') return '';
 
   const attrs: string[] = [];
   attrs.push(`mode="${mode}"`);
   if (layer.titleField) attrs.push(`title-field="${layer.titleField}"`);
   if (layer.popupWidth && layer.popupWidth !== '350px') attrs.push(`width="${layer.popupWidth}"`);
 
+  const template = layer.popupTemplate || autoTemplateFromFields(layer);
   let inner = '';
-  if (layer.popupTemplate) {
-    inner = `\n      <template>${layer.popupTemplate}</template>\n    `;
+  if (template) {
+    inner = `\n      <template>${template}</template>\n    `;
   }
 
   return `    <dsfr-data-map-popup ${attrs.join(' ')}>${inner}</dsfr-data-map-popup>`;
 }
 
-function sourceTag(layer: LayerConfig): string {
+/**
+ * Balise <dsfr-data-source> d'une couche. Reutilisee par l'assistance de
+ * champs (field-service) avec un id/limit d'echantillonnage.
+ */
+export function buildSourceTag(
+  layer: LayerConfig,
+  opts: { id?: string; limit?: number } = {}
+): string {
   if (!layer.source) return '';
   const s = layer.source;
-  const attrs: string[] = [`id="${layer.id}"`];
+  const attrs: string[] = [`id="${opts.id ?? layer.id}"`];
+  const isAdapter: { current: boolean } = { current: false };
 
   // Unified Source format: detect provider from apiUrl
   const provider = s.apiUrl ? detectProvider(s.apiUrl) : getProvider('generic');
@@ -121,24 +148,49 @@ function sourceTag(layer: LayerConfig): string {
     attrs.push('api-type="opendatasoft"');
     attrs.push(`base-url="${baseUrl}"`);
     attrs.push(`dataset-id="${resourceIds.datasetId}"`);
-    if (layer.maxItems !== 5000) attrs.push(`limit="${layer.maxItems}"`);
+    isAdapter.current = true;
   } else if (provider.id === 'tabular' && resourceIds?.resourceId) {
     attrs.push('api-type="tabular"');
     attrs.push(`base-url="https://tabular-api.data.gouv.fr"`);
     attrs.push(`resource="${resourceIds.resourceId}"`);
+    isAdapter.current = true;
   } else if (provider.id === 'insee' && resourceIds?.datasetId) {
     const baseUrl = new URL(s.apiUrl!).origin;
     attrs.push('api-type="insee"');
     attrs.push(`base-url="${baseUrl}"`);
     attrs.push(`dataset-id="${resourceIds.datasetId}"`);
+    isAdapter.current = true;
   } else if (s.apiUrl) {
     attrs.push(`url="${s.apiUrl}"`);
     if (s.dataPath) attrs.push(`transform="${s.dataPath}"`);
   } else if (s.type === 'manual' && s.data?.length) {
-    attrs.push(`data='${JSON.stringify(s.data)}'`);
+    // Attribut simple-quoté : les apostrophes du JSON doivent être échappées
+    // en entité HTML, sinon l'attribut se termine au premier « d' » venu.
+    attrs.push(`data='${JSON.stringify(s.data).replace(/'/g, '&#39;')}'`);
+  } else {
+    return '';
   }
 
+  // limit : echantillonnage (field-service) ou plafond utilisateur (max-items)
+  const limit = opts.limit ?? (isAdapter.current && layer.maxItems !== 5000 ? layer.maxItems : 0);
+  if (limit && isAdapter.current) attrs.push(`limit="${limit}"`);
+
   return `<dsfr-data-source ${attrs.join('\n  ')}>\n</dsfr-data-source>`;
+}
+
+/** Attribut insets : compresse les 5 DROM en groupe `drom` si tous coches. */
+export function insetsAttrValue(): string {
+  const selected = state.map.insets.filter((id) => INSET_TERRITORIES.some((t) => t.id === id));
+  if (!selected.length) return '';
+  const hasAllDrom = DROM_IDS.every((id) => selected.includes(id));
+  const parts: string[] = [];
+  if (hasAllDrom) parts.push('drom');
+  for (const t of INSET_TERRITORIES) {
+    if (!selected.includes(t.id)) continue;
+    if (hasAllDrom && t.drom) continue;
+    parts.push(t.id);
+  }
+  return parts.join(',');
 }
 
 export function generateCode(): string {
@@ -157,7 +209,7 @@ export function generateCode(): string {
   // Sources (only visible layers)
   const visibleLayers = state.layers.filter((l) => l.visible);
   for (const layer of visibleLayers) {
-    const src = sourceTag(layer);
+    const src = buildSourceTag(layer);
     if (src) {
       lines.push(src);
       // Filtre du layer : un dsfr-data-query intermediaire (#297) —
@@ -173,16 +225,21 @@ export function generateCode(): string {
 
   // Map container
   const mapAttrs: string[] = [];
+  if (m.a11y) mapAttrs.push(`id="${MAP_A11Y_ID}"`);
   if (m.center !== '46.603,2.888') mapAttrs.push(`center="${m.center}"`);
   if (m.zoom !== 6) mapAttrs.push(`zoom="${m.zoom}"`);
   if (m.minZoom !== 2) mapAttrs.push(`min-zoom="${m.minZoom}"`);
   if (m.maxZoom !== 18) mapAttrs.push(`max-zoom="${m.maxZoom}"`);
   if (m.tiles !== 'ign-plan') mapAttrs.push(`tiles="${m.tiles}"`);
+  if (m.sovereignOnly) mapAttrs.push('sovereign-only');
   if (m.height !== '500px') mapAttrs.push(`height="${m.height}"`);
   if (m.name) mapAttrs.push(`name="${m.name}"`);
   if (m.fitBounds) mapAttrs.push('fit-bounds');
   if (m.noControls) mapAttrs.push('no-controls');
+  if (m.locked) mapAttrs.push('locked');
   if (m.maxBounds) mapAttrs.push(`max-bounds="${m.maxBounds}"`);
+  const insets = insetsAttrValue();
+  if (insets) mapAttrs.push(`insets="${insets}"`);
 
   lines.push(`<dsfr-data-map${mapAttrs.length ? ' ' + mapAttrs.join(' ') : ''}>`);
 
@@ -202,11 +259,28 @@ export function generateCode(): string {
 
   // Timeline controls (if any layer has time-field)
   if (visibleLayers.some((l) => l.timeField)) {
+    const tAttrs: string[] = [];
+    if (m.timelineSpeed !== 1) tAttrs.push(`speed="${m.timelineSpeed}"`);
+    if (m.timelineInterval !== 1000) tAttrs.push(`interval="${m.timelineInterval}"`);
     lines.push('');
-    lines.push('  <dsfr-data-map-timeline></dsfr-data-map-timeline>');
+    lines.push(
+      `  <dsfr-data-map-timeline${tAttrs.length ? ' ' + tAttrs.join(' ') : ''}></dsfr-data-map-timeline>`
+    );
   }
 
   lines.push('</dsfr-data-map>');
+
+  // Compagnon d'accessibilite : tableau des donnees + export CSV lies a la carte
+  if (m.a11y) {
+    const first = visibleLayers.find((l) => l.source);
+    if (first) {
+      const srcId = first.filter ? `${first.id}-filtre` : first.id;
+      lines.push('');
+      lines.push(
+        `<dsfr-data-a11y for="${MAP_A11Y_ID}" source="${srcId}" table download></dsfr-data-a11y>`
+      );
+    }
+  }
 
   return lines.join('\n');
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -70,6 +70,7 @@ export { buildGristHeaders } from './api/grist.js';
 export {
   loadFromStorage,
   saveToStorage,
+  saveToStorageQuiet,
   removeFromStorage,
   STORAGE_KEYS,
 } from './storage/local-storage.js';

--- a/tests/apps/builder-carto/code-generator.test.ts
+++ b/tests/apps/builder-carto/code-generator.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests du générateur de code du Builder Carto (#461) : nouveaux attributs
+ * carte (insets, locked, sovereign-only), couche (shape-class, no-interactive),
+ * timeline configurée, compagnon a11y et template auto des popups.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { state, createLayer, resetState, DROM_IDS } from '../../../apps/builder-carto/src/state';
+import {
+  generateCode,
+  buildSourceTag,
+  insetsAttrValue,
+} from '../../../apps/builder-carto/src/ui/code-generator';
+
+function withManualSource(layer = state.layers[0]) {
+  layer.source = {
+    id: 'test-src',
+    name: 'Test',
+    type: 'manual',
+    data: [{ ville: 'Paris', lat: 48.85, lon: 2.35, population: 2133111 }],
+  };
+  layer.latField = 'lat';
+  layer.lonField = 'lon';
+  return layer;
+}
+
+beforeEach(() => {
+  resetState();
+});
+
+describe('generateCode — carte', () => {
+  it('émet id + compagnon a11y par défaut', () => {
+    withManualSource();
+    const code = generateCode();
+    expect(code).toContain('<dsfr-data-map id="carte">');
+    expect(code).toContain('<dsfr-data-a11y for="carte" source="layer-1" table download>');
+  });
+
+  it("n'émet ni id ni compagnon quand a11y est décoché", () => {
+    withManualSource();
+    state.map.a11y = false;
+    const code = generateCode();
+    expect(code).toContain('<dsfr-data-map>');
+    expect(code).not.toContain('dsfr-data-a11y');
+  });
+
+  it('émet locked, sovereign-only et no-controls', () => {
+    withManualSource();
+    state.map.locked = true;
+    state.map.sovereignOnly = true;
+    state.map.noControls = true;
+    const code = generateCode();
+    expect(code).toContain('sovereign-only');
+    expect(code).toContain('no-controls');
+    expect(code).toMatch(/<dsfr-data-map[^>]* locked[ >]/);
+  });
+
+  it('compresse les 5 DROM en groupe drom dans insets', () => {
+    state.map.insets = [...DROM_IDS, 'corse'];
+    expect(insetsAttrValue()).toBe('drom,corse');
+    state.map.insets = ['guadeloupe', 'corse'];
+    expect(insetsAttrValue()).toBe('guadeloupe,corse');
+    withManualSource();
+    state.map.insets = [...DROM_IDS];
+    expect(generateCode()).toContain('insets="drom"');
+  });
+
+  it('le compagnon a11y pointe vers la query quand la couche est filtrée', () => {
+    const layer = withManualSource();
+    layer.filter = 'population:gt:100000';
+    const code = generateCode();
+    expect(code).toContain('<dsfr-data-query id="layer-1-filtre" source="layer-1"');
+    expect(code).toContain('source="layer-1-filtre"');
+    expect(code).toContain('<dsfr-data-a11y for="carte" source="layer-1-filtre"');
+  });
+});
+
+describe('generateCode — couche', () => {
+  it('émet no-interactive et supprime tooltip et popup', () => {
+    const layer = withManualSource();
+    layer.noInteractive = true;
+    layer.popupMode = 'panel-right';
+    layer.tooltipField = 'ville';
+    const code = generateCode();
+    expect(code).toContain('no-interactive');
+    expect(code).not.toContain('tooltip-field');
+    expect(code).not.toContain('dsfr-data-map-popup');
+  });
+
+  it('émet shape-class et fill-opacity pour les cercles', () => {
+    const layer = withManualSource();
+    layer.type = 'circle';
+    layer.shapeClass = 'territoire-hachure';
+    layer.fillOpacity = 0.2;
+    const code = generateCode();
+    expect(code).toContain('shape-class="territoire-hachure"');
+    expect(code).toContain('fill-opacity="0.2"');
+  });
+
+  it('génère un template depuis les champs affichés (mode panneau)', () => {
+    const layer = withManualSource();
+    layer.popupMode = 'panel-right';
+    layer.popupFields = 'ville, population';
+    const code = generateCode();
+    expect(code).toContain('mode="panel-right"');
+    expect(code).toContain('<template>');
+    expect(code).toContain('{{ville}}');
+    expect(code).toContain('{{population}}');
+  });
+
+  it('le template explicite prime sur les champs affichés', () => {
+    const layer = withManualSource();
+    layer.popupMode = 'popup';
+    layer.popupFields = 'ville';
+    layer.popupTemplate = '<h3>{{ville}}</h3>';
+    const code = generateCode();
+    expect(code).toContain('<h3>{{ville}}</h3>');
+    expect(code).not.toContain('<strong>ville :</strong>');
+  });
+});
+
+describe('generateCode — timeline', () => {
+  it('émet la timeline avec vitesse et intervalle non par défaut', () => {
+    const layer = withManualSource();
+    layer.timeField = 'date';
+    layer.timeBucket = 'month';
+    layer.timeMode = 'cumulative';
+    state.map.timelineSpeed = 2;
+    state.map.timelineInterval = 1500;
+    const code = generateCode();
+    expect(code).toContain('time-field="date"');
+    expect(code).toContain('time-bucket="month"');
+    expect(code).toContain('time-mode="cumulative"');
+    expect(code).toContain('<dsfr-data-map-timeline speed="2" interval="1500">');
+  });
+
+  it('timeline sans attributs aux valeurs par défaut', () => {
+    const layer = withManualSource();
+    layer.timeField = 'date';
+    const code = generateCode();
+    expect(code).toContain('<dsfr-data-map-timeline></dsfr-data-map-timeline>');
+  });
+});
+
+describe('buildSourceTag', () => {
+  it('adapter ODS avec id et limit de scan', () => {
+    const layer = createLayer();
+    layer.source = {
+      id: 's1',
+      name: 'ODS',
+      type: 'api',
+      apiUrl: 'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/mon-jeu/records',
+    };
+    const tag = buildSourceTag(layer, { id: 'scan-1', limit: 50 });
+    expect(tag).toContain('id="scan-1"');
+    expect(tag).toContain('api-type="opendatasoft"');
+    expect(tag).toContain('dataset-id="mon-jeu"');
+    expect(tag).toContain('limit="50"');
+  });
+
+  it('max-items devient limit pour les adapters', () => {
+    const layer = createLayer();
+    layer.source = {
+      id: 's1',
+      name: 'ODS',
+      type: 'api',
+      apiUrl: 'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/mon-jeu/records',
+    };
+    layer.maxItems = 200;
+    const tag = buildSourceTag(layer);
+    expect(tag).toContain('limit="200"');
+  });
+
+  it('source manuelle : données inline', () => {
+    const layer = withManualSource(createLayer());
+    const tag = buildSourceTag(layer);
+    expect(tag).toContain("data='[{");
+    expect(tag).not.toContain('api-type');
+  });
+
+  it('source vide : chaîne vide', () => {
+    const layer = createLayer();
+    expect(buildSourceTag(layer)).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #461.

## Diagnostic (validé en conditions réelles dans Chrome)

Le pipeline carto fonctionnait — la « casse » ressentie venait d'impasses UX :
1. **Dropdown de sources vide = impasse totale** (aucune alternative pour démarrer).
2. **Champs à deviner à l'aveugle** : le state prévoyait un tableau `fields` d'assistance… jamais peuplé. Premier test réel : un champ géo 100 % null sur le dataset IRVE → **carte vide sans aucun message**.
3. Capacités v0.13→v0.16 absentes : encarts ADR-094, locked, sovereign-only, shape-class, no-interactive, config timeline, a11y.

## Ce que fait cette PR

### Réparations
- **Sources autonomes** : URL directe (providers ODS/tabular/Grist/INSEE détectés automatiquement) + jeu d'exemple embarqué (13 chefs-lieux) — le builder démarre en un clic.
- **Assistance de champs** (`field-service.ts`) : échantillonnage par le pipeline réel (`<dsfr-data-source>` caché, limit 50), datalists avec type + taux de remplissage, **détection automatique geo/lat/lon/date** appliquée d'office, aperçu immédiat.
- **Diagnostic d'aperçu** : bandeau « N éléments affichés (M enregistrements) », avertissement explicite quand 0 dessiné, erreurs de source affichées.
- **Persistance de l'état** (reprise de session) + bouton Réinitialiser.
- Bugs corrigés : apostrophes des données inline (`data='…'` cassait sur « Côte d'Azur ») ; aperçu auto différé après le rendu d'`app-preview-panel` (une carte injectée à 0×0 ne déclenche jamais l'IntersectionObserver d'init Leaflet).

### Nouvelles capacités exposées
- **Carte** : encarts territoriaux (12 territoires, groupe DROM compressé en `insets="drom"`), `locked`, `sovereign-only`, **compagnon `dsfr-data-a11y` généré par défaut**, vitesse/intervalle de timeline.
- **Couche** : `shape-class`, `no-interactive` (décoratif), `fill-opacity` aussi sur les cercles, palettes complètes, **template auto des popups** depuis « Champs affichés » (sinon le compagnon affichait toutes les colonnes).
- **UI redécoupée en disclosures** basique → avancé : Carte / Encarts / Réglages avancés · Données / Localisation / Informations / Apparence / Animation temporelle / Filtres & performances. Sélecteurs du tour guidé et des smoke tests préservés.

## Vérifications
- **15 tests unitaires** du générateur (`tests/apps/builder-carto/`) ; suite complète **3 699 tests verts** ; `tsc` + build du workspace OK.
- Parcours Chrome : jeu d'exemple 1 clic → 13 marqueurs sur fond IGN ; **encarts DROM rendus avec clones des couches** ; panneau latéral au clic (titre + template auto) ; IRVE ODS 1 000 points.
- Changeset patch (export `saveToStorageQuiet` dans le barrel applicatif de shared).

Captures dans la conversation de session (vault `20-Sessions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)