### PR TITLE
feat(builder-carto): refonte « carte plein écran » (panneaux flottants, onboarding, export)

### DIFF
--- a/.changeset/carto-refonte-plein-ecran.md
+++ b/.changeset/carto-refonte-plein-ecran.md
@@ -1,0 +1,5 @@
+---
+'dsfr-data': patch
+---
+
+Builder carto : refonte « carte plein écran » — la carte générée devient l'aperçu permanent (cadrage exporté synchronisé sur la navigation), édition dans trois panneaux flottants (Carte / Couches / Éléments), modale d'onboarding pour le choix des données, modale d'export dédiée, vignettes d'encarts territoriaux visibles dans l'aperçu. Tour guidé partagé réaligné sur la nouvelle interface (v2).

--- a/apps/builder-carto/index.html
+++ b/apps/builder-carto/index.html
@@ -3,76 +3,104 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Generateur de cartes - dsfr-data</title>
-  <style>@view-transition{navigation:auto}app-header:not(:defined){display:block;min-height:56px}app-footer:not(:defined){display:block;min-height:48px}</style>
+  <title>Générateur de cartes - dsfr-data</title>
+  <style>@view-transition{navigation:auto}</style>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
   <script type="module" src="../../packages/core/dist/dsfr-data.esm.js"></script>
-  <script type="module" src="../../packages/app-ui/dist/app-ui.esm.js"></script>
   <script type="module" src="src/main.ts"></script>
 </head>
-<body>
-  <app-header current-page="builder-carto" base-path="../../"></app-header>
+<body class="carto-app">
+  <main id="main-content" class="carto-workspace">
 
-  <main class="fr-container--fluid fr-py-2w" id="main-content">
-    <div class="carto-layout">
+    <!-- Canevas : la carte generee est l'apercu permanent -->
+    <div id="map-canvas" class="carto-canvas">
+      <p class="carto-canvas__hint" id="canvas-hint">
+        <i class="ri-map-2-line" aria-hidden="true"></i><br>
+        Choisissez vos données, la carte s'affiche ici.
+      </p>
+    </div>
 
-      <!-- Col 1: Layers list + Map config -->
-      <div class="carto-col-layers">
-        <h2 class="fr-text--lg fr-mb-1w"><i class="ri-stack-line fr-mr-1w"></i>Couches</h2>
-        <div class="carto-col-actions">
-          <button id="btn-add-layer" class="fr-btn fr-btn--sm fr-btn--secondary fr-btn--icon-left fr-icon-add-line" title="Ajouter une couche">Ajouter</button>
-          <button id="btn-remove-layer" class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-delete-line" title="Supprimer la couche active">Supprimer</button>
-          <button id="btn-reset" class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-refresh-line" title="Repartir de zéro">Réinitialiser</button>
-        </div>
-
-        <ul id="layers-list" class="carto-layers__list"></ul>
-
-        <hr class="fr-mt-2w fr-mb-2w">
-
-        <!-- Map global config -->
-        <div id="map-config"></div>
+    <!-- Barre du haut -->
+    <header class="carto-topbar">
+      <a class="carto-topbar__brand" href="../../index.html" title="Retour à l'accueil Charts builder">
+        <p class="fr-logo carto-topbar__logo">République<br>Française</p>
+      </a>
+      <h1 class="carto-topbar__title">
+        <span class="carto-topbar__app">Charts builder</span>
+        <span class="carto-topbar__page">· Créer une carte</span>
+      </h1>
+      <div class="carto-topbar__actions">
+        <a class="carto-topbar__guide" href="../../guide/index.html">Guide</a>
+        <button id="btn-favorite" class="carto-btn carto-btn--ghost" type="button" title="Sauvegarder en favori">
+          <i class="ri-star-line" aria-hidden="true"></i>Favoris
+        </button>
+        <button id="btn-export" class="carto-btn carto-btn--secondary" type="button">
+          <i class="ri-code-s-slash-line" aria-hidden="true"></i>Obtenir le code
+        </button>
+        <button id="btn-execute" class="carto-btn carto-btn--primary" type="button">
+          <i class="ri-play-line" aria-hidden="true"></i>Exécuter
+        </button>
       </div>
+    </header>
 
-      <!-- Col 2: Active layer config (accordions) -->
-      <div class="carto-col-config">
-        <div id="layer-config"></div>
-      </div>
+    <!-- Colonne de panneaux flottants -->
+    <div class="carto-panels">
 
-      <!-- Col 3: Preview panel -->
-      <app-preview-panel
-        show-save-button
-        show-playground-button
-        tab-labels="Aperçu,Code généré">
+      <section class="carto-panel carto-panel--collapsed" id="panel-carte" aria-label="Réglages de la carte">
+        <button class="carto-panel__header" type="button" data-panel-toggle="panel-carte"
+                aria-expanded="false" aria-controls="map-config">
+          <span class="carto-panel__title"><i class="ri-map-2-line" aria-hidden="true"></i>Carte</span>
+          <i class="ri-arrow-down-s-line carto-panel__arrow" aria-hidden="true"></i>
+        </button>
+        <div class="carto-panel__body" id="map-config"></div>
+      </section>
 
-        <div slot="preview">
-          <div style="display:flex;justify-content:space-between;align-items:center;padding:0.5rem 0;">
-            <span></span>
-            <button id="btn-execute" class="fr-btn fr-btn--sm fr-btn--icon-left fr-icon-play-line">Executer</button>
-          </div>
-          <div class="carto-preview__map" id="map-preview">
-            <p class="fr-text--sm" style="text-align:center;padding:2rem;color:var(--text-mention-grey)">
-              Cliquez sur "Executer" pour afficher l'aperçu de la carte.
-            </p>
-          </div>
-          <div id="preview-status" class="carto-preview-status" role="status" aria-live="polite"></div>
-        </div>
-
-        <div slot="code">
-          <p class="fr-text--sm fr-mb-1w">Copiez ce code pour l'integrer dans votre page :</p>
-          <button class="fr-btn fr-btn--sm fr-btn--secondary fr-mb-1w" id="btn-copy">
-            <i class="ri-file-copy-line"></i> Copier le code
+      <section class="carto-panel" id="panel-couches" aria-label="Couches de données">
+        <div class="carto-panel__header carto-panel__header--split">
+          <button class="carto-panel__header-toggle" type="button" data-panel-toggle="panel-couches"
+                  aria-expanded="true" aria-controls="couches-body">
+            <span class="carto-panel__title"><i class="ri-stack-line" aria-hidden="true"></i>Couches</span>
           </button>
-          <pre class="carto-code" id="code-output"></pre>
+          <div class="carto-panel__header-actions">
+            <button id="btn-add-layer" class="carto-link-btn" type="button" title="Ajouter une couche">
+              <i class="ri-add-line" aria-hidden="true"></i>Ajouter
+            </button>
+            <button id="btn-reset" class="carto-icon-btn" type="button" title="Repartir de zéro" aria-label="Repartir de zéro">
+              <i class="ri-refresh-line" aria-hidden="true"></i>
+            </button>
+            <button class="carto-icon-btn carto-panel__header-arrow" type="button" data-panel-toggle="panel-couches"
+                    aria-expanded="true" aria-controls="couches-body" aria-label="Replier le panneau Couches">
+              <i class="ri-arrow-down-s-line carto-panel__arrow" aria-hidden="true"></i>
+            </button>
+          </div>
         </div>
+        <div class="carto-panel__body" id="couches-body">
+          <ul id="layers-list" class="carto-layers__list"></ul>
+          <div id="layer-data-config"></div>
+        </div>
+      </section>
 
-      </app-preview-panel>
+      <section class="carto-panel" id="panel-elements" aria-label="Éléments de la couche">
+        <button class="carto-panel__header" type="button" data-panel-toggle="panel-elements"
+                aria-expanded="true" aria-controls="layer-config">
+          <span class="carto-panel__title"><i class="ri-paint-brush-line" aria-hidden="true"></i>Éléments</span>
+          <i class="ri-arrow-down-s-line carto-panel__arrow" aria-hidden="true"></i>
+        </button>
+        <div class="carto-panel__body" id="layer-config"></div>
+      </section>
 
     </div>
-  </main>
 
-  <app-footer base-path="../../"></app-footer>
+    <!-- Diagnostic d'apercu -->
+    <div id="preview-status" class="carto-status" role="status" aria-live="polite" hidden></div>
+
+    <!-- Modales (rendues par main.ts) -->
+    <div id="onboard-modal"></div>
+    <div id="export-modal"></div>
+
+  </main>
   <script type="module" src="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.module.min.js" integrity="sha384-gPgRd2+olihO/srZe/Bqw6iVLiiaL7meuri1d5YVMejwPXg7VehLSBeORYq9yh2F" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/apps/builder-carto/src/main.ts
+++ b/apps/builder-carto/src/main.ts
@@ -1,8 +1,10 @@
 /**
- * Builder Carto — Visual map builder for dsfr-data-map
+ * Builder Carto — refonte « carte plein écran »
  *
- * Colonnes : 1) couches + config carte · 2) config de la couche active
- * (sections disclosure, basique → avancé) · 3) aperçu + code généré.
+ * La carte générée EST l'aperçu : elle occupe tout l'écran et le cadrage
+ * exporté suit la navigation (sync moveend/zoomend → state). L'édition se
+ * fait dans trois panneaux flottants (Carte / Couches / Éléments), le choix
+ * des données dans une modale d'onboarding, l'export dans une modale dédiée.
  * L'état complet est persisté (reprise de session) et la saisie des champs
  * est assistée par un échantillonnage réel de la source (field-service).
  */
@@ -51,6 +53,15 @@ interface Favorite {
    * entries may still carry this under the legacy field name `builderState`.
    */
   builderStateJson?: unknown;
+}
+
+/** Accès en lecture au viewport Leaflet de la carte d'aperçu. */
+interface DsfrDataMapElement extends HTMLElement {
+  getLeafletMap?: () => {
+    on: (event: string, handler: () => void) => void;
+    getCenter: () => { lat: number; lng: number };
+    getZoom: () => number;
+  } | null;
 }
 
 /** Jeu d'exemple embarqué : chefs-lieux des régions métropolitaines. */
@@ -113,35 +124,121 @@ function lightweightSource(s: AnySource): AnySource {
 (window as Window & { __BUILDER_CARTO_STATE__?: typeof state }).__BUILDER_CARTO_STATE__ = state;
 
 // ---------------------------------------------------------------------------
-// Accordion helper
+// État d'interface transitoire (jamais persisté)
 // ---------------------------------------------------------------------------
 
-function toggleSection(sectionId: string): void {
-  const section = document.getElementById(sectionId);
-  if (!section) return;
+const ui = {
+  /** Modale « D'où viennent vos données ? » forcée (Changer / Ajouter) */
+  forceChooser: false,
+  /** Ligne de saisie d'URL dépliée dans la modale */
+  urlMode: false,
+  /** Liste des sources enregistrées dépliée dans la modale */
+  savedOpen: false,
+  /** Modale « Obtenir le code » ouverte */
+  exportOpen: false,
+  /** Une carte a déjà été exécutée : re-exécution auto sur modification */
+  executed: false,
+};
 
-  const isCurrentlyCollapsed = section.classList.contains('collapsed');
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-  // Accordion behavior: close others when opening
-  if (isCurrentlyCollapsed) {
-    const parent = section.parentElement;
-    if (parent) {
-      parent.querySelectorAll('.config-section:not(#' + sectionId + ')').forEach((s) => {
-        if (s.querySelector('.config-section-header')) {
-          s.classList.add('collapsed');
-        }
-      });
-    }
-  }
-
-  section.classList.toggle('collapsed');
+function getActiveLayer(): LayerConfig | undefined {
+  return state.layers.find((l) => l.id === state.activeLayerId);
 }
 
-// Make toggleSection available for onclick handlers
-(window as Window & { toggleSection?: typeof toggleSection }).toggleSection = toggleSection;
+function escapeAttr(val: string): string {
+  return val.replace(/"/g, '&quot;').replace(/</g, '&lt;');
+}
+
+const LAYER_TYPE_LABELS: Record<LayerType, string> = {
+  marker: 'marqueurs',
+  geoshape: 'zones',
+  circle: 'cercles',
+  heatmap: 'chaleur',
+};
+
+const TYPE_TILES: { k: LayerType; icon: string; label: string; desc: string }[] = [
+  { k: 'marker', icon: 'ri-map-pin-2-line', label: 'Marqueurs', desc: 'Des repères sur des lieux' },
+  {
+    k: 'geoshape',
+    icon: 'ri-shape-2-line',
+    label: 'Zones',
+    desc: 'Contours et surfaces colorés',
+  },
+  {
+    k: 'circle',
+    icon: 'ri-record-circle-line',
+    label: 'Cercles',
+    desc: 'Taille selon une valeur',
+  },
+  { k: 'heatmap', icon: 'ri-fire-line', label: 'Chaleur', desc: 'Densité des points' },
+];
+
+const SWATCHES: { c: string; n: string }[] = [
+  { c: '#000091', n: 'Bleu France' },
+  { c: '#e1000f', n: 'Rouge Marianne' },
+  { c: '#18753c', n: 'Vert' },
+  { c: '#0063cb', n: 'Bleu info' },
+  { c: '#b34000', n: 'Orange' },
+  { c: '#666666', n: 'Gris' },
+];
+
+/**
+ * Input texte assisté par datalist : suggestions = champs détectés de la
+ * couche (avec type et taux de remplissage), saisie libre toujours possible.
+ */
+function fieldInput(opts: {
+  id: string;
+  label: string;
+  value: string;
+  fields: FieldInfo[];
+  hint?: string;
+  placeholder?: string;
+  numericOnly?: boolean;
+}): string {
+  const candidates = opts.numericOnly
+    ? opts.fields.filter((f) => f.type === 'number')
+    : opts.fields;
+  const options = candidates
+    .map(
+      (f) =>
+        `<option value="${escapeAttr(f.name)}" label="${escapeAttr(
+          `${f.name} — ${f.type}, ${Math.round(f.fillRate * 100)} % renseigné`
+        )}"></option>`
+    )
+    .join('');
+  return `
+    <div class="carto-field">
+      <label for="${opts.id}">${opts.label}
+        ${opts.hint ? `<span class="fr-hint-text">${opts.hint}</span>` : ''}
+      </label>
+      <input type="text" id="${opts.id}" value="${escapeAttr(opts.value)}"
+             list="${opts.id}-list" ${opts.placeholder ? `placeholder="${escapeAttr(opts.placeholder)}"` : ''}
+             autocomplete="off">
+      <datalist id="${opts.id}-list">${options}</datalist>
+    </div>`;
+}
+
+/** La couche a-t-elle une localisation exploitable ? */
+function hasLocation(layer: LayerConfig): boolean {
+  return Boolean(layer.geoField || (layer.latField && layer.lonField));
+}
 
 // ---------------------------------------------------------------------------
-// Drag & Drop
+// Rendu global
+// ---------------------------------------------------------------------------
+
+function renderAll() {
+  renderLayersPanel();
+  renderElementsPanel();
+  renderMapPanel();
+  renderOnboard();
+}
+
+// ---------------------------------------------------------------------------
+// Panneau Couches : liste + données + localisation
 // ---------------------------------------------------------------------------
 
 let draggedLayerIndex: number | null = null;
@@ -181,473 +278,153 @@ function initDragListeners() {
       (el as HTMLElement).classList.remove('drag-over');
       if (draggedLayerIndex === null || draggedLayerIndex === index) return;
 
-      // Reorder state.layers
       const [moved] = state.layers.splice(draggedLayerIndex, 1);
       state.layers.splice(index, 0, moved);
       draggedLayerIndex = null;
 
-      renderLayersList();
+      renderLayersPanel();
       updateCodePreview();
     });
   });
 }
 
