### PR TITLE
feat(builder-carto): réintégrer <app-header> commun (nav inter-apps)

### DIFF
--- a/apps/builder-carto/index.html
+++ b/apps/builder-carto/index.html
@@ -4,14 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Générateur de cartes - dsfr-data</title>
-  <style>@view-transition{navigation:auto}</style>
+  <style>@view-transition{navigation:auto}app-header:not(:defined){display:block;min-height:96px}</style>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css" integrity="sha384-atVZ+aK6VI0nWyTEhKgze5InDJ+SWRRqa0BCZ2MTNyoOcBiHj1c3dGPdi6ML65B3" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/utility/utility.min.css" integrity="sha384-5P5DFFqorcEBpfnK9WHu/Ralfr7ZxyCZh0ryaJbgucSvc71+qRYdGvNEcyMqQwa/" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.2.0/fonts/remixicon.css" integrity="sha384-6FSSi597BTd6QcnsBNoLclRKxTOyyYqkaucRjFgCNr8wHVCp0COLClSPY4Vy/bjh" crossorigin="anonymous">
   <script type="module" src="../../packages/core/dist/dsfr-data.esm.js"></script>
+  <script type="module" src="../../packages/app-ui/dist/app-ui.esm.js"></script>
   <script type="module" src="src/main.ts"></script>
 </head>
 <body class="carto-app">
+  <app-header current-page="builder-carto" base-path="../../"></app-header>
   <main id="main-content" class="carto-workspace">
 
     <!-- Canevas : la carte generee est l'apercu permanent -->
@@ -22,20 +24,12 @@
       </p>
     </div>
 
-    <!-- Barre du haut -->
+    <!-- Barre d'actions carto (le header commun est rendu par <app-header>) -->
     <header class="carto-topbar">
-      <a class="carto-topbar__brand" href="../../index.html" title="Retour à l'accueil Charts builder">
-        <p class="fr-logo carto-topbar__logo">République<br>Française</p>
-      </a>
       <h1 class="carto-topbar__title">
-        <span class="carto-topbar__app">Charts builder</span>
-        <span class="carto-topbar__page">· Créer une carte</span>
+        <span class="carto-topbar__page">Créer une carte</span>
       </h1>
       <div class="carto-topbar__actions">
-        <a class="carto-topbar__guide" href="../../guide/index.html">Guide</a>
-        <button id="btn-favorite" class="carto-btn carto-btn--ghost" type="button" title="Sauvegarder en favori">
-          <i class="ri-star-line" aria-hidden="true"></i>Favoris
-        </button>
         <button id="btn-export" class="carto-btn carto-btn--secondary" type="button">
           <i class="ri-code-s-slash-line" aria-hidden="true"></i>Obtenir le code
         </button>