-// ---------------------------------------------------------------------------
-// Rendering helpers
-// ---------------------------------------------------------------------------
-
-function getActiveLayer(): LayerConfig | undefined {
-  return state.layers.find((l) => l.id === state.activeLayerId);
-}
-
-function escapeAttr(val: string): string {
-  return val.replace(/"/g, '&quot;').replace(/</g, '&lt;');
-}
-
-const LAYER_TYPE_LABELS: Record<LayerType, string> = {
-  marker: 'marqueurs',
-  geoshape: 'zones',
-  circle: 'cercles',
-  heatmap: 'chaleur',
-};
-
-/**
- * Input texte assisté par datalist : suggestions = champs détectés de la
- * couche (avec type et taux de remplissage), saisie libre toujours possible.
- */
-function fieldInput(opts: {
-  id: string;
-  label: string;
-  value: string;
-  fields: FieldInfo[];
-  hint?: string;
-  placeholder?: string;
-  numericOnly?: boolean;
-}): string {
-  const candidates = opts.numericOnly
-    ? opts.fields.filter((f) => f.type === 'number')
-    : opts.fields;
-  const options = candidates
-    .map(
-      (f) =>
-        `<option value="${escapeAttr(f.name)}" label="${escapeAttr(
-          `${f.name} — ${f.type}, ${Math.round(f.fillRate * 100)} % renseigné`
-        )}"></option>`
-    )
-    .join('');
-  return `
-    <div class="carto-field">
-      <label for="${opts.id}">${opts.label}
-        ${opts.hint ? `<span class="fr-hint-text">${opts.hint}</span>` : ''}
-      </label>
-      <input type="text" id="${opts.id}" value="${escapeAttr(opts.value)}"
-             list="${opts.id}-list" ${opts.placeholder ? `placeholder="${escapeAttr(opts.placeholder)}"` : ''}
-             autocomplete="off">
-      <datalist id="${opts.id}-list">${options}</datalist>
-    </div>`;
-}
-
-// ---------------------------------------------------------------------------
-// Col 1: Layers list
-// ---------------------------------------------------------------------------
-
-function renderLayersList() {
+function renderLayersPanel() {
   const list = document.getElementById('layers-list')!;
+  const removable = state.layers.length > 1;
   list.innerHTML = state.layers
     .map(
       (layer) => `
     <li class="carto-layers__item ${layer.id === state.activeLayerId ? 'carto-layers__item--active' : ''}"
         data-layer-id="${layer.id}">
-      <span class="carto-layers__item-drag" title="Glisser pour reordonner"><i class="ri-draggable"></i></span>
       <div class="carto-layers__item-info">
         <div class="carto-layers__item-header">
           <span class="carto-layers__item-name">${escapeAttr(layer.name)}</span>
           <span class="carto-layers__item-type">${LAYER_TYPE_LABELS[layer.type]}${layer.noInteractive ? ' · décor' : ''}</span>
         </div>
-        <span class="carto-layers__item-source">${layer.source ? escapeAttr(String(layer.source.name || layer.source.datasetId || 'Source configurée')) : '<span style="color:var(--text-default-warning)">Aucune source</span>'}</span>
+        <span class="carto-layers__item-source ${layer.source ? '' : 'carto-layers__item-source--missing'}">${
+          layer.source
+            ? escapeAttr(String(layer.source.name || layer.source.datasetId || 'Source configurée'))
+            : 'Aucune source'
+        }</span>
       </div>
-      <div class="carto-layers__item-actions">
-        <button class="carto-layers__btn-eye ${layer.visible ? '' : 'carto-layers__btn-eye--hidden'}"
-                data-eye-id="${layer.id}" title="${layer.visible ? 'Masquer' : 'Afficher'}">
-          <i class="${layer.visible ? 'ri-eye-line' : 'ri-eye-off-line'}"></i>
-        </button>
-      </div>
+      <button class="carto-icon-btn" data-eye-id="${layer.id}" type="button"
+              title="${layer.visible ? 'Masquer la couche' : 'Afficher la couche'}"
+              aria-label="${layer.visible ? 'Masquer la couche' : 'Afficher la couche'} ${escapeAttr(layer.name)}">
+        <i class="${layer.visible ? 'ri-eye-line' : 'ri-eye-off-line'}" aria-hidden="true"></i>
+      </button>
+      ${
+        removable
+          ? `<button class="carto-icon-btn" data-del-id="${layer.id}" type="button"
+              title="Supprimer la couche" aria-label="Supprimer la couche ${escapeAttr(layer.name)}">
+              <i class="ri-delete-bin-line" aria-hidden="true"></i>
+            </button>`
+          : ''
+      }
     </li>
   `
     )
     .join('');
 
-  // Click handlers: select layer
+  // Sélection de couche
   list.querySelectorAll('.carto-layers__item').forEach((el) => {
     el.addEventListener('click', (e) => {
-      // Don't select when clicking eye button or drag handle
-      if (
-        (e.target as HTMLElement).closest('.carto-layers__btn-eye') ||
-        (e.target as HTMLElement).closest('.carto-layers__item-drag')
-      )
-        return;
+      if ((e.target as HTMLElement).closest('.carto-icon-btn')) return;
       state.activeLayerId = el.getAttribute('data-layer-id')!;
-      renderLayersList();
-      renderLayerConfig();
+      renderAll();
       persistState();
     });
   });
 
-  // Eye toggle
-  list.querySelectorAll('.carto-layers__btn-eye').forEach((btn) => {
+  // Afficher / masquer
+  list.querySelectorAll('[data-eye-id]').forEach((btn) => {
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
-      const layerId = (btn as HTMLElement).getAttribute('data-eye-id')!;
-      const layer = state.layers.find((l) => l.id === layerId);
+      const layer = state.layers.find((l) => l.id === btn.getAttribute('data-eye-id'));
       if (layer) {
         layer.visible = !layer.visible;
-        renderLayersList();
+        renderLayersPanel();
         updateCodePreview();
       }
     });
   });
 
-  // Drag & drop
+  // Supprimer
+  list.querySelectorAll('[data-del-id]').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const id = btn.getAttribute('data-del-id')!;
+      if (state.layers.length <= 1) return;
+      state.layers = state.layers.filter((l) => l.id !== id);
+      if (state.activeLayerId === id) state.activeLayerId = state.layers[0].id;
+      renderAll();
+      updateCodePreview();
+    });
+  });
+
   initDragListeners();
+  renderLayerDataConfig();
 }
 
-// ---------------------------------------------------------------------------
-// Col 1: Map config (below layers list)
-// ---------------------------------------------------------------------------
-
-function renderMapConfig() {
-  const m = state.map;
-  const container = document.getElementById('map-config')!;
-  const hasTimeline = state.layers.some((l) => l.visible && l.timeField);
-  const insetCount = m.insets.length;
-  const otherTerritories = INSET_TERRITORIES.filter((t) => !t.drom);
-  const allDromChecked = DROM_IDS.every((id) => m.insets.includes(id));
-
-  container.innerHTML = `
-    <div class="config-section" id="section-map-config">
-      <div class="config-section-header" onclick="toggleSection('section-map-config')">
-        <h3><i class="ri-map-2-line"></i> Carte</h3>
-        <i class="ri-arrow-down-s-line collapse-icon"></i>
-      </div>
-      <div class="config-section-content">
-        <div class="carto-field">
-          <label for="map-name">Nom (accessibilité)
-            <span class="fr-hint-text">Décrit la carte aux lecteurs d'écran</span>
-          </label>
-          <input type="text" id="map-name" value="${escapeAttr(m.name)}" placeholder="Ma carte">
-        </div>
-        <div class="carto-field">
-          <label for="map-tiles">Fond de carte</label>
-          <select id="map-tiles" class="fr-select fr-select--sm">
-            <optgroup label="IGN (souverain)">
-              <option value="ign-plan" ${m.tiles === 'ign-plan' || m.tiles === 'ign-topo' ? 'selected' : ''}>IGN Plan</option>
-              <option value="ign-ortho" ${m.tiles === 'ign-ortho' ? 'selected' : ''}>IGN Ortho (satellite)</option>
-              <option value="ign-cadastre" ${m.tiles === 'ign-cadastre' ? 'selected' : ''}>IGN Cadastre</option>
-            </optgroup>
-            <optgroup label="Autres">
-              <option value="osm" ${m.tiles === 'osm' ? 'selected' : ''}>OpenStreetMap France</option>
-              <option value="osm-standard" ${m.tiles === 'osm-standard' ? 'selected' : ''}>OpenStreetMap</option>
-              <option value="carto-positron" ${m.tiles === 'carto-positron' ? 'selected' : ''}>CARTO clair (dataviz)</option>
-              <option value="carto-dark" ${m.tiles === 'carto-dark' ? 'selected' : ''}>CARTO sombre</option>
-              <option value="opentopomap" ${m.tiles === 'opentopomap' ? 'selected' : ''}>OpenTopoMap (relief)</option>
-            </optgroup>
-          </select>
-        </div>
-        <div class="carto-inline">
-          <div class="carto-field">
-            <label for="map-center">Centre (lat,lon)
-              <span class="fr-hint-text">46.6,2.4 = France entière</span>
-            </label>
-            <input type="text" id="map-center" value="${escapeAttr(m.center)}">
-          </div>
-          <div class="carto-field">
-            <label for="map-zoom">Zoom
-              <span class="fr-hint-text">6 = France, 12 = ville</span>
-            </label>
-            <input type="number" id="map-zoom" value="${m.zoom}" min="1" max="18">
-          </div>
-        </div>
-        <div class="carto-field">
-          <label for="map-height">Hauteur
-            <span class="fr-hint-text">px, vh, ou % de la largeur (ex : 500px, 60%)</span>
-          </label>
-          <input type="text" id="map-height" value="${escapeAttr(m.height)}" placeholder="500px">
-        </div>
-        <div class="carto-checkbox">
-          <input type="checkbox" id="map-fit-bounds" ${m.fitBounds ? 'checked' : ''}>
-          <label for="map-fit-bounds">Cadrer automatiquement sur les données (fit-bounds)</label>
-        </div>
-      </div>
-    </div>
-
-    <div class="config-section collapsed" id="section-insets">
-      <div class="config-section-header" onclick="toggleSection('section-insets')">
-        <h3><i class="ri-collage-line"></i> Encarts territoriaux${insetCount ? ` <span class="carto-badge">${insetCount}</span>` : ''}</h3>
-        <i class="ri-arrow-down-s-line collapse-icon"></i>
-      </div>
-      <div class="config-section-content">
-        <p class="fr-text--xs fr-mb-1w" style="color:var(--text-mention-grey)">
-          Affiche les territoires ultramarins et la Corse en vignettes à côté de la carte.
-          Les couches y sont automatiquement reprises.
-        </p>
-        <div class="carto-checkbox">
-          <input type="checkbox" id="inset-drom" ${allDromChecked ? 'checked' : ''}>
-          <label for="inset-drom"><strong>Les 5 DROM</strong> (Guadeloupe, Martinique, Guyane, La Réunion, Mayotte)</label>
-        </div>
-        <details class="carto-advanced" ${m.insets.some((id) => !DROM_IDS.includes(id)) ? 'open' : ''}>
-          <summary>Territoire par territoire</summary>
-          ${INSET_TERRITORIES.map(
-            (t) => `
-          <div class="carto-checkbox">
-            <input type="checkbox" id="inset-${t.id}" data-inset="${t.id}" ${m.insets.includes(t.id) ? 'checked' : ''}>
-            <label for="inset-${t.id}">${t.label}</label>
-          </div>`
-          ).join('')}
-        </details>
-        ${otherTerritories.length ? '' : ''}
-      </div>
-    </div>
-
-    <div class="config-section collapsed" id="section-map-advanced">
-      <div class="config-section-header" onclick="toggleSection('section-map-advanced')">
-        <h3><i class="ri-equalizer-line"></i> Réglages avancés</h3>
-        <i class="ri-arrow-down-s-line collapse-icon"></i>
-      </div>
-      <div class="config-section-content">
-        <div class="carto-inline">
-          <div class="carto-field">
-            <label for="map-min-zoom">Zoom min</label>
-            <input type="number" id="map-min-zoom" value="${m.minZoom}" min="1" max="18">
-          </div>
-          <div class="carto-field">
-            <label for="map-max-zoom">Zoom max</label>
-            <input type="number" id="map-max-zoom" value="${m.maxZoom}" min="1" max="18">
-          </div>
-        </div>
-        <div class="carto-field">
-          <label for="map-max-bounds">Limites (max-bounds)
-            <span class="fr-hint-text">Borne la navigation ET le cadrage automatique : lat-sud,lon-ouest,lat-nord,lon-est</span>
-          </label>
-          <input type="text" id="map-max-bounds" value="${escapeAttr(m.maxBounds)}" placeholder="41.0,-5.5,51.5,10.0">
-        </div>
-        <div class="carto-checkbox">
-          <input type="checkbox" id="map-no-controls" ${m.noControls ? 'checked' : ''}>
-          <label for="map-no-controls">Masquer les contrôles de zoom (no-controls)</label>
-        </div>
-        <div class="carto-checkbox">
-          <input type="checkbox" id="map-locked" ${m.locked ? 'checked' : ''}>
-          <label for="map-locked">Carte figée, aucune interaction (locked)
-            <span class="fr-hint-text">Pour une vignette ou une carte purement illustrative</span>
-          </label>
-        </div>
-        <div class="carto-checkbox">
-          <input type="checkbox" id="map-sovereign" ${m.sovereignOnly ? 'checked' : ''}>
-          <label for="map-sovereign">Fonds souverains uniquement (sovereign-only)
-            <span class="fr-hint-text">Restreint aux fonds IGN, exigence de certaines administrations</span>
-          </label>
-        </div>
-        <div class="carto-checkbox">
-          <input type="checkbox" id="map-a11y" ${m.a11y ? 'checked' : ''}>
-          <label for="map-a11y">Compagnon d'accessibilité (recommandé)
-            <span class="fr-hint-text">Ajoute le tableau des données et l'export CSV sous la carte</span>
-          </label>
-        </div>
-        ${
-          hasTimeline
-            ? `
-        <hr class="fr-mt-1w fr-mb-1w">
-        <p class="fr-text--sm fr-mb-1w"><i class="ri-play-circle-line"></i> Lecture temporelle</p>
-        <div class="carto-inline">
-          <div class="carto-field">
-            <label for="map-timeline-speed">Vitesse</label>
-            <select id="map-timeline-speed" class="fr-select fr-select--sm">
-              ${[0.5, 1, 2, 4].map((v) => `<option value="${v}" ${m.timelineSpeed === v ? 'selected' : ''}>× ${v}</option>`).join('')}
-            </select>
-          </div>
-          <div class="carto-field">
-            <label for="map-timeline-interval">Intervalle (ms)</label>
-            <input type="number" id="map-timeline-interval" value="${m.timelineInterval}" min="50" max="10000" step="50">
-          </div>
-        </div>
-        `
-            : ''
-        }
-      </div>
-    </div>
-
-    <div class="config-section collapsed" id="section-gen-mode">
-      <div class="config-section-header" onclick="toggleSection('section-gen-mode')">
-        <h3><i class="ri-code-s-slash-line"></i> Mode de génération</h3>
-        <i class="ri-arrow-down-s-line collapse-icon"></i>
-      </div>
-      <div class="config-section-content">
-        <div class="carto-field">
-          <label class="fr-label fr-label--sm" for="gen-mode">Mode</label>
-          <select id="gen-mode" class="fr-select fr-select--sm">
-            <option value="embedded" ${state.generationMode === 'embedded' ? 'selected' : ''}>Embarqué (composants seuls)</option>
-            <option value="dynamic" ${state.generationMode === 'dynamic' ? 'selected' : ''}>Autonome (avec scripts/CSS)</option>
-          </select>
-        </div>
-      </div>
-    </div>
-  `;
-
-  // Bind map config
-  const bindMap = (id: string, key: keyof typeof m, transform?: (v: string) => unknown) => {
-    const el = document.getElementById(id) as HTMLInputElement | HTMLSelectElement | null;
-    if (!el) return;
-    el.addEventListener('change', () => {
-      const val =
-        (el as HTMLInputElement).type === 'checkbox'
-          ? (el as HTMLInputElement).checked
-          : transform
-            ? transform(el.value)
-            : el.value;
-      (m as unknown as Record<string, unknown>)[key] = val;
-      updateCodePreview();
-    });
-  };
-
-  bindMap('map-name', 'name');
-  bindMap('map-tiles', 'tiles');
-  bindMap('map-center', 'center');
-  bindMap('map-zoom', 'zoom', Number);
-  bindMap('map-height', 'height');
-  bindMap('map-min-zoom', 'minZoom', Number);
-  bindMap('map-max-zoom', 'maxZoom', Number);
-  bindMap('map-max-bounds', 'maxBounds');
-  bindMap('map-fit-bounds', 'fitBounds');
-  bindMap('map-no-controls', 'noControls');
-  bindMap('map-locked', 'locked');
-  bindMap('map-sovereign', 'sovereignOnly');
-  bindMap('map-a11y', 'a11y');
-  bindMap('map-timeline-speed', 'timelineSpeed', Number);
-  bindMap('map-timeline-interval', 'timelineInterval', Number);
-
-  // Encarts : groupe DROM + territoires individuels
-  const dromEl = document.getElementById('inset-drom') as HTMLInputElement | null;
-  dromEl?.addEventListener('change', () => {
-    if (dromEl.checked) {
-      for (const id of DROM_IDS) if (!m.insets.includes(id)) m.insets.push(id);
-    } else {
-      m.insets = m.insets.filter((id) => !DROM_IDS.includes(id));
-    }
-    renderMapConfig();
-    keepSectionOpen('section-insets');
-    updateCodePreview();
-  });
-  container.querySelectorAll('[data-inset]').forEach((el) => {
-    el.addEventListener('change', () => {
-      const id = (el as HTMLInputElement).getAttribute('data-inset')!;
-      if ((el as HTMLInputElement).checked) {
-        if (!m.insets.includes(id)) m.insets.push(id);
-      } else {
-        m.insets = m.insets.filter((i) => i !== id);
-      }
-      renderMapConfig();
-      keepSectionOpen('section-insets');
-      updateCodePreview();
-    });
-  });
-
-  const genEl = document.getElementById('gen-mode') as HTMLSelectElement;
-  genEl?.addEventListener('change', () => {
-    state.generationMode = genEl.value as 'embedded' | 'dynamic';
-    updateCodePreview();
-  });
-}
-
-/** Après un re-render de colonne, rouvre la section demandée (UX accordéon). */
-function keepSectionOpen(sectionId: string) {
-  const section = document.getElementById(sectionId);
-  if (!section) return;
-  const parent = section.parentElement;
-  parent?.querySelectorAll('.config-section').forEach((s) => s.classList.add('collapsed'));
-  section.classList.remove('collapsed');
-}
-
-// ---------------------------------------------------------------------------
-// Col 2: Active layer config (accordions)
-// ---------------------------------------------------------------------------
-
-/** Section actuellement ouverte dans la colonne couche (persistée au re-render). */
-function currentOpenLayerSection(): string | null {
-  const open = document.querySelector('#layer-config .config-section:not(.collapsed)');
-  return open?.id ?? null;
-}
-
-function renderLayerConfig(openSection?: string | null) {
-  const container = document.getElementById('layer-config')!;
+/** Sections Données + Localisation de la couche active (panneau Couches). */
+function renderLayerDataConfig() {
+  const container = document.getElementById('layer-data-config')!;
   const layer = getActiveLayer();
   if (!layer) {
-    container.innerHTML =
-      '<p class="carto-col-config__empty"><i class="ri-information-line"></i><br>Sélectionnez une couche.</p>';
+    container.innerHTML = '';
     return;
   }
 
-  const savedSources = loadSavedSources();
-  const isPopupOrPanel =
-    layer.popupMode === 'popup' ||
-    layer.popupMode === 'panel-right' ||
-    layer.popupMode === 'panel-left';
-  const isPanel = layer.popupMode === 'panel-right' || layer.popupMode === 'panel-left';
   const fields = layer.fields;
-  const fieldsBadge = fields.length
-    ? `<span class="carto-badge carto-badge--ok">${fields.length} champs</span>`
+  const sourceName = layer.source
+    ? String(layer.source.name || layer.source.datasetId || layer.source.apiUrl || 'Source')
     : '';
+  const sourceDetail = fields.length
+    ? `${fields.length} champs détectés`
+    : 'Analyse des champs en cours…';
 
   container.innerHTML = `
-    <!-- Section: Données -->
-    <div class="config-section" id="section-source">
-      <div class="config-section-header" onclick="toggleSection('section-source')">
-        <h3><i class="ri-database-2-line"></i> Données ${fieldsBadge}</h3>
-        <i class="ri-arrow-down-s-line collapse-icon"></i>
+    <div class="carto-section">
+      <div class="carto-section__label">
+        <span>Données</span>
+        ${layer.source ? '<button id="btn-change-source" class="carto-text-link" type="button">Changer</button>' : ''}
       </div>
-      <div class="config-section-content">
-        <div class="carto-field">
-          <label for="layer-source">Source enregistrée
-            <span class="fr-hint-text">Créées dans l'application Sources</span>
-          </label>
-          <select id="layer-source" class="fr-select fr-select--sm">
-            <option value="">-- Choisir une source --</option>
-            ${savedSources.map((s: AnySource) => `<option value="${s.id}" ${layer.source?.id === s.id ? 'selected' : ''}>${escapeAttr(String(s.name || s.datasetId || s.url || ''))}</option>`).join('')}
-          </select>
+      ${
+        layer.source
+          ? `
+      <div class="carto-source-ok">
+        <i class="ri-check-line" aria-hidden="true"></i>
+        <div class="carto-source-ok__body">
+          <div class="carto-source-ok__name">${escapeAttr(sourceName)}</div>
+          <div class="carto-source-ok__detail">${sourceDetail}</div>
         </div>
-        <div class="carto-field">
-          <label for="layer-source-url">…ou URL d'un jeu de données
-            <span class="fr-hint-text">Lien OpenDataSoft, data.gouv (tabular), Grist ou API JSON</span>
-          </label>
-          <div class="carto-url-row">
-            <input type="text" id="layer-source-url" value="${escapeAttr(layer.source?.adHoc && layer.source?.apiUrl ? layer.source.apiUrl : '')}" placeholder="https://data.economie.gouv.fr/explore/dataset/…">
-            <button class="fr-btn fr-btn--sm fr-btn--secondary" id="btn-source-url" title="Utiliser cette URL">OK</button>
-          </div>
-        </div>
-        <button class="fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-left fr-icon-lightbulb-line fr-mb-1w" id="btn-source-sample">Essayer avec le jeu d'exemple</button>
-        <div id="source-scan-status" class="carto-scan-status" aria-live="polite"></div>
-        <hr class="fr-mt-1w fr-mb-1w">
-        <div class="carto-field">
-          <label for="layer-type">Type de couche</label>
-          <select id="layer-type" class="fr-select fr-select--sm">
-            <option value="marker" ${layer.type === 'marker' ? 'selected' : ''}>Marqueurs (points d'intérêt)</option>
-            <option value="geoshape" ${layer.type === 'geoshape' ? 'selected' : ''}>Zones colorées (contours, choroplèthe)</option>
-            <option value="circle" ${layer.type === 'circle' ? 'selected' : ''}>Cercles proportionnels</option>
-            <option value="heatmap" ${layer.type === 'heatmap' ? 'selected' : ''}>Carte de chaleur</option>
-          </select>
-        </div>
-        <div class="carto-field">
-          <label for="layer-name">Nom de la couche</label>
-          <input type="text" id="layer-name" value="${escapeAttr(layer.name)}">
-        </div>
+      </div>`
+          : `
+      <button id="btn-choose-source" class="carto-source-choose" type="button">
+        <i class="ri-database-2-line" aria-hidden="true"></i> Choisir les données de cette couche
+      </button>`
+      }
+      <div id="source-scan-status" class="carto-scan-status" aria-live="polite"></div>
+      <div class="carto-field fr-mt-1w">
+        <label for="layer-name">Nom de la couche</label>
+        <input type="text" id="layer-name" value="${escapeAttr(layer.name)}">
       </div>
     </div>
-
-    <!-- Section: Localisation -->
-    <div class="config-section collapsed" id="section-geo">
-      <div class="config-section-header" onclick="toggleSection('section-geo')">
-        <h3><i class="ri-map-pin-2-line"></i> Localisation</h3>
-        <i class="ri-arrow-down-s-line collapse-icon"></i>
+    ${
+      layer.source
+        ? `
+    <div class="carto-section">
+      <div class="carto-section__label"><span>Localisation</span></div>
+      ${
+        hasLocation(layer)
+          ? `<p class="carto-msg carto-msg--ok"><i class="ri-magic-line" aria-hidden="true"></i> Champs détectés automatiquement — modifiez si besoin</p>`
+          : `<p class="carto-msg carto-msg--warn"><i class="ri-alert-line" aria-hidden="true"></i> Requis : sans localisation, rien ne s'affiche sur la carte</p>`
+      }
+      <div class="carto-inline">
+        ${fieldInput({ id: 'layer-lat', label: 'Latitude', value: layer.latField, fields, numericOnly: true, placeholder: 'latitude' })}
+        ${fieldInput({ id: 'layer-lon', label: 'Longitude', value: layer.lonField, fields, numericOnly: true, placeholder: 'longitude' })}
       </div>
-      <div class="config-section-content">
+      <details class="carto-advanced" ${layer.geoField ? 'open' : ''}>
+        <summary>…ou un champ géographique unique</summary>
         ${fieldInput({
           id: 'layer-geo-field',
           label: 'Champ géographique',
@@ -656,181 +433,149 @@ function renderLayerConfig(openSection?: string | null) {
           hint: 'Colonne contenant la géométrie (GeoJSON, point, texte JSON)',
           placeholder: 'geo_point_2d, geo_shape…',
         })}
-        <p class="fr-text--xs fr-mb-1w" style="color:var(--text-mention-grey)">ou coordonnées séparées :</p>
-        <div class="carto-inline">
-          ${fieldInput({ id: 'layer-lat', label: 'Latitude', value: layer.latField, fields, numericOnly: true, placeholder: 'latitude' })}
-          ${fieldInput({ id: 'layer-lon', label: 'Longitude', value: layer.lonField, fields, numericOnly: true, placeholder: 'longitude' })}
-        </div>
-        <p class="fr-text--xs" style="color:var(--text-mention-grey)">
-          <i class="ri-magic-line"></i> Ces champs sont proposés automatiquement après l'analyse de la source.
-        </p>
+      </details>
+    </div>`
+        : ''
+    }
+  `;
+
+  document.getElementById('btn-change-source')?.addEventListener('click', () => {
+    ui.forceChooser = true;
+    renderOnboard();
+  });
+  document.getElementById('btn-choose-source')?.addEventListener('click', () => {
+    ui.forceChooser = true;
+    renderOnboard();
+  });
+
+  const nameEl = document.getElementById('layer-name') as HTMLInputElement | null;
+  nameEl?.addEventListener('change', () => {
+    layer.name = nameEl.value;
+    renderLayersPanel();
+    updateCodePreview();
+  });
+
+  const bindGeo = (id: string, key: 'latField' | 'lonField' | 'geoField') => {
+    const el = document.getElementById(id) as HTMLInputElement | null;
+    el?.addEventListener('change', () => {
+      layer[key] = el.value;
+      renderLayerDataConfig();
+      updateCodePreview();
+    });
+  };
+  bindGeo('layer-lat', 'latField');
+  bindGeo('layer-lon', 'lonField');
+  bindGeo('layer-geo-field', 'geoField');
+}
+
+// ---------------------------------------------------------------------------
+// Panneau Éléments : représentation, couleur, interactions, animation, avancé
+// ---------------------------------------------------------------------------
+
+/** Cases à cocher « Champs à afficher » (fiche/panneau), repli input texte. */
+function popupFieldsHtml(layer: LayerConfig): string {
+  const known = layer.fields.map((f) => f.name);
+  const chosen = layer.popupFields
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean);
+  if (!known.length) {
+    return `
+      <div class="carto-field">
+        <label for="layer-popup-fields">Champs à afficher
+          <span class="fr-hint-text">Noms de colonnes séparés par des virgules. Vide = toutes les colonnes.</span>
+        </label>
+        <input type="text" id="layer-popup-fields" value="${escapeAttr(layer.popupFields)}" placeholder="nom,adresse,prix">
+      </div>`;
+  }
+  const all = [...new Set([...known, ...chosen])];
+  return `
+    <div class="carto-field">
+      <span class="carto-field__legend" style="display:block;font-size:0.8125rem;font-weight:600;margin-bottom:0.25rem">Champs à afficher
+        <span class="fr-hint-text">Aucun coché = toutes les colonnes</span>
+      </span>
+      <div class="carto-field-checks">
+        ${all
+          .map(
+            (f) => `
+        <label><input type="checkbox" data-pf="${escapeAttr(f)}" ${chosen.includes(f) ? 'checked' : ''}>${escapeAttr(f)}</label>`
+          )
+          .join('')}
       </div>
-    </div>
+    </div>`;
+}
 
-    <!-- Section: Informations -->
-    <div class="config-section collapsed" id="section-info">
-      <div class="config-section-header" onclick="toggleSection('section-info')">
-        <h3><i class="ri-information-line"></i> Informations</h3>
-        <i class="ri-arrow-down-s-line collapse-icon"></i>
+function renderElementsPanel() {
+  const container = document.getElementById('layer-config')!;
+  const layer = getActiveLayer();
+  if (!layer) {
+    container.innerHTML =
+      '<p class="carto-msg carto-msg--muted carto-section"><i class="ri-information-line" aria-hidden="true"></i> Sélectionnez une couche.</p>';
+    return;
+  }
+  if (!layer.source) {
+    container.innerHTML =
+      '<p class="carto-msg carto-msg--muted carto-section"><i class="ri-information-line" aria-hidden="true"></i> Choisissez d\'abord les données de la couche.</p>';
+    return;
+  }
+
+  const fields = layer.fields;
+  const isPopupOrPanel =
+    layer.popupMode === 'popup' ||
+    layer.popupMode === 'panel-right' ||
+    layer.popupMode === 'panel-left';
+  const isPanel = layer.popupMode === 'panel-right' || layer.popupMode === 'panel-left';
+  const customColor = !SWATCHES.some((sw) => sw.c === layer.color);
+  const advancedOpen =
+    layer.filter ||
+    layer.maxItems !== 5000 ||
+    layer.minZoom !== 0 ||
+    layer.maxZoom !== 18 ||
+    layer.bbox ||
+    layer.noInteractive ||
+    layer.shapeClass ||
+    (layer.type === 'circle' && layer.fillOpacity !== 0.6);
+
+  container.innerHTML = `
+    <div class="carto-section fr-pt-1w">
+      <div class="carto-section__label"><span>Représentation</span></div>
+      <div class="carto-tiles">
+        ${TYPE_TILES.map(
+          (t) => `
+        <button type="button" class="carto-tile ${layer.type === t.k ? 'carto-tile--active' : ''}"
+                data-type="${t.k}" title="${t.desc}">
+          <i class="${t.icon}" aria-hidden="true"></i>
+          <span class="carto-tile__label">${t.label}</span>
+          <span class="carto-tile__desc">${t.desc}</span>
+        </button>`
+        ).join('')}
       </div>
-      <div class="config-section-content">
-        ${
-          layer.noInteractive
-            ? `<p class="fr-text--sm" style="color:var(--text-mention-grey)"><i class="ri-eye-off-line"></i>
-               Couche décorative : aucune interaction (voir Apparence &gt; Avancé).</p>`
-            : `
-        <div class="carto-field">
-          <label for="layer-popup-mode">Au clic ou au survol, afficher…</label>
-          <select id="layer-popup-mode" class="fr-select fr-select--sm">
-            <option value="none" ${layer.popupMode === 'none' ? 'selected' : ''}>Rien</option>
-            <option value="tooltip" ${layer.popupMode === 'tooltip' ? 'selected' : ''}>Une infobulle au survol</option>
-            <option value="popup" ${layer.popupMode === 'popup' ? 'selected' : ''}>Une popup au clic</option>
-            <option value="panel-right" ${layer.popupMode === 'panel-right' ? 'selected' : ''}>Un panneau latéral droit</option>
-            <option value="panel-left" ${layer.popupMode === 'panel-left' ? 'selected' : ''}>Un panneau latéral gauche</option>
-          </select>
+
+      ${
+        layer.type === 'marker'
+          ? `
+      <div class="fr-mt-1w">
+        <div class="carto-checkbox">
+          <input type="checkbox" id="layer-cluster" ${layer.cluster ? 'checked' : ''}>
+          <label for="layer-cluster">Regrouper les points proches (clustering)</label>
         </div>
-
         ${
-          layer.popupMode === 'tooltip'
-            ? fieldInput({
-                id: 'layer-tooltip',
-                label: 'Champ affiché en infobulle',
-                value: layer.tooltipField,
-                fields,
-                placeholder: 'nom, denomination…',
-              })
-            : ''
-        }
-
-        ${
-          isPopupOrPanel
+          layer.cluster
             ? `
-        ${fieldInput({
-          id: 'layer-title-field',
-          label: 'Champ titre',
-          value: layer.titleField,
-          fields,
-          hint: 'Titre en haut de la popup ou du panneau',
-          placeholder: 'nom',
-        })}
         <div class="carto-field">
-          <label for="layer-popup-fields">Champs affichés
-            <span class="fr-hint-text">Noms de colonnes séparés par des virgules. Vide = toutes les colonnes.</span>
-          </label>
-          <input type="text" id="layer-popup-fields" value="${escapeAttr(layer.popupFields)}" placeholder="nom,adresse,prix">
-        </div>
-        <details class="carto-advanced" ${layer.popupTemplate ? 'open' : ''}>
-          <summary>Mise en forme avancée (template HTML)</summary>
-          <div class="carto-field">
-            <label for="layer-popup-template">Template
-              <span class="fr-hint-text">{{champ}} insère la valeur, {{champ:number}} formate un nombre</span>
-            </label>
-            <textarea id="layer-popup-template" placeholder="&lt;h3&gt;{{nom}}&lt;/h3&gt;&#10;&lt;p&gt;{{adresse}}&lt;/p&gt;">${escapeAttr(layer.popupTemplate)}</textarea>
-          </div>
-          ${
-            isPanel
-              ? `
-          <div class="carto-field">
-            <label for="layer-popup-width">Largeur du panneau</label>
-            <input type="text" id="layer-popup-width" value="${escapeAttr(layer.popupWidth)}" placeholder="350px">
-          </div>`
-              : ''
-          }
-        </details>
-        `
-            : ''
-        }`
-        }
-      </div>
-    </div>
-
-    <!-- Section: Apparence -->
-    <div class="config-section collapsed" id="section-style">
-      <div class="config-section-header" onclick="toggleSection('section-style')">
-        <h3><i class="ri-palette-line"></i> Apparence</h3>
-        <i class="ri-arrow-down-s-line collapse-icon"></i>
-      </div>
-      <div class="config-section-content">
-        <div class="carto-field">
-          <label for="layer-color">Couleur ${layer.colorField ? '(par défaut)' : ''}</label>
-          <input type="color" id="layer-color" value="${layer.color}">
-        </div>
-
-        ${
-          layer.type === 'geoshape'
-            ? `
-        ${fieldInput({
-          id: 'layer-fill-field',
-          label: 'Colorer selon un champ numérique (choroplèthe)',
-          value: layer.fillField,
-          fields,
-          numericOnly: true,
-          hint: 'Chaque zone prend une teinte selon sa valeur',
-        })}
-        ${
-          layer.fillField
-            ? `
-        <div class="carto-field">
-          <label for="layer-palette">Palette</label>
-          <select id="layer-palette" class="fr-select fr-select--sm">
-            <option value="" ${!layer.selectedPalette ? 'selected' : ''}>Séquentielle (clair → foncé) — défaut</option>
-            <option value="sequentialAscending" ${layer.selectedPalette === 'sequentialAscending' ? 'selected' : ''}>Séquentielle (clair → foncé)</option>
-            <option value="sequentialDescending" ${layer.selectedPalette === 'sequentialDescending' ? 'selected' : ''}>Séquentielle (foncé → clair)</option>
-            <option value="divergentAscending" ${layer.selectedPalette === 'divergentAscending' ? 'selected' : ''}>Divergente (négatif ↔ positif)</option>
-            <option value="divergentDescending" ${layer.selectedPalette === 'divergentDescending' ? 'selected' : ''}>Divergente inversée</option>
-            <option value="neutral" ${layer.selectedPalette === 'neutral' ? 'selected' : ''}>Neutre (gris)</option>
-            <option value="categorical" ${layer.selectedPalette === 'categorical' ? 'selected' : ''}>Catégorielle</option>
-          </select>
+          <label for="layer-cluster-radius">Rayon de regroupement (px)</label>
+          <input type="number" id="layer-cluster-radius" value="${layer.clusterRadius}" min="10" max="200">
         </div>`
             : ''
         }
-        `
-            : ''
-        }
+      </div>`
+          : ''
+      }
 
-        ${
-          layer.type !== 'heatmap'
-            ? `
-        ${fieldInput({
-          id: 'layer-color-field',
-          label: 'Colorer par catégorie',
-          value: layer.colorField,
-          fields,
-          hint: 'Champ dont chaque valeur reçoit sa couleur',
-        })}
-        ${
-          layer.colorField
-            ? `
-        <div class="carto-field">
-          <label for="layer-color-map">Couleur par valeur
-            <span class="fr-hint-text">valeur:#couleur séparées par des virgules. Ex : EPCI:#000091,Commune:#00A95F</span>
-          </label>
-          <textarea id="layer-color-map" rows="3" class="fr-input" placeholder="val1:#couleur1,val2:#couleur2">${escapeAttr(layer.colorMap)}</textarea>
-        </div>
-        `
-            : ''
-        }`
-            : ''
-        }
-
-        ${
-          layer.type === 'marker'
-            ? `
-        <div class="carto-checkbox">
-          <input type="checkbox" id="layer-cluster" ${layer.cluster ? 'checked' : ''}>
-          <label for="layer-cluster">Regrouper les marqueurs proches (clustering)</label>
-        </div>
-        <div class="carto-field" ${!layer.cluster ? 'style="display:none"' : ''} id="cluster-radius-group">
-          <label for="layer-cluster-radius">Rayon de regroupement (px)</label>
-          <input type="number" id="layer-cluster-radius" value="${layer.clusterRadius}" min="10" max="200">
-        </div>
-        `
-            : ''
-        }
-
-        ${
-          layer.type === 'circle'
-            ? `
+      ${
+        layer.type === 'circle'
+          ? `
+      <div class="fr-mt-1w">
         ${fieldInput({
           id: 'layer-radius-field',
           label: 'Taille selon un champ numérique',
@@ -838,11 +583,12 @@ function renderLayerConfig(openSection?: string | null) {
           fields,
           numericOnly: true,
           hint: 'La taille du cercle varie selon la valeur',
+          placeholder: 'population',
         })}
         <div class="carto-inline">
           <div class="carto-field">
             <label for="layer-radius-unit">Unité</label>
-            <select id="layer-radius-unit" class="fr-select fr-select--sm">
+            <select id="layer-radius-unit">
               <option value="px" ${layer.radiusUnit === 'px' ? 'selected' : ''}>Pixels (px)</option>
               <option value="m" ${layer.radiusUnit === 'm' ? 'selected' : ''}>Mètres réels (m)</option>
             </select>
@@ -867,20 +613,22 @@ function renderLayerConfig(openSection?: string | null) {
         </div>`
             : ''
         }
-        `
-            : ''
-        }
+      </div>`
+          : ''
+      }
 
-        ${
-          layer.type === 'heatmap'
-            ? `
+      ${
+        layer.type === 'heatmap'
+          ? `
+      <div class="fr-mt-1w">
         ${fieldInput({
           id: 'layer-heat-field',
           label: 'Champ de pondération',
           value: layer.heatField,
           fields,
           numericOnly: true,
-          hint: 'Intensité de chaleur selon ce champ (vide = chaque point compte 1)',
+          hint: 'Vide = chaque point compte 1',
+          placeholder: 'population',
         })}
         <div class="carto-inline">
           <div class="carto-field">
@@ -892,160 +640,271 @@ function renderLayerConfig(openSection?: string | null) {
             <input type="number" id="layer-heat-blur" value="${layer.heatBlur}" min="1" max="100">
           </div>
         </div>
-        `
-            : ''
-        }
+      </div>`
+          : ''
+      }
 
-        ${
-          layer.type !== 'heatmap'
-            ? `
-        <details class="carto-advanced" ${layer.shapeClass || layer.noInteractive || layer.fillOpacity !== 0.6 ? 'open' : ''}>
-          <summary>Avancé</summary>
-          ${
-            layer.type !== 'marker'
-              ? `
+      ${
+        layer.type === 'geoshape'
+          ? `
+      <div class="fr-mt-1w">
+        ${fieldInput({
+          id: 'layer-fill-field',
+          label: 'Colorer selon un champ numérique (choroplèthe)',
+          value: layer.fillField,
+          fields,
+          numericOnly: true,
+          hint: 'Chaque zone prend une teinte selon sa valeur',
+          placeholder: 'population',
+        })}
+        <div class="carto-inline">
           <div class="carto-field">
-            <label for="layer-fill-opacity">Opacité de remplissage
-              <span class="fr-hint-text">0 = contours seuls, 1 = opaque</span>
-            </label>
+            <label for="layer-palette">Palette</label>
+            <select id="layer-palette">
+              <option value="" ${!layer.selectedPalette ? 'selected' : ''}>Séquentielle (clair → foncé) — défaut</option>
+              <option value="sequentialDescending" ${layer.selectedPalette === 'sequentialDescending' ? 'selected' : ''}>Séquentielle (foncé → clair)</option>
+              <option value="divergentAscending" ${layer.selectedPalette === 'divergentAscending' ? 'selected' : ''}>Divergente (négatif ↔ positif)</option>
+              <option value="divergentDescending" ${layer.selectedPalette === 'divergentDescending' ? 'selected' : ''}>Divergente inversée</option>
+              <option value="neutral" ${layer.selectedPalette === 'neutral' ? 'selected' : ''}>Neutre (gris)</option>
+              <option value="categorical" ${layer.selectedPalette === 'categorical' ? 'selected' : ''}>Catégorielle</option>
+            </select>
+          </div>
+          <div class="carto-field" style="flex:0 0 90px">
+            <label for="layer-fill-opacity">Opacité</label>
             <input type="number" id="layer-fill-opacity" value="${layer.fillOpacity}" min="0" max="1" step="0.1">
           </div>
+        </div>
+      </div>`
+          : ''
+      }
+    </div>
+
+    ${
+      layer.type !== 'heatmap'
+        ? `
+    <div class="carto-section">
+      <div class="carto-section__label"><span>Couleur</span></div>
+      <div class="carto-swatches">
+        ${SWATCHES.map(
+          (sw) => `
+        <button type="button" class="carto-swatch ${layer.color === sw.c ? 'carto-swatch--active' : ''}"
+                data-swatch="${sw.c}" style="background:${sw.c}" title="${sw.n}" aria-label="${sw.n}"></button>`
+        ).join('')}
+        <input type="color" id="layer-color" class="carto-swatch-custom ${customColor ? 'carto-swatch--active' : ''}"
+               value="${layer.color}" title="Couleur personnalisée" aria-label="Couleur personnalisée">
+      </div>
+      <details class="carto-advanced fr-mt-1w" ${layer.colorField ? 'open' : ''}>
+        <summary>Colorer par catégorie</summary>
+        ${fieldInput({
+          id: 'layer-color-field',
+          label: 'Champ catégorie',
+          value: layer.colorField,
+          fields,
+          hint: 'Chaque valeur du champ reçoit sa couleur',
+          placeholder: 'region',
+        })}
+        ${
+          layer.colorField
+            ? `
+        <div class="carto-field">
+          <label for="layer-color-map">Couleur par valeur
+            <span class="fr-hint-text">valeur:#couleur séparées par des virgules</span>
+          </label>
+          <textarea id="layer-color-map" rows="2" placeholder="Corse:#e1000f,Bretagne:#000091">${escapeAttr(layer.colorMap)}</textarea>
+        </div>`
+            : ''
+        }
+      </details>
+    </div>`
+        : ''
+    }
+
+    <div class="carto-section">
+      <div class="carto-section__label"><span>Au clic sur un élément</span></div>
+      ${
+        layer.noInteractive
+          ? `<p class="carto-msg carto-msg--muted"><i class="ri-eye-off-line" aria-hidden="true"></i>
+             Couche décorative : aucune interaction (voir Options avancées).</p>`
+          : `
+      <div class="carto-field">
+        <label for="layer-popup-mode" class="fr-sr-only">Comportement au clic</label>
+        <select id="layer-popup-mode">
+          <option value="none" ${layer.popupMode === 'none' ? 'selected' : ''}>Ne rien afficher</option>
+          <option value="tooltip" ${layer.popupMode === 'tooltip' ? 'selected' : ''}>Le nom, au survol</option>
+          <option value="popup" ${layer.popupMode === 'popup' ? 'selected' : ''}>Une fiche (popup) au clic</option>
+          <option value="panel-right" ${layer.popupMode === 'panel-right' ? 'selected' : ''}>Un panneau latéral droit</option>
+          <option value="panel-left" ${layer.popupMode === 'panel-left' ? 'selected' : ''}>Un panneau latéral gauche</option>
+        </select>
+      </div>
+      ${
+        layer.popupMode === 'tooltip'
+          ? fieldInput({
+              id: 'layer-tooltip',
+              label: 'Champ affiché en infobulle',
+              value: layer.tooltipField,
+              fields,
+              placeholder: 'nom, denomination…',
+            })
+          : ''
+      }
+      ${
+        isPopupOrPanel
+          ? `
+      <details class="carto-advanced" open>
+        <summary>Contenu de la fiche</summary>
+        ${fieldInput({
+          id: 'layer-title-field',
+          label: 'Champ titre',
+          value: layer.titleField,
+          fields,
+          placeholder: 'nom',
+        })}
+        ${popupFieldsHtml(layer)}
+        <details class="carto-advanced" ${layer.popupTemplate ? 'open' : ''}>
+          <summary>Mise en forme avancée (template HTML)</summary>
           <div class="carto-field">
-            <label for="layer-shape-class">Classe CSS des tracés (shape-class)
-              <span class="fr-hint-text">Pour appliquer un style de la page (hachures, pointillés…)</span>
+            <label for="layer-popup-template">Template
+              <span class="fr-hint-text">Écrivez le nom du champ entre doubles accolades pour insérer sa valeur ; ajoutez :number pour formater un nombre</span>
             </label>
-            <input type="text" id="layer-shape-class" value="${escapeAttr(layer.shapeClass)}" placeholder="territoire-hachure">
+            <textarea id="layer-popup-template" rows="3" placeholder="&lt;h3&gt;{{nom}}&lt;/h3&gt;&#10;&lt;p&gt;{{adresse}}&lt;/p&gt;">${escapeAttr(layer.popupTemplate)}</textarea>
+          </div>
+          ${
+            isPanel
+              ? `
+          <div class="carto-field">
+            <label for="layer-popup-width">Largeur du panneau</label>
+            <input type="text" id="layer-popup-width" value="${escapeAttr(layer.popupWidth)}" placeholder="350px">
           </div>`
               : ''
           }
-          <div class="carto-checkbox">
-            <input type="checkbox" id="layer-no-interactive" ${layer.noInteractive ? 'checked' : ''}>
-            <label for="layer-no-interactive">Couche décorative (no-interactive)
-              <span class="fr-hint-text">Habillage : ni clic, ni infobulle, ignorée par le cadrage automatique</span>
-            </label>
-          </div>
-        </details>`
-            : ''
-        }
-      </div>
-    </div>
-
-    <!-- Section: Animation temporelle -->
-    <div class="config-section collapsed" id="section-time">
-      <div class="config-section-header" onclick="toggleSection('section-time')">
-        <h3><i class="ri-history-line"></i> Animation temporelle${layer.timeField ? ' <span class="carto-badge carto-badge--ok">active</span>' : ''}</h3>
-        <i class="ri-arrow-down-s-line collapse-icon"></i>
-      </div>
-      <div class="config-section-content">
-        ${fieldInput({
-          id: 'layer-time-field',
-          label: 'Champ date/heure',
-          value: layer.timeField,
-          fields,
-          hint: 'Renseigner ce champ active les contrôles de lecture sous la carte',
-        })}
-        ${
-          layer.timeField
-            ? `
-        <div class="carto-inline">
-          <div class="carto-field">
-            <label for="layer-time-bucket">Granularité</label>
-            <select id="layer-time-bucket" class="fr-select fr-select--sm">
-              <option value="none" ${layer.timeBucket === 'none' ? 'selected' : ''}>Valeurs brutes</option>
-              <option value="hour" ${layer.timeBucket === 'hour' ? 'selected' : ''}>Heure</option>
-              <option value="day" ${layer.timeBucket === 'day' ? 'selected' : ''}>Jour</option>
-              <option value="month" ${layer.timeBucket === 'month' ? 'selected' : ''}>Mois</option>
-              <option value="year" ${layer.timeBucket === 'year' ? 'selected' : ''}>Année</option>
-            </select>
-          </div>
-          <div class="carto-field">
-            <label for="layer-time-mode">Mode</label>
-            <select id="layer-time-mode" class="fr-select fr-select--sm">
-              <option value="snapshot" ${layer.timeMode === 'snapshot' ? 'selected' : ''}>Instantané (pas à pas)</option>
-              <option value="cumulative" ${layer.timeMode === 'cumulative' ? 'selected' : ''}>Cumulatif (tout jusqu'à la date)</option>
-            </select>
-          </div>
-        </div>
-        <p class="fr-text--xs" style="color:var(--text-mention-grey)">Vitesse et intervalle : colonne de gauche, Réglages avancés.</p>
-        `
-            : ''
-        }
-      </div>
-    </div>
-
-    <!-- Section: Filtres & performances -->
-    <div class="config-section collapsed" id="section-perf">
-      <div class="config-section-header" onclick="toggleSection('section-perf')">
-        <h3><i class="ri-filter-3-line"></i> Filtres &amp; performances</h3>
-        <i class="ri-arrow-down-s-line collapse-icon"></i>
-      </div>
-      <div class="config-section-content">
-        <div class="carto-field">
-          <label for="layer-filter">Filtrer les données
-            <span class="fr-hint-text">Syntaxe champ:opérateur:valeur — ex : type:eq:Commune, prix:gt:100</span>
-          </label>
-          <input type="text" id="layer-filter" value="${escapeAttr(layer.filter)}" placeholder="champ:eq:valeur, champ2:gt:100">
-        </div>
-
-        <div class="carto-field">
-          <label for="layer-max-items">Nombre max d'éléments affichés
-            <span class="fr-hint-text">Au-delà, un bandeau « N affichés sur M » apparaît</span>
-          </label>
-          <input type="number" id="layer-max-items" value="${layer.maxItems}" min="1" max="100000">
-        </div>
-
-        <details class="carto-advanced" ${layer.bbox || layer.minZoom !== 0 || layer.maxZoom !== 18 ? 'open' : ''}>
-          <summary>Chargement et zoom (avancé)</summary>
-          <div class="carto-checkbox">
-            <input type="checkbox" id="layer-bbox" ${layer.bbox ? 'checked' : ''}>
-            <label for="layer-bbox">Charger selon la zone visible (bbox)
-              <span class="fr-hint-text">Pour les très gros jeux de données : seuls les éléments visibles sont chargés</span>
-            </label>
-          </div>
-          ${
-            layer.bbox
-              ? `
-          <div class="carto-inline">
-            <div class="carto-field">
-              <label for="layer-bbox-debounce">Délai après déplacement (ms)</label>
-              <input type="number" id="layer-bbox-debounce" value="${layer.bboxDebounce}" min="0" max="2000">
-            </div>
-            ${fieldInput({ id: 'layer-bbox-field', label: 'Champ géo du filtre', value: layer.bboxField, fields, hint: 'Vide = champ géo de la couche' })}
-          </div>
-          `
-              : ''
-          }
-          <div class="carto-inline">
-            <div class="carto-field">
-              <label for="layer-min-zoom">Visible à partir du zoom</label>
-              <input type="number" id="layer-min-zoom" value="${layer.minZoom}" min="0" max="18">
-            </div>
-            <div class="carto-field">
-              <label for="layer-max-zoom">Jusqu'au zoom</label>
-              <input type="number" id="layer-max-zoom" value="${layer.maxZoom}" min="0" max="18">
-            </div>
-          </div>
         </details>
-      </div>
+      </details>`
+          : ''
+      }`
+      }
     </div>
+
+    <details class="carto-advanced carto-section" ${layer.timeField ? 'open' : ''}>
+      <summary>Animation temporelle</summary>
+      ${fieldInput({
+        id: 'layer-time-field',
+        label: 'Champ date/heure',
+        value: layer.timeField,
+        fields,
+        hint: 'Renseigner ce champ active les contrôles de lecture sur la carte',
+        placeholder: 'date_mesure',
+      })}
+      ${
+        layer.timeField
+          ? `
+      <div class="carto-inline">
+        <div class="carto-field">
+          <label for="layer-time-bucket">Granularité</label>
+          <select id="layer-time-bucket">
+            <option value="none" ${layer.timeBucket === 'none' ? 'selected' : ''}>Valeurs brutes</option>
+            <option value="hour" ${layer.timeBucket === 'hour' ? 'selected' : ''}>Heure</option>
+            <option value="day" ${layer.timeBucket === 'day' ? 'selected' : ''}>Jour</option>
+            <option value="month" ${layer.timeBucket === 'month' ? 'selected' : ''}>Mois</option>
+            <option value="year" ${layer.timeBucket === 'year' ? 'selected' : ''}>Année</option>
+          </select>
+        </div>
+        <div class="carto-field">
+          <label for="layer-time-mode">Mode</label>
+          <select id="layer-time-mode">
+            <option value="snapshot" ${layer.timeMode === 'snapshot' ? 'selected' : ''}>Instantané (pas à pas)</option>
+            <option value="cumulative" ${layer.timeMode === 'cumulative' ? 'selected' : ''}>Cumulatif</option>
+          </select>
+        </div>
+      </div>
+      <div class="carto-inline">
+        <div class="carto-field">
+          <label for="map-timeline-speed">Vitesse</label>
+          <select id="map-timeline-speed">
+            ${[0.5, 1, 2, 4].map((v) => `<option value="${v}" ${state.map.timelineSpeed === v ? 'selected' : ''}>× ${v}</option>`).join('')}
+          </select>
+        </div>
+        <div class="carto-field">
+          <label for="map-timeline-interval">Intervalle (ms)</label>
+          <input type="number" id="map-timeline-interval" value="${state.map.timelineInterval}" min="50" max="10000" step="50">
+        </div>
+      </div>`
+          : ''
+      }
+    </details>
+
+    <details class="carto-advanced carto-section" ${advancedOpen ? 'open' : ''}>
+      <summary>Options avancées</summary>
+      <div class="carto-field">
+        <label for="layer-filter">Filtrer les données
+          <span class="fr-hint-text">champ:opérateur:valeur — ex : population:gt:200000</span>
+        </label>
+        <input type="text" id="layer-filter" value="${escapeAttr(layer.filter)}" placeholder="champ:eq:valeur">
+      </div>
+      <div class="carto-field">
+        <label for="layer-max-items">Nombre max d'éléments affichés
+          <span class="fr-hint-text">Au-delà, un bandeau « N affichés sur M » apparaît</span>
+        </label>
+        <input type="number" id="layer-max-items" value="${layer.maxItems}" min="1" max="100000">
+      </div>
+      <div class="carto-inline">
+        <div class="carto-field">
+          <label for="layer-min-zoom">Visible dès le zoom</label>
+          <input type="number" id="layer-min-zoom" value="${layer.minZoom}" min="0" max="18">
+        </div>
+        <div class="carto-field">
+          <label for="layer-max-zoom">Jusqu'au zoom</label>
+          <input type="number" id="layer-max-zoom" value="${layer.maxZoom}" min="0" max="18">
+        </div>
+      </div>
+      ${
+        layer.type === 'geoshape' || layer.type === 'circle'
+          ? `
+      ${
+        layer.type === 'circle'
+          ? `
+      <div class="carto-field">
+        <label for="layer-fill-opacity">Opacité de remplissage
+          <span class="fr-hint-text">0 = contours seuls, 1 = opaque</span>
+        </label>
+        <input type="number" id="layer-fill-opacity" value="${layer.fillOpacity}" min="0" max="1" step="0.1">
+      </div>`
+          : ''
+      }
+      <div class="carto-field">
+        <label for="layer-shape-class">Classe CSS des tracés (shape-class)
+          <span class="fr-hint-text">Pour appliquer un style de la page (hachures, pointillés…)</span>
+        </label>
+        <input type="text" id="layer-shape-class" value="${escapeAttr(layer.shapeClass)}" placeholder="territoire-hachure">
+      </div>`
+          : ''
+      }
+      <div class="carto-checkbox">
+        <input type="checkbox" id="layer-bbox" ${layer.bbox ? 'checked' : ''}>
+        <label for="layer-bbox">Charger selon la zone visible (bbox) — gros jeux de données</label>
+      </div>
+      ${
+        layer.bbox
+          ? `
+      <div class="carto-inline">
+        <div class="carto-field">
+          <label for="layer-bbox-debounce">Délai après déplacement (ms)</label>
+          <input type="number" id="layer-bbox-debounce" value="${layer.bboxDebounce}" min="0" max="2000">
+        </div>
+        ${fieldInput({ id: 'layer-bbox-field', label: 'Champ géo du filtre', value: layer.bboxField, fields, hint: 'Vide = champ géo de la couche' })}
+      </div>`
+          : ''
+      }
+      <div class="carto-checkbox">
+        <input type="checkbox" id="layer-no-interactive" ${layer.noInteractive ? 'checked' : ''}>
+        <label for="layer-no-interactive">Couche décorative — ni clic, ni infobulle</label>
+      </div>
+    </details>
   `;
 
-  if (openSection) keepSectionOpen(openSection);
-
-  // Bind change events
-  bindLayerInputs(layer);
+  bindElementsInputs(layer);
 }
 
-// ---------------------------------------------------------------------------
-// Bind layer inputs
-// ---------------------------------------------------------------------------
-
-/** Re-render la config couche en conservant la section ouverte. */
-function rerenderLayerConfig() {
-  renderLayerConfig(currentOpenLayerSection());
-}
-
-function bindLayerInputs(layer: LayerConfig) {
+function bindElementsInputs(layer: LayerConfig) {
   const bind = (id: string, key: keyof LayerConfig, transform?: (v: string) => unknown) => {
     const el = document.getElementById(id) as
       HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null;
@@ -1063,175 +922,524 @@ function bindLayerInputs(layer: LayerConfig) {
     });
   };
 
-  // Source enregistrée
-  const sourceEl = document.getElementById('layer-source') as HTMLSelectElement | null;
-  sourceEl?.addEventListener('change', () => {
-    const savedSources = loadSavedSources();
-    const found = savedSources.find((s: AnySource) => s.id === sourceEl.value);
-    layer.source = found ? lightweightSource(found) : null;
-    layer.fields = [];
-    renderLayersList();
-    updateCodePreview();
-    if (layer.source) void scanAndSuggest(layer);
-    else rerenderLayerConfig();
-  });
-
-  // Source par URL directe
-  const urlBtn = document.getElementById('btn-source-url');
-  const urlInput = document.getElementById('layer-source-url') as HTMLInputElement | null;
-  const applyUrl = () => {
-    const url = urlInput?.value.trim();
-    if (!url) return;
-    layer.source = {
-      id: `url-${layer.id}`,
-      name: url.replace(/^https?:\/\//, '').slice(0, 60),
-      type: 'api',
-      apiUrl: url,
-      adHoc: true,
-    };
-    layer.fields = [];
-    renderLayersList();
-    updateCodePreview();
-    void scanAndSuggest(layer);
+  /** Comme bind, mais re-render le panneau (sections conditionnelles). */
+  const bindRerender = (id: string, apply: (value: string, checked: boolean) => void) => {
+    const el = document.getElementById(id) as HTMLInputElement | HTMLSelectElement | null;
+    el?.addEventListener('change', () => {
+      apply(el.value, (el as HTMLInputElement).checked ?? false);
+      renderElementsPanel();
+      updateCodePreview();
+    });
   };
-  urlBtn?.addEventListener('click', applyUrl);
-  urlInput?.addEventListener('keydown', (e) => {
-    if ((e as KeyboardEvent).key === 'Enter') applyUrl();
+
+  // Représentation
+  document.querySelectorAll('#layer-config [data-type]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      layer.type = btn.getAttribute('data-type') as LayerType;
+      renderLayersPanel();
+      renderElementsPanel();
+      updateCodePreview();
+    });
+  });
+  bindRerender('layer-cluster', (_v, checked) => {
+    layer.cluster = checked;
+  });
+  bind('layer-cluster-radius', 'clusterRadius', Number);
+  bind('layer-radius', 'radius', Number);
+  bind('layer-radius-field', 'radiusField');
+  bindRerender('layer-radius-unit', (v) => {
+    layer.radiusUnit = v as 'px' | 'm';
+  });
+  bind('layer-radius-min', 'radiusMin', Number);
+  bind('layer-radius-max', 'radiusMax', Number);
+  bind('layer-heat-radius', 'heatRadius', Number);
+  bind('layer-heat-blur', 'heatBlur', Number);
+  bind('layer-heat-field', 'heatField');
+  bind('layer-fill-field', 'fillField');
+  bind('layer-palette', 'selectedPalette');
+  bind('layer-fill-opacity', 'fillOpacity', Number);
+
+  // Couleur
+  document.querySelectorAll('#layer-config [data-swatch]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      layer.color = btn.getAttribute('data-swatch')!;
+      renderElementsPanel();
+      updateCodePreview();
+    });
+  });
+  const colorEl = document.getElementById('layer-color') as HTMLInputElement | null;
+  colorEl?.addEventListener('change', () => {
+    layer.color = colorEl.value;
+    renderElementsPanel();
+    updateCodePreview();
+  });
+  bindRerender('layer-color-field', (v) => {
+    layer.colorField = v;
+  });
+  bind('layer-color-map', 'colorMap');
+
+  // Interactions
+  bindRerender('layer-popup-mode', (v) => {
+    layer.popupMode = v as PopupMode;
+  });
+  bind('layer-tooltip', 'tooltipField');
+  bind('layer-title-field', 'titleField');
+  bind('layer-popup-fields', 'popupFields');
+  bind('layer-popup-template', 'popupTemplate');
+  bind('layer-popup-width', 'popupWidth');
+
+  // Champs à afficher (cases à cocher)
+  const checks = document.querySelectorAll<HTMLInputElement>('#layer-config [data-pf]');
+  checks.forEach((cb) => {
+    cb.addEventListener('change', () => {
+      layer.popupFields = [...checks]
+        .filter((c) => c.checked)
+        .map((c) => c.getAttribute('data-pf')!)
+        .join(',');
+      updateCodePreview();
+    });
   });
 
-  // Jeu d'exemple
-  document.getElementById('btn-source-sample')?.addEventListener('click', () => {
-    layer.source = {
+  // Animation temporelle
+  bindRerender('layer-time-field', (v) => {
+    layer.timeField = v;
+  });
+  bind('layer-time-bucket', 'timeBucket');
+  bind('layer-time-mode', 'timeMode');
+  const speedEl = document.getElementById('map-timeline-speed') as HTMLSelectElement | null;
+  speedEl?.addEventListener('change', () => {
+    state.map.timelineSpeed = Number(speedEl.value);
+    updateCodePreview();
+  });
+  const intervalEl = document.getElementById('map-timeline-interval') as HTMLInputElement | null;
+  intervalEl?.addEventListener('change', () => {
+    state.map.timelineInterval = Number(intervalEl.value) || 1000;
+    updateCodePreview();
+  });
+
+  // Options avancées
+  bind('layer-filter', 'filter');
+  bind('layer-max-items', 'maxItems', Number);
+  bind('layer-min-zoom', 'minZoom', Number);
+  bind('layer-max-zoom', 'maxZoom', Number);
+  bind('layer-shape-class', 'shapeClass');
+  bindRerender('layer-bbox', (_v, checked) => {
+    layer.bbox = checked;
+  });
+  bind('layer-bbox-debounce', 'bboxDebounce', Number);
+  bind('layer-bbox-field', 'bboxField');
+  bindRerender('layer-no-interactive', (_v, checked) => {
+    layer.noInteractive = checked;
+    renderLayersPanel();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Panneau Carte
+// ---------------------------------------------------------------------------
+
+function renderMapPanel() {
+  const m = state.map;
+  const container = document.getElementById('map-config')!;
+  const allDromChecked = DROM_IDS.every((id) => m.insets.includes(id));
+  const otherInsets = m.insets.filter((id) => !DROM_IDS.includes(id) && id !== 'corse');
+
+  container.innerHTML = `
+    <div class="carto-section">
+      <div class="carto-field">
+        <label for="map-tiles">Fond de carte</label>
+        <select id="map-tiles">
+          <optgroup label="IGN (souverain)">
+            <option value="ign-plan" ${m.tiles === 'ign-plan' || m.tiles === 'ign-topo' ? 'selected' : ''}>IGN Plan</option>
+            <option value="ign-ortho" ${m.tiles === 'ign-ortho' ? 'selected' : ''}>IGN Ortho (satellite)</option>
+            <option value="ign-cadastre" ${m.tiles === 'ign-cadastre' ? 'selected' : ''}>IGN Cadastre</option>
+          </optgroup>
+          <optgroup label="Autres">
+            <option value="osm" ${m.tiles === 'osm' ? 'selected' : ''}>OpenStreetMap France</option>
+            <option value="osm-standard" ${m.tiles === 'osm-standard' ? 'selected' : ''}>OpenStreetMap</option>
+            <option value="carto-positron" ${m.tiles === 'carto-positron' ? 'selected' : ''}>CARTO clair (dataviz)</option>
+            <option value="carto-dark" ${m.tiles === 'carto-dark' ? 'selected' : ''}>CARTO sombre</option>
+            <option value="opentopomap" ${m.tiles === 'opentopomap' ? 'selected' : ''}>OpenTopoMap (relief)</option>
+          </optgroup>
+        </select>
+      </div>
+      <div class="carto-field">
+        <label for="map-name">Nom de la carte
+          <span class="fr-hint-text">Décrit la carte aux lecteurs d'écran</span>
+        </label>
+        <input type="text" id="map-name" value="${escapeAttr(m.name)}" placeholder="Ma carte">
+      </div>
+      <div class="carto-checkbox">
+        <input type="checkbox" id="inset-drom" ${allDromChecked ? 'checked' : ''}>
+        <label for="inset-drom">Les 5 DROM en vignettes (encarts)</label>
+      </div>
+      <div class="carto-checkbox">
+        <input type="checkbox" id="inset-corse" ${m.insets.includes('corse') ? 'checked' : ''}>
+        <label for="inset-corse">La Corse en vignette</label>
+      </div>
+      <details class="carto-advanced" ${otherInsets.length ? 'open' : ''}>
+        <summary>Territoire par territoire</summary>
+        ${INSET_TERRITORIES.map(
+          (t) => `
+        <div class="carto-checkbox">
+          <input type="checkbox" id="inset-${t.id}" data-inset="${t.id}" ${m.insets.includes(t.id) ? 'checked' : ''}>
+          <label for="inset-${t.id}">${t.label}</label>
+        </div>`
+        ).join('')}
+      </details>
+      <div class="carto-checkbox">
+        <input type="checkbox" id="map-a11y" ${m.a11y ? 'checked' : ''}>
+        <label for="map-a11y">Tableau des données sous la carte (accessibilité)
+          <span class="fr-hint-text">Dans le code exporté : tableau + export CSV liés à la carte</span>
+        </label>
+      </div>
+      <details class="carto-advanced">
+        <summary>Réglages avancés de la carte</summary>
+        <div class="carto-inline">
+          <div class="carto-field">
+            <label for="map-min-zoom">Zoom min</label>
+            <input type="number" id="map-min-zoom" value="${m.minZoom}" min="1" max="18">
+          </div>
+          <div class="carto-field">
+            <label for="map-max-zoom">Zoom max</label>
+            <input type="number" id="map-max-zoom" value="${m.maxZoom}" min="1" max="18">
+          </div>
+        </div>
+        <div class="carto-field">
+          <label for="map-max-bounds">Limites (max-bounds)
+            <span class="fr-hint-text">lat-sud,lon-ouest,lat-nord,lon-est</span>
+          </label>
+          <input type="text" id="map-max-bounds" value="${escapeAttr(m.maxBounds)}" placeholder="41.0,-5.5,51.5,10.0">
+        </div>
+        <div class="carto-field">
+          <label for="map-height">Hauteur de la carte exportée
+            <span class="fr-hint-text">px, vh, ou % de la largeur (ex : 500px, 60%)</span>
+          </label>
+          <input type="text" id="map-height" value="${escapeAttr(m.height)}" placeholder="500px">
+        </div>
+        <div class="carto-checkbox">
+          <input type="checkbox" id="map-fit-bounds" ${m.fitBounds ? 'checked' : ''}>
+          <label for="map-fit-bounds">Cadrer automatiquement sur les données (fit-bounds)</label>
+        </div>
+        <div class="carto-checkbox">
+          <input type="checkbox" id="map-no-controls" ${m.noControls ? 'checked' : ''}>
+          <label for="map-no-controls">Masquer les contrôles de zoom (no-controls)</label>
+        </div>
+        <div class="carto-checkbox">
+          <input type="checkbox" id="map-locked" ${m.locked ? 'checked' : ''}>
+          <label for="map-locked">Carte figée, aucune interaction (locked)</label>
+        </div>
+        <div class="carto-checkbox">
+          <input type="checkbox" id="map-sovereign" ${m.sovereignOnly ? 'checked' : ''}>
+          <label for="map-sovereign">Fonds souverains uniquement (sovereign-only)</label>
+        </div>
+      </details>
+      <p class="carto-msg carto-msg--muted"><i class="ri-drag-move-2-line" aria-hidden="true"></i>
+        Le cadrage exporté est celui de la carte : déplacez et zoomez directement.</p>
+    </div>
+  `;
+
+  const bindMap = (id: string, key: keyof typeof m, transform?: (v: string) => unknown) => {
+    const el = document.getElementById(id) as HTMLInputElement | HTMLSelectElement | null;
+    if (!el) return;
+    el.addEventListener('change', () => {
+      const val =
+        (el as HTMLInputElement).type === 'checkbox'
+          ? (el as HTMLInputElement).checked
+          : transform
+            ? transform(el.value)
+            : el.value;
+      (m as unknown as Record<string, unknown>)[key] = val;
+      updateCodePreview();
+    });
+  };
+
+  bindMap('map-tiles', 'tiles');
+  bindMap('map-name', 'name');
+  bindMap('map-a11y', 'a11y');
+  bindMap('map-min-zoom', 'minZoom', Number);
+  bindMap('map-max-zoom', 'maxZoom', Number);
+  bindMap('map-max-bounds', 'maxBounds');
+  bindMap('map-height', 'height');
+  bindMap('map-fit-bounds', 'fitBounds');
+  bindMap('map-no-controls', 'noControls');
+  bindMap('map-locked', 'locked');
+  bindMap('map-sovereign', 'sovereignOnly');
+
+  // Encarts : groupe DROM, Corse, puis territoire par territoire
+  const dromEl = document.getElementById('inset-drom') as HTMLInputElement | null;
+  dromEl?.addEventListener('change', () => {
+    if (dromEl.checked) {
+      for (const id of DROM_IDS) if (!m.insets.includes(id)) m.insets.push(id);
+    } else {
+      m.insets = m.insets.filter((id) => !DROM_IDS.includes(id));
+    }
+    renderMapPanel();
+    updateCodePreview();
+  });
+  const corseEl = document.getElementById('inset-corse') as HTMLInputElement | null;
+  corseEl?.addEventListener('change', () => {
+    if (corseEl.checked) {
+      if (!m.insets.includes('corse')) m.insets.push('corse');
+    } else {
+      m.insets = m.insets.filter((id) => id !== 'corse');
+    }
+    renderMapPanel();
+    updateCodePreview();
+  });
+  container.querySelectorAll('[data-inset]').forEach((el) => {
+    el.addEventListener('change', () => {
+      const id = (el as HTMLInputElement).getAttribute('data-inset')!;
+      if ((el as HTMLInputElement).checked) {
+        if (!m.insets.includes(id)) m.insets.push(id);
+      } else {
+        m.insets = m.insets.filter((i) => i !== id);
+      }
+      renderMapPanel();
+      updateCodePreview();
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Modale « D'où viennent vos données ? »
+// ---------------------------------------------------------------------------
+
+function closeOnboard() {
+  ui.forceChooser = false;
+  ui.urlMode = false;
+  ui.savedOpen = false;
+  renderOnboard();
+}
+
+function setLayerSource(layer: LayerConfig, src: AnySource) {
+  layer.source = src;
+  layer.fields = [];
+  ui.forceChooser = false;
+  ui.urlMode = false;
+  ui.savedOpen = false;
+  renderAll();
+  updateCodePreview();
+  void scanAndSuggest(layer, { fit: true });
+  // Premier contact : le tour se lance une fois les données choisies
+  startTourIfFirstVisit(BUILDER_CARTO_TOUR);
+}
+
+function renderOnboard() {
+  const host = document.getElementById('onboard-modal')!;
+  const show = ui.forceChooser || state.layers.every((l) => !l.source);
+  if (!show) {
+    host.innerHTML = '';
+    return;
+  }
+  const layer = getActiveLayer() ?? state.layers[0];
+  const canClose = state.layers.some((l) => l.source);
+  const savedSources = ui.savedOpen ? loadSavedSources() : [];
+
+  host.innerHTML = `
+    <div class="carto-modal-overlay" id="onboard-overlay">
+      <div class="carto-modal" role="dialog" aria-modal="true" aria-labelledby="onboard-title">
+        <div class="carto-modal__top">
+          <div>
+            <h2 class="carto-modal__title" id="onboard-title">D'où viennent vos données ?</h2>
+            <p class="carto-modal__subtitle">Choisissez une option — vous pourrez en changer à tout moment.</p>
+          </div>
+          ${
+            canClose
+              ? `<button class="carto-modal__close" id="onboard-close" type="button" title="Fermer" aria-label="Fermer">
+                  <i class="ri-close-line" aria-hidden="true"></i>
+                </button>`
+              : ''
+          }
+        </div>
+        <button class="carto-choice carto-choice--featured" id="onboard-sample" type="button">
+          <i class="ri-lightbulb-line" aria-hidden="true"></i>
+          <span class="carto-choice__body">
+            <span class="carto-choice__title">Essayer avec un jeu d'exemple</span>
+            <span class="carto-choice__desc">Les chefs-lieux des régions françaises — idéal pour découvrir</span>
+          </span>
+          <i class="ri-arrow-right-line carto-choice__arrow" aria-hidden="true"></i>
+        </button>
+        <button class="carto-choice" id="onboard-url" type="button" aria-expanded="${ui.urlMode}">
+          <i class="ri-link" aria-hidden="true"></i>
+          <span class="carto-choice__body">
+            <span class="carto-choice__title">Coller un lien de données</span>
+            <span class="carto-choice__desc">data.gouv.fr, OpenDataSoft, Grist ou API JSON</span>
+          </span>
+          <i class="ri-arrow-right-line carto-choice__arrow" aria-hidden="true"></i>
+        </button>
+        ${
+          ui.urlMode
+            ? `
+        <div class="carto-url-row">
+          <input type="text" id="onboard-url-input" aria-label="URL du jeu de données"
+                 placeholder="https://data.economie.gouv.fr/explore/dataset/…">
+          <button id="onboard-url-ok" type="button">Utiliser</button>
+        </div>`
+            : ''
+        }
+        <button class="carto-choice" id="onboard-saved" type="button" aria-expanded="${ui.savedOpen}">
+          <i class="ri-database-2-line" aria-hidden="true"></i>
+          <span class="carto-choice__body">
+            <span class="carto-choice__title">Une source enregistrée</span>
+            <span class="carto-choice__desc">Créées dans l'application Sources</span>
+          </span>
+          <i class="ri-arrow-right-line carto-choice__arrow" aria-hidden="true"></i>
+        </button>
+        ${
+          ui.savedOpen
+            ? savedSources.length
+              ? `
+        <div class="carto-saved-list">
+          ${savedSources
+            .map(
+              (s) =>
+                `<button type="button" data-saved-id="${escapeAttr(String(s.id))}">${escapeAttr(String(s.name || s.datasetId || s.url || s.id))}</button>`
+            )
+            .join('')}
+        </div>`
+              : `
+        <p class="carto-msg carto-msg--warn"><i class="ri-information-line" aria-hidden="true"></i>
+          Aucune source enregistrée pour l'instant — créez-en une dans l'application Sources.</p>`
+            : ''
+        }
+      </div>
+    </div>
+  `;
+
+  document.getElementById('onboard-sample')?.addEventListener('click', () => {
+    setLayerSource(layer, {
       id: `sample-${layer.id}`,
       name: "Jeu d'exemple — chefs-lieux",
       type: 'manual',
       data: SAMPLE_DATA,
       adHoc: true,
-    };
-    layer.fields = [];
-    renderLayersList();
-    updateCodePreview();
-    void scanAndSuggest(layer);
+    });
   });
 
-  // Type change re-renders entire config (different options sections)
-  const typeEl = document.getElementById('layer-type');
-  typeEl?.addEventListener('change', () => {
-    layer.type = (typeEl as HTMLSelectElement).value as LayerType;
-    rerenderLayerConfig();
-    renderLayersList();
-    updateCodePreview();
+  document.getElementById('onboard-url')?.addEventListener('click', () => {
+    ui.urlMode = !ui.urlMode;
+    renderOnboard();
+    document.getElementById('onboard-url-input')?.focus();
   });
 
-  // Name
-  const nameEl = document.getElementById('layer-name') as HTMLInputElement | null;
-  nameEl?.addEventListener('change', () => {
-    layer.name = nameEl.value;
-    renderLayersList();
-    updateCodePreview();
+  const applyUrl = () => {
+    const input = document.getElementById('onboard-url-input') as HTMLInputElement | null;
+    const url = input?.value.trim();
+    if (!url) return;
+    setLayerSource(layer, {
+      id: `url-${layer.id}`,
+      name: url.replace(/^https?:\/\//, '').slice(0, 60),
+      type: 'api',
+      apiUrl: url,
+      adHoc: true,
+    });
+  };
+  document.getElementById('onboard-url-ok')?.addEventListener('click', applyUrl);
+  document.getElementById('onboard-url-input')?.addEventListener('keydown', (e) => {
+    if ((e as KeyboardEvent).key === 'Enter') applyUrl();
   });
 
-  // Geo
-  bind('layer-geo-field', 'geoField');
-  bind('layer-lat', 'latField');
-  bind('layer-lon', 'lonField');
-
-  // Info display
-  const popupModeEl = document.getElementById('layer-popup-mode') as HTMLSelectElement | null;
-  popupModeEl?.addEventListener('change', () => {
-    layer.popupMode = popupModeEl.value as PopupMode;
-    rerenderLayerConfig();
-    updateCodePreview();
+  document.getElementById('onboard-saved')?.addEventListener('click', () => {
+    ui.savedOpen = !ui.savedOpen;
+    renderOnboard();
+  });
+  host.querySelectorAll('[data-saved-id]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const found = loadSavedSources().find(
+        (s) => String(s.id) === btn.getAttribute('data-saved-id')
+      );
+      if (found) setLayerSource(layer, lightweightSource(found));
+    });
   });
 
-  bind('layer-tooltip', 'tooltipField');
-  bind('layer-popup-fields', 'popupFields');
-  bind('layer-title-field', 'titleField');
-  bind('layer-popup-template', 'popupTemplate');
-  bind('layer-popup-width', 'popupWidth');
+  if (canClose) {
+    document.getElementById('onboard-close')?.addEventListener('click', closeOnboard);
+    document.getElementById('onboard-overlay')?.addEventListener('click', (e) => {
+      if ((e.target as HTMLElement).id === 'onboard-overlay') closeOnboard();
+    });
+  }
+}
 
-  // Apparence
-  bind('layer-color', 'color');
-  const colorFieldEl = document.getElementById('layer-color-field') as HTMLInputElement | null;
-  colorFieldEl?.addEventListener('change', () => {
-    layer.colorField = colorFieldEl.value;
-    rerenderLayerConfig(); // show/hide color-map textarea
-    updateCodePreview();
+// ---------------------------------------------------------------------------
+// Modale « Obtenir le code »
+// ---------------------------------------------------------------------------
+
+function closeExport() {
+  ui.exportOpen = false;
+  renderExport();
+}
+
+function renderExport() {
+  const host = document.getElementById('export-modal')!;
+  if (!ui.exportOpen) {
+    host.innerHTML = '';
+    return;
+  }
+
+  host.innerHTML = `
+    <div class="carto-modal-overlay carto-modal-overlay--dark" id="export-overlay">
+      <div class="carto-modal carto-modal--wide" role="dialog" aria-modal="true" aria-labelledby="export-title">
+        <div class="carto-export__head">
+          <h2 id="export-title">Intégrer la carte dans votre page</h2>
+          <button class="carto-modal__close" id="export-close" type="button">
+            Fermer <i class="ri-close-line" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div class="carto-export__body">
+          <p class="carto-msg carto-msg--muted">Copiez ce code et collez-le dans votre CMS ou votre page HTML.</p>
+          <div class="carto-export__toolbar">
+            <label for="gen-mode" class="fr-sr-only">Mode de génération</label>
+            <select id="gen-mode">
+              <option value="embedded" ${state.generationMode === 'embedded' ? 'selected' : ''}>Ma page charge déjà dsfr-data (composants seuls)</option>
+              <option value="dynamic" ${state.generationMode === 'dynamic' ? 'selected' : ''}>Page autonome (avec scripts et CSS)</option>
+            </select>
+            <button id="btn-copy" class="carto-btn carto-btn--secondary" type="button">
+              <i class="ri-file-copy-line" aria-hidden="true"></i>Copier le code
+            </button>
+            <button id="btn-export-favorite" class="carto-btn carto-btn--ghost" type="button">
+              <i class="ri-star-line" aria-hidden="true"></i>Sauvegarder en favori
+            </button>
+            <button id="btn-playground" class="carto-btn carto-btn--ghost" type="button">
+              <i class="ri-flask-line" aria-hidden="true"></i>Ouvrir dans le playground
+            </button>
+          </div>
+          <pre class="carto-code" id="code-output"></pre>
+        </div>
+      </div>
+    </div>
+  `;
+
+  const codeEl = document.getElementById('code-output')!;
+  codeEl.textContent = generateCode();
+
+  document.getElementById('export-close')?.addEventListener('click', closeExport);
+  document.getElementById('export-overlay')?.addEventListener('click', (e) => {
+    if ((e.target as HTMLElement).id === 'export-overlay') closeExport();
   });
-  bind('layer-color-map', 'colorMap');
-  bind('layer-filter', 'filter');
-  bind('layer-shape-class', 'shapeClass');
-  const noInteractiveEl = document.getElementById(
-    'layer-no-interactive'
-  ) as HTMLInputElement | null;
-  noInteractiveEl?.addEventListener('change', () => {
-    layer.noInteractive = noInteractiveEl.checked;
-    rerenderLayerConfig();
-    renderLayersList();
-    updateCodePreview();
+
+  const genEl = document.getElementById('gen-mode') as HTMLSelectElement | null;
+  genEl?.addEventListener('change', () => {
+    state.generationMode = genEl.value as 'embedded' | 'dynamic';
+    codeEl.textContent = generateCode();
+    persistState();
   });
 
-  // Marker
-  const clusterEl = document.getElementById('layer-cluster') as HTMLInputElement | null;
-  clusterEl?.addEventListener('change', () => {
-    layer.cluster = clusterEl.checked;
-    const clusterGroup = document.getElementById('cluster-radius-group');
-    if (clusterGroup) clusterGroup.style.display = clusterEl.checked ? '' : 'none';
-    updateCodePreview();
+  document.getElementById('btn-copy')?.addEventListener('click', () => {
+    navigator.clipboard.writeText(generateCode()).catch(() => {});
+    const btn = document.getElementById('btn-copy');
+    if (btn) {
+      btn.innerHTML = '<i class="ri-check-line" aria-hidden="true"></i>Copié !';
+      setTimeout(() => {
+        btn.innerHTML = '<i class="ri-file-copy-line" aria-hidden="true"></i>Copier le code';
+      }, 1500);
+    }
   });
-  bind('layer-cluster-radius', 'clusterRadius', Number);
 
-  // Geoshape
-  const fillFieldEl = document.getElementById('layer-fill-field') as HTMLInputElement | null;
-  fillFieldEl?.addEventListener('change', () => {
-    layer.fillField = fillFieldEl.value;
-    rerenderLayerConfig(); // show/hide palette
-    updateCodePreview();
-  });
-  bind('layer-fill-opacity', 'fillOpacity', Number);
-  bind('layer-palette', 'selectedPalette');
-
-  // Circle
-  bind('layer-radius', 'radius', Number);
-  bind('layer-radius-field', 'radiusField');
-  const radiusUnitEl = document.getElementById('layer-radius-unit') as HTMLSelectElement | null;
-  radiusUnitEl?.addEventListener('change', () => {
-    layer.radiusUnit = radiusUnitEl.value as 'px' | 'm';
-    rerenderLayerConfig(); // min/max seulement en px
-    updateCodePreview();
-  });
-  bind('layer-radius-min', 'radiusMin', Number);
-  bind('layer-radius-max', 'radiusMax', Number);
-
-  // Heatmap
-  bind('layer-heat-radius', 'heatRadius', Number);
-  bind('layer-heat-blur', 'heatBlur', Number);
-  bind('layer-heat-field', 'heatField');
-
-  // Timeline
-  const timeFieldEl = document.getElementById('layer-time-field') as HTMLInputElement | null;
-  timeFieldEl?.addEventListener('change', () => {
-    layer.timeField = timeFieldEl.value;
-    rerenderLayerConfig(); // show/hide bucket+mode fields
-    renderMapConfig(); // section timeline des réglages avancés carte
-    updateCodePreview();
-  });
-  bind('layer-time-bucket', 'timeBucket');
-  bind('layer-time-mode', 'timeMode');
-
-  // Viewport
-  const bboxEl = document.getElementById('layer-bbox') as HTMLInputElement | null;
-  bboxEl?.addEventListener('change', () => {
-    layer.bbox = bboxEl.checked;
-    rerenderLayerConfig();
-    updateCodePreview();
-  });
-  bind('layer-bbox-debounce', 'bboxDebounce', Number);
-  bind('layer-bbox-field', 'bboxField');
-
-  bind('layer-min-zoom', 'minZoom', Number);
-  bind('layer-max-zoom', 'maxZoom', Number);
-  bind('layer-max-items', 'maxItems', Number);
+  document
+    .getElementById('btn-export-favorite')
+    ?.addEventListener('click', () => saveFavorite('btn-export-favorite'));
+  document.getElementById('btn-playground')?.addEventListener('click', sendToPlayground);
 }
 
 // ---------------------------------------------------------------------------
@@ -1243,8 +1451,10 @@ function setScanStatus(html: string) {
   if (el) el.innerHTML = html;
 }
 
-async function scanAndSuggest(layer: LayerConfig) {
-  setScanStatus('<i class="ri-loader-4-line carto-spin"></i> Analyse des champs de la source…');
+async function scanAndSuggest(layer: LayerConfig, opts: { fit?: boolean } = {}) {
+  setScanStatus(
+    '<i class="ri-loader-4-line carto-spin" aria-hidden="true"></i> Analyse des champs de la source…'
+  );
   try {
     const result = await scanLayerFields(layer);
     layer.fields = result.fields;
@@ -1263,32 +1473,42 @@ async function scanAndSuggest(layer: LayerConfig) {
       }
     }
 
-    rerenderLayerConfig();
+    renderLayersPanel();
+    renderElementsPanel();
     setScanStatus(
-      `<i class="ri-check-line" style="color:var(--text-default-success)"></i> ${result.fields.length} champs (échantillon de ${result.sampleSize})${suggested ? ' — ' + suggested : ''}`
+      `<i class="ri-check-line" aria-hidden="true"></i> ${result.fields.length} champs (échantillon de ${result.sampleSize})${suggested ? ' — ' + suggested : ''}`
     );
     updateCodePreview();
-    // Aperçu immédiat dès qu'une localisation est connue
-    if (layer.geoField || (layer.latField && layer.lonField)) executePreview();
+    // Aperçu immédiat : la carte plein écran montre le résultat (ou son
+    // diagnostic si la localisation manque encore).
+    executePreview(opts.fit ?? false);
   } catch (err) {
     layer.fields = [];
-    rerenderLayerConfig();
+    renderLayersPanel();
+    renderElementsPanel();
     setScanStatus(
-      `<i class="ri-error-warning-line" style="color:var(--text-default-error)"></i> ${escapeAttr((err as Error).message)}`
+      `<i class="ri-error-warning-line" aria-hidden="true"></i> ${escapeAttr((err as Error).message)}`
     );
   }
 }
 
 // ---------------------------------------------------------------------------
-// Code preview
+// Code généré + re-exécution auto
 // ---------------------------------------------------------------------------
+
+let rerunTimer: ReturnType<typeof setTimeout> | undefined;
+
+function scheduleRerun() {
+  if (!ui.executed) return;
+  clearTimeout(rerunTimer);
+  rerunTimer = setTimeout(() => executePreview(false), 400);
+}
 
 function updateCodePreview() {
   const codeEl = document.getElementById('code-output');
-  if (codeEl) {
-    codeEl.textContent = generateCode();
-  }
+  if (codeEl) codeEl.textContent = generateCode();
   persistState();
+  scheduleRerun();
 }
 
 // ---------------------------------------------------------------------------
@@ -1299,45 +1519,25 @@ function addLayer() {
   const layer = createLayer();
   state.layers.push(layer);
   state.activeLayerId = layer.id;
-  renderLayersList();
-  renderLayerConfig();
-  updateCodePreview();
-}
-
-function removeActiveLayer() {
-  if (state.layers.length <= 1) return;
-  state.layers = state.layers.filter((l) => l.id !== state.activeLayerId);
-  state.activeLayerId = state.layers[0].id;
-  renderLayersList();
-  renderLayerConfig();
+  ui.forceChooser = true;
+  renderAll();
   updateCodePreview();
 }
 
 function resetBuilder() {
   if (!confirm('Repartir de zéro ? La configuration actuelle sera perdue.')) return;
   resetState();
-  renderLayersList();
-  renderLayerConfig();
-  renderMapConfig();
-  updateCodePreview();
-  const preview = document.getElementById('map-preview');
-  if (preview)
-    preview.innerHTML =
-      '<p class="fr-text--sm" style="text-align:center;padding:2rem;color:var(--text-mention-grey)">Cliquez sur « Exécuter » pour afficher l\'aperçu de la carte.</p>';
+  ui.executed = false;
+  ui.forceChooser = false;
+  const canvas = document.getElementById('map-canvas');
+  if (canvas)
+    canvas.innerHTML = `
+      <p class="carto-canvas__hint">
+        <i class="ri-map-2-line" aria-hidden="true"></i><br>
+        Choisissez vos données, la carte s'affiche ici.
+      </p>`;
   setPreviewStatus('');
-}
-
-function copyCode() {
-  const code = generateCode();
-  navigator.clipboard.writeText(code).catch(() => {});
-  const btn = document.getElementById('btn-copy');
-  if (btn) {
-    const original = btn.innerHTML;
-    btn.innerHTML = '<i class="ri-check-line"></i> Copie !';
-    setTimeout(() => {
-      btn.innerHTML = original;
-    }, 1500);
-  }
+  renderAll();
 }
 
 function sendToPlayground() {
@@ -1346,14 +1546,14 @@ function sendToPlayground() {
   window.location.href = '../../apps/playground/index.html?from=builder-carto';
 }
 
-function saveFavorite() {
-  const code = generateCode();
-  if (!code.trim()) {
+function saveFavorite(feedbackBtnId = 'btn-favorite') {
+  if (!state.layers.some((l) => l.visible && l.source)) {
     toastWarning(
-      'Cliquez d’abord sur « Exécuter » pour générer la carte, puis vous pourrez la sauvegarder en favori.'
+      'Choisissez d’abord les données d’une couche, puis vous pourrez sauvegarder la carte en favori.'
     );
     return;
   }
+  const code = generateCode();
 
   const name = prompt('Nom du favori :', state.map.name || 'Ma carte');
   if (!name) return;
@@ -1373,28 +1573,26 @@ function saveFavorite() {
   favorites.unshift(favorite);
   saveToStorage(FAVORITES_KEY, favorites);
 
-  // Visual feedback on the save button inside app-preview-panel
-  const btn = document.querySelector('.preview-panel-save-btn') as HTMLButtonElement | null;
+  const btn = document.getElementById(feedbackBtnId);
   if (btn) {
     const originalHTML = btn.innerHTML;
-    btn.innerHTML = '<i class="ri-check-line" aria-hidden="true"></i> Sauvegarde !';
-    btn.style.background = 'var(--background-contrast-success)';
+    btn.innerHTML = '<i class="ri-check-line" aria-hidden="true"></i>Sauvegardé !';
     setTimeout(() => {
       btn.innerHTML = originalHTML;
-      btn.style.background = '';
     }, 2000);
   }
 }
 
 // ---------------------------------------------------------------------------
-// Aperçu + diagnostic
+// Aperçu plein écran + diagnostic
 // ---------------------------------------------------------------------------
 
 function setPreviewStatus(html: string, tone: 'ok' | 'warn' | 'err' | '' = '') {
   const el = document.getElementById('preview-status');
   if (!el) return;
   el.innerHTML = html;
-  el.className = `carto-preview-status${tone ? ` carto-preview-status--${tone}` : ''}`;
+  el.hidden = !html;
+  el.className = `carto-status${tone ? ` carto-status--${tone}` : ''}`;
 }
 
 let statusTimers: ReturnType<typeof setTimeout>[] = [];
@@ -1409,7 +1607,7 @@ function updatePreviewStatus() {
   statusTimers = [];
 
   const check = (attempt: number) => {
-    const preview = document.getElementById('map-preview');
+    const preview = document.getElementById('map-canvas');
     if (!preview) return;
 
     const sources = [...preview.querySelectorAll('dsfr-data-source')] as (HTMLElement & {
@@ -1424,30 +1622,38 @@ function updatePreviewStatus() {
       return acc + (Array.isArray(d) ? d.length : 0);
     }, 0);
 
+    // Les vignettes territoriales clonent les couches : on ne compte que la
+    // carte principale, sinon N est multiplié par le nombre d'encarts.
+    const notInInset = (el: Element) => !el.closest('dsfr-data-map-inset');
     const drawn =
-      preview.querySelectorAll('.leaflet-marker-icon').length +
-      preview.querySelectorAll('.leaflet-overlay-pane path').length +
-      preview.querySelectorAll('.leaflet-heatmap-layer, .leaflet-overlay-pane canvas').length;
+      [...preview.querySelectorAll('.leaflet-marker-icon')].filter(notInInset).length +
+      [...preview.querySelectorAll('.leaflet-overlay-pane path')].filter(notInInset).length +
+      [...preview.querySelectorAll('.leaflet-heatmap-layer, .leaflet-overlay-pane canvas')].filter(
+        notInInset
+      ).length;
 
     if (errors.length) {
       setPreviewStatus(
-        `<i class="ri-error-warning-line"></i> Erreur de chargement : ${escapeAttr(errors[0].message ?? String(errors[0]))}`,
+        `<i class="ri-error-warning-line" aria-hidden="true"></i> Erreur de chargement : ${escapeAttr(errors[0].message ?? String(errors[0]))}`,
         'err'
       );
       return;
     }
     if (loading && attempt < 4) return; // on laisse les timers suivants re-vérifier
 
-    if (records > 0 && drawn === 0) {
+    if (records > 0 && drawn === 0 && attempt >= 2) {
       setPreviewStatus(
-        `<i class="ri-alert-line"></i> ${records} enregistrements chargés mais aucun élément dessiné — vérifiez le champ de localisation (section Localisation).`,
+        `<i class="ri-alert-line" aria-hidden="true"></i> ${records} enregistrements chargés mais aucun élément dessiné — vérifiez la localisation (panneau Couches).`,
         'warn'
       );
     } else if (records === 0 && sources.length && attempt >= 4) {
-      setPreviewStatus(`<i class="ri-alert-line"></i> Aucune donnée reçue de la source.`, 'warn');
+      setPreviewStatus(
+        `<i class="ri-alert-line" aria-hidden="true"></i> Aucune donnée reçue de la source.`,
+        'warn'
+      );
     } else if (drawn > 0) {
       setPreviewStatus(
-        `<i class="ri-check-line"></i> ${drawn.toLocaleString('fr-FR')} éléments affichés (${records.toLocaleString('fr-FR')} enregistrements)`,
+        `<i class="ri-check-line" aria-hidden="true"></i> ${drawn.toLocaleString('fr-FR')} éléments affichés (${records.toLocaleString('fr-FR')} enregistrements)`,
         'ok'
       );
     }
@@ -1458,24 +1664,124 @@ function updatePreviewStatus() {
   });
 }
 
-function executePreview() {
-  const preview = document.getElementById('map-preview');
-  if (!preview) return;
+// Onglet en arrière-plan : Leaflet ne dessine qu'au retour de visibilité,
+// après la fenêtre des timers — on re-vérifie une fois l'onglet redevenu
+// visible pour ne pas laisser un faux « aucun élément dessiné ».
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden && ui.executed) {
+    statusTimers.push(setTimeout(() => updatePreviewStatus(), 1200));
+  }
+});
 
-  // Generate embedded code
-  const savedMode = state.generationMode;
+/** Jeton d'annulation des sondes viewport de l'exécution précédente. */
+let viewportWatchToken = 0;
+
+/**
+ * Synchronise le cadrage de la carte d'aperçu vers l'état : le code exporté
+ * reprend exactement ce que l'utilisateur voit (« la carte est l'aperçu »).
+ */
+function watchViewport() {
+  const token = ++viewportWatchToken;
+  const tryAttach = (attempt: number) => {
+    if (token !== viewportWatchToken) return;
+    const mapEl = document.querySelector('#map-canvas dsfr-data-map') as DsfrDataMapElement | null;
+    const lmap = mapEl?.getLeafletMap?.();
+    if (!lmap) {
+      // L'init Leaflet est différée (lazy-load + IntersectionObserver) et
+      // peut prendre longtemps (onglet en arrière-plan) : on sonde ~5 min,
+      // le jeton annule la sonde à la prochaine exécution.
+      if (attempt < 750) setTimeout(() => tryAttach(attempt + 1), 400);
+      return;
+    }
+    const sync = () => {
+      const c = lmap.getCenter();
+      state.map.center = `${c.lat.toFixed(4)},${c.lng.toFixed(4)}`;
+      state.map.zoom = lmap.getZoom();
+      persistState();
+    };
+    lmap.on('moveend', sync);
+    lmap.on('zoomend', sync);
+  };
+  tryAttach(0);
+}
+
+/**
+ * (Re)génère la carte d'aperçu dans le canevas plein écran. Le code d'aperçu
+ * diffère du code exporté sur trois points : hauteur plein écran, compagnon
+ * a11y omis (réservé à l'export) et fit-bounds ponctuel à la demande.
+ */
+function executePreview(fit = false) {
+  clearTimeout(rerunTimer);
+  const canvas = document.getElementById('map-canvas');
+  if (!canvas) return;
+  if (!state.layers.some((l) => l.visible && l.source)) {
+    ui.forceChooser = true;
+    renderOnboard();
+    return;
+  }
+
+  const saved = {
+    mode: state.generationMode,
+    a11y: state.map.a11y,
+    height: state.map.height,
+    fitBounds: state.map.fitBounds,
+  };
   state.generationMode = 'embedded';
+  state.map.a11y = false;
+  // Avec des encarts, une bande basse leur est réservée (vignettes).
+  state.map.height = state.map.insets.length
+    ? 'calc(100dvh - 56px - 208px)'
+    : 'calc(100dvh - 56px)';
+  if (fit) state.map.fitBounds = true;
   const code = generateCode();
-  state.generationMode = savedMode;
+  state.generationMode = saved.mode;
+  state.map.a11y = saved.a11y;
+  state.map.height = saved.height;
+  state.map.fitBounds = saved.fitBounds;
 
-  preview.innerHTML = code;
-  setPreviewStatus('<i class="ri-loader-4-line carto-spin"></i> Chargement…');
+  canvas.innerHTML = code;
+  ui.executed = true;
+  setPreviewStatus('<i class="ri-loader-4-line carto-spin" aria-hidden="true"></i> Chargement…');
   updatePreviewStatus();
+  watchViewport();
 }
 
 // ---------------------------------------------------------------------------
 // Init
 // ---------------------------------------------------------------------------
+
+function bindStaticUi() {
+  // Pliage / dépliage des panneaux
+  document.querySelectorAll('[data-panel-toggle]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const panel = document.getElementById(btn.getAttribute('data-panel-toggle')!);
+      if (!panel) return;
+      const collapsed = panel.classList.toggle('carto-panel--collapsed');
+      panel
+        .querySelectorAll('[data-panel-toggle]')
+        .forEach((b) => b.setAttribute('aria-expanded', String(!collapsed)));
+    });
+  });
+
+  document.getElementById('btn-add-layer')?.addEventListener('click', addLayer);
+  document.getElementById('btn-reset')?.addEventListener('click', resetBuilder);
+  document.getElementById('btn-execute')?.addEventListener('click', () => executePreview(true));
+  document.getElementById('btn-favorite')?.addEventListener('click', () => saveFavorite());
+  document.getElementById('btn-export')?.addEventListener('click', () => {
+    ui.exportOpen = true;
+    renderExport();
+  });
+
+  // Échap ferme la modale du dessus
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    if (ui.exportOpen) {
+      closeExport();
+    } else if (ui.forceChooser && state.layers.some((l) => l.source)) {
+      closeOnboard();
+    }
+  });
+}
 
 document.addEventListener('DOMContentLoaded', async () => {
   // Hook saveToStorage to /api/* sync (when authenticated). Without this,
@@ -1485,37 +1791,23 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const restored = restoreState();
 
-  renderLayersList();
-  renderLayerConfig();
-  renderMapConfig();
-  updateCodePreview();
-
-  document.getElementById('btn-add-layer')?.addEventListener('click', addLayer);
-  document.getElementById('btn-remove-layer')?.addEventListener('click', removeActiveLayer);
-  document.getElementById('btn-reset')?.addEventListener('click', resetBuilder);
-  document.getElementById('btn-copy')?.addEventListener('click', copyCode);
-  document.getElementById('btn-execute')?.addEventListener('click', executePreview);
-
-  // app-preview-panel events
-  const previewPanel = document.querySelector('app-preview-panel');
-  if (previewPanel) {
-    previewPanel.addEventListener('save-favorite', saveFavorite);
-    previewPanel.addEventListener('open-playground', sendToPlayground);
-  }
+  bindStaticUi();
+  renderAll();
+  persistState();
 
   // Reprise de session : re-analyse les champs de la couche active et relance
-  // l'aperçu pour retrouver l'écran tel qu'on l'avait laissé. Attendre que
-  // app-preview-panel soit rendu : une carte injectée dans un conteneur encore
-  // à 0×0 ne déclenche jamais l'init Leaflet (IntersectionObserver).
+  // l'aperçu (sans re-cadrer : le viewport sauvegardé est restauré tel quel).
   if (restored) {
     const layer = getActiveLayer();
     if (layer?.source) {
-      await customElements.whenDefined('app-preview-panel');
-      setTimeout(() => void scanAndSuggest(layer), 150);
+      setTimeout(() => void scanAndSuggest(layer, { fit: false }), 150);
     }
   }
 
-  // Product tour
+  // Product tour : seulement quand la modale d'onboarding n'est pas affichée
+  // (sinon il démarre au premier choix de données — setLayerSource).
   injectTourStyles();
-  startTourIfFirstVisit(BUILDER_CARTO_TOUR);
+  if (state.layers.some((l) => l.source)) {
+    startTourIfFirstVisit(BUILDER_CARTO_TOUR);
+  }
 });

--- a/apps/builder-carto/src/styles/carto.css
+++ b/apps/builder-carto/src/styles/carto.css
@@ -1,76 +1,350 @@
-/* Builder Carto styles */
+/* Builder Carto — refonte « carte plein écran + panneaux flottants » */
 
-/* ---- Layout 3 columns ---- */
-.carto-layout {
-  display: grid;
-  grid-template-columns: 280px 320px 1fr;
-  gap: 0;
-  min-height: calc(100vh - 130px);
+/* ---- Page ---- */
+body.carto-app {
+  margin: 0;
+  overflow: hidden;
 }
 
-@media (max-width: 1200px) {
-  .carto-layout {
-    grid-template-columns: 1fr;
-  }
+.carto-workspace {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+  background: var(--background-alt-grey, #f6f6f6);
 }
 
-/* ---- Col 1: Layers + Map config ---- */
-.carto-col-layers {
-  border-right: 1px solid var(--border-default-grey);
-  padding: 1rem;
-  overflow-y: auto;
-  max-height: calc(100vh - 130px);
+/* ---- Canevas carte ---- */
+.carto-canvas {
+  position: absolute;
+  top: 56px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
 }
 
-.carto-col-actions {
+.carto-canvas__hint {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  color: var(--text-mention-grey);
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.carto-canvas__hint i {
+  font-size: 2rem;
+}
+
+/* Les controles Leaflet (zoom) passent en bas a droite : la colonne
+   de panneaux occupe le flanc gauche. */
+.carto-canvas .leaflet-top.leaflet-left {
+  top: auto;
+  left: auto;
+  right: 0;
+  bottom: 24px;
+}
+
+/* Encarts territoriaux : bandeau de vignettes sous la carte (l'aperçu
+   réserve une bande basse — voir executePreview). Alignés à droite pour
+   ne pas passer sous la colonne de panneaux. */
+.carto-canvas > dsfr-data-map {
+  display: block;
+  text-align: right;
+  white-space: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  height: 100%;
+}
+
+.carto-canvas > dsfr-data-map > dsfr-data-map-inset {
+  width: 170px;
+  margin: 8px 4px 0;
+  text-align: center;
+}
+
+.carto-canvas > dsfr-data-map > dsfr-data-map-inset > dsfr-data-map {
+  display: block;
+  border: 1px solid var(--border-default-grey);
+  overflow: hidden;
+  background: var(--background-default-grey, #fff);
+}
+
+/* ---- Barre du haut ---- */
+.carto-topbar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 56px;
+  z-index: 1100;
+  background: var(--background-default-grey, #fff);
+  border-bottom: 1px solid var(--border-default-grey);
   display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0 1rem;
+  box-sizing: border-box;
+}
+
+.carto-topbar__brand {
+  display: flex;
+  align-items: center;
+  background-image: none;
+}
+
+.carto-topbar__logo.fr-logo {
+  font-size: 0.4688rem;
+  margin: 0;
+}
+
+.carto-topbar__logo.fr-logo::after {
+  display: none !important;
+  content: none !important;
+}
+
+.carto-topbar__title {
+  display: flex;
+  align-items: baseline;
   gap: 0.5rem;
-  margin-bottom: 0.75rem;
+  min-width: 0;
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
 }
 
-/* ---- Col 2: Layer config ---- */
-.carto-col-config {
-  border-right: 1px solid var(--border-default-grey);
-  padding: 1rem;
+.carto-topbar__app {
+  font-weight: 700;
+  color: var(--text-title-grey);
+  white-space: nowrap;
+}
+
+.carto-topbar__page {
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: var(--text-mention-grey);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.carto-topbar__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.carto-topbar__guide {
+  font-size: 0.875rem;
+  color: var(--text-action-high-blue-france);
+  white-space: nowrap;
+}
+
+/* ---- Boutons de la barre ---- */
+.carto-btn {
+  height: 36px;
+  padding: 0 0.75rem;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  white-space: nowrap;
+}
+
+.carto-btn--ghost {
+  color: var(--text-action-high-blue-france);
+}
+
+.carto-btn--ghost:hover {
+  background: var(--background-alt-grey);
+}
+
+.carto-btn--secondary {
+  border: 1px solid var(--border-action-high-blue-france);
+  background: var(--background-default-grey);
+  color: var(--text-action-high-blue-france);
+  font-weight: 500;
+}
+
+.carto-btn--secondary:hover {
+  background: var(--background-alt-grey);
+}
+
+.carto-btn--primary {
+  padding: 0 1rem;
+  background: var(--background-action-high-blue-france);
+  color: var(--text-inverted-blue-france, #f5f5fe);
+  font-weight: 500;
+}
+
+.carto-btn--primary:hover {
+  background: var(--background-action-high-blue-france-hover, #1212ff);
+}
+
+/* ---- Colonne de panneaux flottants ---- */
+.carto-panels {
+  position: absolute;
+  top: 72px;
+  left: 16px;
+  bottom: 16px;
+  width: 344px;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  pointer-events: none;
+}
+
+.carto-panel {
+  pointer-events: auto;
+  background: var(--background-default-grey, #fff);
+  border: 1px solid var(--border-default-grey);
+  box-shadow: 0 2px 6px rgba(0, 0, 18, 0.16);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+  flex: 0 1 auto;
+}
+
+.carto-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-bottom: 1px solid var(--border-default-grey);
+  background: none;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+  font-family: inherit;
+  text-align: left;
+}
+
+.carto-panel__header:hover {
+  background: var(--background-alt-grey);
+}
+
+.carto-panel__header--split {
+  cursor: default;
+  padding: 0.375rem 0.5rem 0.375rem 0;
+}
+
+.carto-panel__header--split:hover {
+  background: none;
+}
+
+.carto-panel__header-toggle {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0.375rem 0.5rem 0.375rem 1rem;
+  flex: 1;
+  text-align: left;
+}
+
+.carto-panel__header-toggle:hover {
+  background: var(--background-alt-grey);
+}
+
+.carto-panel__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.carto-panel__title {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--text-title-grey);
+}
+
+.carto-panel__title i {
+  margin-right: 0.375rem;
+}
+
+.carto-panel__arrow {
+  font-size: 1rem;
+  color: var(--text-mention-grey);
+  transition: transform 0.2s;
+}
+
+.carto-panel--collapsed .carto-panel__arrow {
+  transform: rotate(-90deg);
+}
+
+.carto-panel__body {
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
-  max-height: calc(100vh - 130px);
 }
 
-/* ---- Layers list ---- */
+.carto-panel--collapsed .carto-panel__body {
+  display: none;
+}
+
+/* ---- Sections internes des panneaux ---- */
+.carto-section {
+  padding: 0.75rem 1rem;
+}
+
+.carto-section + .carto-section {
+  padding-top: 0;
+}
+
+.carto-section__label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--text-mention-grey);
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+}
+
+/* ---- Liste des couches ---- */
 .carto-layers__list {
   list-style: none;
-  padding: 0;
+  padding: 0.5rem 1rem 0;
   margin: 0;
 }
 
 .carto-layers__item {
-  padding: 0.5rem 0.75rem;
-  border: 1px solid var(--border-default-grey);
-  border-radius: 4px;
-  margin-bottom: 0.5rem;
-  cursor: pointer;
-  transition:
-    border-color 0.15s,
-    background 0.15s;
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
+  margin-bottom: 0.375rem;
+  border: 1px solid var(--border-default-grey);
+  background: var(--background-default-grey);
+  cursor: pointer;
 }
 
 .carto-layers__item--active {
-  border-color: var(--border-active-blue-france);
+  border-color: var(--border-action-high-blue-france);
   background: var(--background-alt-blue-france);
 }
 
-.carto-layers__item-drag {
-  cursor: grab;
-  color: var(--text-mention-grey);
-  font-size: 1rem;
-  flex-shrink: 0;
+.carto-layers__item.dragging {
+  opacity: 0.5;
 }
 
-.carto-layers__item-drag:active {
-  cursor: grabbing;
+.carto-layers__item.drag-over {
+  border-top: 2px solid var(--border-action-high-blue-france);
 }
 
 .carto-layers__item-info {
@@ -82,6 +356,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.5rem;
 }
 
 .carto-layers__item-name {
@@ -96,132 +371,190 @@
   font-size: 0.7rem;
   color: var(--text-mention-grey);
   flex-shrink: 0;
+  white-space: nowrap;
 }
 
 .carto-layers__item-source {
   font-size: 0.7rem;
   color: var(--text-mention-grey);
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.carto-layers__item-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  flex-shrink: 0;
+.carto-layers__item-source--missing {
+  color: var(--text-default-warning);
 }
 
-.carto-layers__btn-eye {
+.carto-icon-btn {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 2px;
+  padding: 2px 4px;
   font-size: 0.875rem;
   color: var(--text-mention-grey);
-  border-radius: 2px;
-  transition: color 0.15s;
 }
 
-.carto-layers__btn-eye:hover {
+.carto-icon-btn:hover {
   color: var(--text-action-high-blue-france);
 }
 
-.carto-layers__btn-eye--hidden {
-  opacity: 0.4;
-}
-
-/* ---- Drag & drop ---- */
-.carto-layers__item.dragging {
-  opacity: 0.4;
-}
-
-.carto-layers__item.drag-over {
-  border-top: 2px solid var(--border-action-high-blue-france);
-}
-
-/* ---- Collapsible sections (accordion) ---- */
-.config-section {
-  margin-bottom: 0.5rem;
-  border-bottom: 1px solid var(--border-default-grey);
-  padding-bottom: 0.5rem;
-}
-
-.config-section:last-child {
-  border-bottom: none;
-}
-
-.config-section-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+.carto-link-btn {
+  border: none;
+  background: none;
+  color: var(--text-action-high-blue-france);
   cursor: pointer;
-  user-select: none;
-  padding: 0.5rem 0;
+  font-size: 0.8125rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: inherit;
+  padding: 0.25rem 0.5rem;
 }
 
-.config-section-header:hover {
-  opacity: 0.8;
+.carto-link-btn:hover {
+  background: var(--background-contrast-grey, #ececec);
 }
 
-.config-section-header h3 {
-  margin: 0;
-  font-size: 0.875rem;
-  font-weight: 700;
+.carto-text-link {
+  border: none;
+  background: none;
+  color: var(--text-action-high-blue-france);
+  cursor: pointer;
+  font-size: 0.75rem;
+  text-decoration: underline;
+  font-family: inherit;
+  padding: 0;
+  text-transform: none;
+  letter-spacing: normal;
+  font-weight: 400;
+}
+
+/* ---- Carte source de la couche ---- */
+.carto-source-ok {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem 0.625rem;
+  background: var(--background-contrast-success, #dffee6);
+}
+
+.carto-source-ok i {
+  color: var(--text-default-success, #18753c);
+  font-size: 1rem;
+}
+
+.carto-source-ok__body {
+  min-width: 0;
+}
+
+.carto-source-ok__name {
+  font-size: 0.8125rem;
+  font-weight: 600;
   color: var(--text-title-grey);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.carto-source-ok__detail {
+  font-size: 0.75rem;
+  color: var(--text-default-success, #18753c);
+}
+
+.carto-source-choose {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.625rem;
+  border: 1px dashed var(--border-default-grey);
+  background: none;
+  color: var(--text-action-high-blue-france);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-family: inherit;
+  text-align: center;
+}
+
+.carto-source-choose:hover {
+  background: var(--background-alt-grey);
+}
+
+/* ---- Tuiles de representation ---- */
+.carto-tiles {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.375rem;
+}
+
+.carto-tile {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.125rem;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid var(--border-default-grey);
+  background: var(--background-default-grey);
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+}
+
+.carto-tile--active {
+  border-color: var(--border-action-high-blue-france);
+  background: var(--background-alt-blue-france);
+}
+
+.carto-tile i {
+  font-size: 1.125rem;
+  color: var(--text-action-high-blue-france);
+}
+
+.carto-tile__label {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-title-grey);
+}
+
+.carto-tile__desc {
+  font-size: 0.7rem;
+  color: var(--text-mention-grey);
+  line-height: 1.3;
+}
+
+/* ---- Nuancier ---- */
+.carto-swatches {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
-.config-section-header .collapse-icon {
-  transition: transform 0.2s;
-  font-size: 1rem;
-  color: var(--text-mention-grey);
+.carto-swatch {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border-default-grey);
+  cursor: pointer;
+  padding: 0;
 }
 
-.config-section.collapsed .collapse-icon {
-  transform: rotate(-90deg);
+.carto-swatch--active {
+  outline: 2px solid var(--border-active-blue-france, #0a76f6);
+  outline-offset: 2px;
 }
 
-.config-section-content {
-  overflow: hidden;
-  max-height: 2000px;
-  transition:
-    max-height 0.3s ease,
-    padding 0.3s ease;
+.carto-swatch-custom {
+  width: 36px;
+  height: 32px;
+  padding: 0.125rem;
+  border: 1px solid var(--border-default-grey);
+  background: var(--background-default-grey);
+  cursor: pointer;
 }
 
-.config-section.collapsed .config-section-content {
-  max-height: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-}
-
-/* ---- Preview ---- */
-.carto-preview__map {
-  flex: 1;
-  min-height: 400px;
-}
-
-/* ---- Code output ---- */
-.carto-code {
-  background: #1e1e1e;
-  color: #d4d4d4;
-  padding: 1rem;
-  border-radius: 4px;
-  font-family: monospace;
-  font-size: 0.8rem;
-  overflow-x: auto;
-  white-space: pre-wrap;
-  max-height: 500px;
-  overflow-y: auto;
-}
-
-/* ---- Form helpers ---- */
+/* ---- Champs de formulaire ---- */
 .carto-field {
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.625rem;
 }
 
 .carto-field label {
@@ -233,145 +566,413 @@
 
 .carto-field .fr-hint-text {
   font-size: 0.75rem;
-  color: var(--text-mention-grey);
   font-weight: normal;
+  margin-bottom: 0;
 }
 
-.carto-field select,
 .carto-field input[type='text'],
-.carto-field input[type='number'] {
+.carto-field input[type='number'],
+.carto-field select,
+.carto-field textarea {
   width: 100%;
+  box-sizing: border-box;
   padding: 0.375rem 0.5rem;
   border: 1px solid var(--border-default-grey);
-  border-radius: 4px;
+  background: var(--background-default-grey);
+  color: var(--text-default-grey);
   font-size: 0.8125rem;
+  font-family: inherit;
+  border-radius: 0;
 }
 
 .carto-field textarea {
-  width: 100%;
-  padding: 0.375rem 0.5rem;
-  border: 1px solid var(--border-default-grey);
-  border-radius: 4px;
-  font-size: 0.8125rem;
   font-family: monospace;
   resize: vertical;
-  min-height: 80px;
-}
-
-.carto-field input[type='color'] {
-  width: 40px;
-  height: 32px;
-  border: 1px solid var(--border-default-grey);
-  border-radius: 4px;
-  cursor: pointer;
 }
 
 .carto-inline {
   display: flex;
   gap: 0.5rem;
-  align-items: end;
 }
 
-.carto-inline > .carto-field {
-  flex: 1;
-}
-
-.carto-checkbox {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.carto-checkbox label {
-  font-size: 0.8125rem;
-  font-weight: normal;
-}
-
-/* ---- No-layer placeholder ---- */
-.carto-col-config__empty {
-  text-align: center;
-  padding: 2rem 1rem;
-  color: var(--text-mention-grey);
-}
-
-/* --- Réalignement #461 : assistance, disclosures, statut d'aperçu --- */
-
-.carto-badge {
-  display: inline-block;
-  font-size: 0.7rem;
-  font-weight: 500;
-  padding: 0 0.4rem;
-  border-radius: 0.75rem;
-  background: var(--background-contrast-grey);
-  color: var(--text-mention-grey);
-  vertical-align: middle;
-}
-.carto-badge--ok {
-  background: var(--background-contrast-success, #dffee6);
-  color: var(--text-default-success, #18753c);
-}
-
-.carto-advanced {
-  margin: 0.5rem 0;
-  border-left: 2px solid var(--border-default-grey, #ddd);
-  padding-left: 0.75rem;
-}
-.carto-advanced > summary {
-  cursor: pointer;
-  font-size: 0.8125rem;
-  color: var(--text-action-high-blue-france, #000091);
-  padding: 0.25rem 0;
-  list-style-position: inside;
-}
-.carto-advanced[open] > summary {
-  margin-bottom: 0.5rem;
-}
-
-.carto-url-row {
-  display: flex;
-  gap: 0.5rem;
-  align-items: stretch;
-}
-.carto-url-row input {
+.carto-inline .carto-field {
   flex: 1;
   min-width: 0;
 }
 
-.carto-scan-status {
-  font-size: 0.8125rem;
-  min-height: 1.25rem;
-  color: var(--text-mention-grey);
-}
-.carto-scan-status code {
-  font-size: 0.75rem;
-  background: var(--background-contrast-grey);
-  padding: 0 0.25rem;
-  border-radius: 2px;
+.carto-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.375rem;
 }
 
-.carto-preview-status {
-  font-size: 0.8125rem;
-  padding: 0.375rem 0.25rem;
-  min-height: 1.5rem;
-  color: var(--text-mention-grey);
+.carto-checkbox input {
+  margin-top: 0.2rem;
+  flex-shrink: 0;
 }
-.carto-preview-status--ok {
+
+.carto-checkbox label {
+  font-size: 0.8125rem;
+}
+
+.carto-checkbox .fr-hint-text {
+  font-size: 0.75rem;
+  margin-bottom: 0;
+}
+
+/* ---- Disclosures « avance » ---- */
+.carto-advanced {
+  border-left: 2px solid var(--border-default-grey);
+  padding-left: 0.75rem;
+  margin-bottom: 0.625rem;
+}
+
+.carto-advanced > summary {
+  cursor: pointer;
+  font-size: 0.8125rem;
+  color: var(--text-action-high-blue-france);
+  padding: 0.25rem 0;
+}
+
+.carto-advanced > *:not(summary) {
+  margin-top: 0.5rem;
+}
+
+/* ---- Cases a cocher des champs de la fiche ---- */
+.carto-field-checks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-bottom: 0.5rem;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.carto-field-checks label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  cursor: pointer;
+}
+
+/* ---- Messages ---- */
+.carto-msg {
+  margin: 0 0 0.5rem;
+  font-size: 0.75rem;
+}
+
+.carto-msg--ok {
   color: var(--text-default-success, #18753c);
 }
-.carto-preview-status--warn {
+
+.carto-msg--warn {
   color: var(--text-default-warning, #b34000);
 }
-.carto-preview-status--err {
-  color: var(--text-default-error, #ce0500);
+
+.carto-msg--muted {
+  color: var(--text-mention-grey);
+}
+
+/* ---- Statut d'analyse de source ---- */
+.carto-scan-status {
+  font-size: 0.75rem;
+  color: var(--text-mention-grey);
+  min-height: 1rem;
+  margin-top: 0.375rem;
 }
 
 .carto-spin {
   display: inline-block;
   animation: carto-spin 1s linear infinite;
 }
+
 @keyframes carto-spin {
   to {
     transform: rotate(360deg);
+  }
+}
+
+/* ---- Pastille de diagnostic ---- */
+.carto-status {
+  position: absolute;
+  left: 376px;
+  bottom: 16px;
+  z-index: 1000;
+  background: var(--background-default-grey, #fff);
+  border: 1px solid var(--border-default-grey);
+  box-shadow: 0 2px 6px rgba(0, 0, 18, 0.16);
+  padding: 0.5rem 0.875rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--text-default-grey);
+  max-width: min(60vw, 640px);
+}
+
+.carto-status--ok {
+  color: var(--text-default-success);
+}
+
+.carto-status--warn {
+  color: var(--text-default-warning);
+}
+
+.carto-status--err {
+  color: var(--text-default-error);
+}
+
+/* ---- Modales ---- */
+.carto-modal-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1200;
+  background: rgba(22, 22, 22, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.carto-modal-overlay--dark {
+  z-index: 1300;
+  background: rgba(22, 22, 22, 0.64);
+}
+
+.carto-modal {
+  width: 520px;
+  max-width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  background: var(--background-default-grey, #fff);
+  box-shadow:
+    0 8px 16px rgba(0, 0, 0, 0.1),
+    0 8px 32px rgba(0, 0, 0, 0.32);
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.carto-modal--wide {
+  width: 680px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow-y: hidden;
+}
+
+.carto-modal__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.carto-modal__title {
+  margin: 0 0 0.25rem;
+  font-size: 1.375rem;
+  line-height: 1.875rem;
+  color: var(--text-title-grey);
+}
+
+.carto-modal__subtitle {
+  margin: 0 0 1.25rem;
+  font-size: 0.875rem;
+  color: var(--text-mention-grey);
+}
+
+.carto-modal__close {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1.125rem;
+  color: var(--text-action-high-blue-france);
+  padding: 0.25rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: inherit;
+}
+
+.carto-modal__close:hover {
+  background: var(--background-alt-grey);
+}
+
+/* Options de l'onboarding */
+.carto-choice {
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  padding: 0.875rem 1rem;
+  margin-bottom: 0.5rem;
+  border: 1px solid var(--border-default-grey);
+  background: var(--background-default-grey);
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+}
+
+.carto-choice:hover {
+  background: var(--background-alt-grey);
+}
+
+.carto-choice--featured {
+  border-color: var(--border-action-high-blue-france);
+  background: var(--background-alt-blue-france, #f5f5fe);
+}
+
+.carto-choice--featured:hover {
+  background: var(--background-alt-blue-france-hover, #ececfe);
+}
+
+.carto-choice > i:first-child {
+  font-size: 1.5rem;
+  color: var(--text-action-high-blue-france);
+  flex-shrink: 0;
+}
+
+.carto-choice__body {
+  min-width: 0;
+  flex: 1;
+}
+
+.carto-choice__title {
+  display: block;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--text-title-grey);
+}
+
+.carto-choice__desc {
+  display: block;
+  font-size: 0.8125rem;
+  color: var(--text-mention-grey);
+}
+
+.carto-choice__arrow {
+  margin-left: auto;
+  color: var(--text-action-high-blue-france);
+  flex-shrink: 0;
+}
+
+.carto-url-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  padding: 0.75rem;
+  background: var(--background-alt-grey, #f6f6f6);
+}
+
+.carto-url-row input {
+  flex: 1;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 0.5rem;
+  border: 1px solid var(--border-default-grey);
+  font-size: 0.8125rem;
+  font-family: inherit;
+}
+
+.carto-url-row button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: var(--background-action-high-blue-france);
+  color: var(--text-inverted-blue-france, #f5f5fe);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-family: inherit;
+}
+
+.carto-saved-list {
+  margin-bottom: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: var(--background-alt-grey, #f6f6f6);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.carto-saved-list button {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  border: none;
+  background: none;
+  color: var(--text-action-high-blue-france);
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-family: inherit;
+  text-align: left;
+  padding: 0.375rem 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.carto-saved-list button:hover {
+  background: var(--background-contrast-grey, #ececec);
+}
+
+/* Modale export */
+.carto-export__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem 0;
+}
+
+.carto-export__head h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: var(--text-title-grey);
+}
+
+.carto-export__body {
+  padding: 0.75rem 1.5rem 1.5rem;
+  overflow-y: auto;
+}
+
+.carto-export__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.carto-export__toolbar select {
+  padding: 0.5rem;
+  border: 1px solid var(--border-default-grey);
+  font-size: 0.8125rem;
+  font-family: inherit;
+  background: var(--background-default-grey);
+}
+
+.carto-code {
+  background: #1e1e1e;
+  color: #d4d4d4;
+  padding: 1rem;
+  font-family: monospace;
+  font-size: 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: auto;
+  max-height: 45vh;
+  margin: 0;
+}
+
+/* ---- Ecrans etroits : la colonne s'adapte ---- */
+@media (max-width: 760px) {
+  .carto-panels {
+    width: calc(100vw - 32px);
+  }
+
+  .carto-status {
+    left: 16px;
+    bottom: auto;
+    top: 64px;
   }
 }

--- a/packages/shared/src/tour/tour-configs.ts
+++ b/packages/shared/src/tour/tour-configs.ts
@@ -76,35 +76,42 @@ export const BUILDER_IA_TOUR: TourConfig = {
 export const BUILDER_CARTO_TOUR: TourConfig = {
   id: 'builder-carto',
   label: 'Builder Carto',
-  version: 1,
+  version: 2,
   steps: [
     {
-      selector: '#btn-add-layer',
-      title: 'Ajouter une couche',
+      selector: '#panel-couches',
+      title: 'Vos couches de données',
       description:
-        'Cliquez ici pour ajouter une couche de données sur la carte : marqueurs, zones colorees, cercles proportionnels ou carte de chaleur.',
-      position: 'bottom',
+        'Chaque couche a sa source de données et sa localisation. Ajoutez-en pour superposer plusieurs jeux de données sur la même carte.',
+      position: 'right',
     },
     {
-      selector: '.carto-col-config',
-      title: 'Configurer la couche',
+      selector: '#panel-elements',
+      title: 'La représentation',
       description:
-        "Choisissez la source de données, le type de couche, le champ geographique et les options d'affichage (popup, couleur, clustering...).",
+        'Marqueurs, zones colorees, cercles proportionnels ou carte de chaleur — puis couleurs, contenu du clic et options avancees.',
+      position: 'right',
+    },
+    {
+      selector: '#panel-carte',
+      title: 'La carte elle-même',
+      description:
+        "Fond de carte, encarts DROM et Corse, tableau d'accessibilite et reglages avances.",
       position: 'right',
     },
     {
       selector: '#btn-execute',
-      title: 'Prévisualiser',
+      title: 'La carte est l’aperçu',
       description:
-        'Cliquez sur "Executer" pour voir la carte en direct. Modifiez et re-executez autant de fois que necessaire.',
+        'La carte occupe tout l’écran : déplacez et zoomez, le cadrage exporté suit. "Executer" recharge l’aperçu et recadre sur les données.',
       position: 'bottom',
     },
     {
-      selector: 'app-preview-panel',
-      title: 'Carte et code',
+      selector: '#btn-export',
+      title: 'Obtenir le code',
       description:
-        'La carte s\'affiche ici. L\'onglet "Code" contient le HTML pret a copier-coller dans votre site.',
-      position: 'left',
+        'Le HTML pret a copier-coller dans votre site, en mode composants seuls ou page autonome.',
+      position: 'bottom',
     },
   ],
 };


### PR DESCRIPTION
## Refonte du builder carto

Implémente la maquette Claude Design « Builder carto - refonte » : l'app passe d'un layout 3 colonnes + panneau d'aperçu à une **carte plein écran qui EST l'aperçu**, éditée par panneaux flottants.

### Ce qui change

- **La carte est l'aperçu** : la vraie `dsfr-data-map` (pipeline complet) occupe tout l'écran ; le **cadrage exporté suit la navigation** (sync `moveend`/`zoomend` → state via `getLeafletMap()`). L'aperçu ne diffère de l'export que sur 3 points : hauteur plein écran, compagnon a11y omis, fit-bounds ponctuel sur « Exécuter ».
- **Barre du haut** : logo RF → hub, Guide, Favoris, « Obtenir le code », « Exécuter » (`app-header`/`app-preview-panel` retirés de cette app).
- **3 panneaux flottants** : Carte (replié par défaut) · Couches (liste, données, localisation avec détection auto) · Éléments (tuiles de représentation, nuancier DSFR + couleur libre, interactions, animation temporelle, options avancées).
- **Modale d'onboarding** « D'où viennent vos données ? » (jeu d'exemple 1 clic / URL / sources enregistrées) et **modale d'export** (embarqué/autonome, copie, favori, playground).
- **Encarts territoriaux visibles** en bandeau de vignettes dans l'aperçu ; le diagnostic « N éléments affichés » exclut leurs clones et se re-vérifie au retour de visibilité de l'onglet.
- **Tour guidé partagé réaligné** (v2, `packages/shared`) — démarre après le premier choix de données.
- Parité fonctionnelle conservée : bbox (+debounce/champ), shape-class, 8 fonds de carte, 12 territoires d'encart, drag & drop et suppression de couches, persistance/reprise de session, favoris, playground.

### Non modifié

`state.ts`, `ui/code-generator.ts`, `field-service.ts` — le code généré est identique.

### Vérifications

- 3 699 tests Vitest verts · typecheck · build Vite OK
- e2e smoke + axe WCAG 2a/2aa « Builder Carto » verts (contrats `#layers-list`, `#btn-execute`, `__BUILDER_CARTO_STATE__` préservés)
- `check:accents` propre · changeset patch inclus
- Validation visuelle Chrome : exemple → 13 marqueurs, panneau latéral au clic, vignettes DROM, code exporté correct (template popup auto + compagnon a11y)

🤖 Generated with [Claude Code](https://claude.com/claude-code)