--- a/apps/builder-carto/src/main.ts
+++ b/apps/builder-carto/src/main.ts
@@ -907,7 +907,10 @@ function renderElementsPanel() {
 function bindElementsInputs(layer: LayerConfig) {
   const bind = (id: string, key: keyof LayerConfig, transform?: (v: string) => unknown) => {
     const el = document.getElementById(id) as
-      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement | null;
+      | HTMLInputElement
+      | HTMLSelectElement
+      | HTMLTextAreaElement
+      | null;
     if (!el) return;
     const eventType = el.tagName === 'TEXTAREA' ? 'input' : 'change';
     el.addEventListener(eventType, () => {
@@ -1546,7 +1549,7 @@ function sendToPlayground() {
   window.location.href = '../../apps/playground/index.html?from=builder-carto';
 }
 
-function saveFavorite(feedbackBtnId = 'btn-favorite') {
+function saveFavorite(feedbackBtnId = 'btn-export-favorite') {
   if (!state.layers.some((l) => l.visible && l.source)) {
     toastWarning(
       'Choisissez d’abord les données d’une couche, puis vous pourrez sauvegarder la carte en favori.'
@@ -1729,9 +1732,11 @@ function executePreview(fit = false) {
   state.generationMode = 'embedded';
   state.map.a11y = false;
   // Avec des encarts, une bande basse leur est réservée (vignettes).
+  // --carto-header-h : hauteur du <app-header> commun (mesurée au runtime,
+  // cf. bindStaticUi ci-dessous), + 56px pour la topbar carto locale.
   state.map.height = state.map.insets.length
-    ? 'calc(100dvh - 56px - 208px)'
-    : 'calc(100dvh - 56px)';
+    ? 'calc(100dvh - var(--carto-header-h, 96px) - 56px - 208px)'
+    : 'calc(100dvh - var(--carto-header-h, 96px) - 56px)';
   if (fit) state.map.fitBounds = true;
   const code = generateCode();
   state.generationMode = saved.mode;
@@ -1750,6 +1755,27 @@ function executePreview(fit = false) {
 // Init
 // ---------------------------------------------------------------------------
 
+/**
+ * Le <app-header> commun a une hauteur qui varie selon le breakpoint (menu
+ * mobile hors modale, tools stackés, tagline sur 2 lignes en desktop…).
+ * On mesure au runtime et on expose via --carto-header-h — utilisée à la
+ * fois par le CSS des panneaux et par le calc() de state.map.height.
+ */
+function observeHeaderHeight() {
+  const header = document.querySelector('app-header');
+  if (!header) return;
+  const apply = () => {
+    const h = Math.round(header.getBoundingClientRect().height);
+    if (h > 0) document.body.style.setProperty('--carto-header-h', `${h}px`);
+  };
+  apply();
+  if (typeof ResizeObserver !== 'undefined') {
+    new ResizeObserver(apply).observe(header);
+  } else {
+    window.addEventListener('resize', apply);
+  }
+}
+
 function bindStaticUi() {
   // Pliage / dépliage des panneaux
   document.querySelectorAll('[data-panel-toggle]').forEach((btn) => {
@@ -1766,7 +1792,6 @@ function bindStaticUi() {
   document.getElementById('btn-add-layer')?.addEventListener('click', addLayer);
   document.getElementById('btn-reset')?.addEventListener('click', resetBuilder);
   document.getElementById('btn-execute')?.addEventListener('click', () => executePreview(true));
-  document.getElementById('btn-favorite')?.addEventListener('click', () => saveFavorite());
   document.getElementById('btn-export')?.addEventListener('click', () => {
     ui.exportOpen = true;
     renderExport();
@@ -1792,6 +1817,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const restored = restoreState();
 
   bindStaticUi();
+  observeHeaderHeight();
   renderAll();
   persistState();
 

--- a/apps/builder-carto/src/styles/carto.css
+++ b/apps/builder-carto/src/styles/carto.css
@@ -2,15 +2,26 @@
 
 /* ---- Page ---- */
 body.carto-app {
+  /* --carto-header-h est mesurée au runtime (main.ts) pour compenser la
+     hauteur réelle du <app-header> commun, qui varie selon breakpoint. */
+  --carto-header-h: 96px;
   margin: 0;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+body.carto-app > app-header {
+  flex: 0 0 auto;
 }
 
 .carto-workspace {
   position: relative;
   width: 100vw;
-  height: 100vh;
-  height: 100dvh;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: hidden;
   background: var(--background-alt-grey, #f6f6f6);
 }
@@ -191,6 +202,9 @@ body.carto-app {
 }
 
 /* ---- Colonne de panneaux flottants ---- */
+/* Note : .carto-panels est positionnée par rapport à .carto-workspace
+   (l'<app-header> est en dehors du workspace, pas besoin de le
+   compenser ici — seule la topbar carto locale à 56px l'est). */
 .carto-panels {
   position: absolute;
   top: 72px;


### PR DESCRIPTION
## Contexte

La refonte carte plein écran (PR #472) avait volontairement retiré l'`app-header` partagé au profit d'une topbar carto minimaliste — on perdait la navigation vers les autres apps du monorepo (Sources, Builder, Dashboard, Playground…), ce qui isolait le builder-carto du reste de l'écosystème.

## Approche (option B validée en session)

Superposer les deux barres :
- **Header commun** (`<app-header>`) en haut avec la nav DSFR + les liens outils (Guide, Specs, Favoris, Mon espace)
- **Topbar carto** simplifiée en dessous avec les actions carto-spécifiques (Exécuter / Obtenir le code)

Les liens redondants sont retirés de la topbar carto :
- Logo « République Française » → présent dans `<app-header>`
- Lien « Guide » → présent dans `<app-header>`
- Bouton « Favoris » → doublon avec le lien Favoris du header + toujours accessible via la modale d'export (bouton `btn-export-favorite`)

## Layout

Passage de `position: absolute; height: 100dvh` (plein-viewport) à `body { display: flex; flex-direction: column }` avec le workspace en `flex: 1`.

Une CSS variable `--carto-header-h` est mesurée au runtime via `ResizeObserver` sur `<app-header>` (le `fr-header` varie selon breakpoint : mobile menu stack, tagline sur 2 lignes desktop…). Cette variable est consommée par :
- `state.map.height` : `calc(100dvh - var(--carto-header-h, 96px) - 56px [- 208px])`

Les offsets internes du workspace (canvas `top:56px`, panels `top:72px`) restent inchangés puisqu'ils sont relatifs au workspace, pas au body.

## Fichiers touchés

- `apps/builder-carto/index.html` — ajout du `<script app-ui.esm.js>` + `<app-header>` + simplification de la topbar carto
- `apps/builder-carto/src/main.ts` — `observeHeaderHeight()` (ResizeObserver → var CSS), retrait du binding `btn-favorite`, ajustement du calc `state.map.height`
- `apps/builder-carto/src/styles/carto.css` — body en flex column, workspace en flex:1, var `--carto-header-h`

Aucun changeset : rien dans `packages/core/src` ou `packages/shared`.

## Test plan

- [ ] Chrome desktop : header commun visible, topbar carto en dessous, carte occupe le reste de la hauteur sans scroll
- [ ] Nav vers Sources / Builder / Dashboard depuis le menu commun
- [ ] Redimensionnement fenêtre : `--carto-header-h` s'actualise, la carte se réajuste
- [ ] Encarts territoriaux (DROM) : bande basse toujours de 208px
- [ ] Sauvegarde en favori via la modale « Obtenir le code » (bouton reste fonctionnel)
- [ ] Mobile : header menu-modal fonctionnel (à vérifier sur breakpoint <768px)

## Refs

- Session 2026-08-19 (écluse Dependabot + release v0.16.2 + merge #472 + demande utilisateur)
- La refonte carto originelle : PR #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)