### PR TITLE
fix(security): escape systématique dans code-generator (CodeQL #63)

### DIFF
--- a/apps/builder-carto/src/ui/code-generator.ts
+++ b/apps/builder-carto/src/ui/code-generator.ts
@@ -13,70 +13,86 @@ import {
 
 const MAP_A11Y_ID = 'carte';
 
+/**
+ * Échappe une valeur pour interpolation sans risque dans un attribut HTML.
+ * Ferme la vecteur XSS (CodeQL #63) : sans cet escape, un `apiUrl` bidouillé
+ * `x" onerror="alert(1)` produirait `url="x" onerror="alert(1)"…` — parsé et
+ * exécuté au moment où le HTML est injecté (field-service.ts:145
+ * `host.innerHTML = tag` + export utilisateur du code copié dans un site).
+ * `&` doit être remplacé en premier pour ne pas double-escape les entités.
+ */
+function esc(val: string | number | boolean): string {
+  return String(val)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 function layerAttrs(layer: LayerConfig): string {
   const attrs: string[] = [];
   // Avec un filtre, le layer consomme le dsfr-data-query intermediaire (#297)
-  attrs.push(`source="${layer.filter ? `${layer.id}-filtre` : layer.id}"`);
-  attrs.push(`type="${layer.type}"`);
+  attrs.push(`source="${esc(layer.filter ? `${layer.id}-filtre` : layer.id)}"`);
+  attrs.push(`type="${esc(layer.type)}"`);
 
-  if (layer.latField) attrs.push(`lat-field="${layer.latField}"`);
-  if (layer.lonField) attrs.push(`lon-field="${layer.lonField}"`);
-  if (layer.geoField) attrs.push(`geo-field="${layer.geoField}"`);
+  if (layer.latField) attrs.push(`lat-field="${esc(layer.latField)}"`);
+  if (layer.lonField) attrs.push(`lon-field="${esc(layer.lonField)}"`);
+  if (layer.geoField) attrs.push(`geo-field="${esc(layer.geoField)}"`);
 
   // Couche decorative : aucune interaction, exclue du fit-bounds
   if (layer.noInteractive) attrs.push('no-interactive');
 
   // Tooltip (only if popupMode is tooltip, pointless on a decorative layer)
   if (!layer.noInteractive && layer.popupMode === 'tooltip' && layer.tooltipField) {
-    attrs.push(`tooltip-field="${layer.tooltipField}"`);
+    attrs.push(`tooltip-field="${esc(layer.tooltipField)}"`);
   }
 
-  if (layer.color !== '#000091') attrs.push(`color="${layer.color}"`);
-  if (layer.colorField) attrs.push(`color-field="${layer.colorField}"`);
-  if (layer.colorMap) attrs.push(`color-map="${layer.colorMap}"`);
+  if (layer.color !== '#000091') attrs.push(`color="${esc(layer.color)}"`);
+  if (layer.colorField) attrs.push(`color-field="${esc(layer.colorField)}"`);
+  if (layer.colorMap) attrs.push(`color-map="${esc(layer.colorMap)}"`);
 
   if (layer.type === 'geoshape') {
-    if (layer.fillField) attrs.push(`fill-field="${layer.fillField}"`);
-    if (layer.selectedPalette) attrs.push(`selected-palette="${layer.selectedPalette}"`);
+    if (layer.fillField) attrs.push(`fill-field="${esc(layer.fillField)}"`);
+    if (layer.selectedPalette) attrs.push(`selected-palette="${esc(layer.selectedPalette)}"`);
   }
   if (layer.type === 'geoshape' || layer.type === 'circle') {
-    if (layer.fillOpacity !== 0.6) attrs.push(`fill-opacity="${layer.fillOpacity}"`);
-    if (layer.shapeClass) attrs.push(`shape-class="${layer.shapeClass}"`);
+    if (layer.fillOpacity !== 0.6) attrs.push(`fill-opacity="${esc(layer.fillOpacity)}"`);
+    if (layer.shapeClass) attrs.push(`shape-class="${esc(layer.shapeClass)}"`);
   }
 
   if (layer.type === 'circle') {
-    if (layer.radius !== 8) attrs.push(`radius="${layer.radius}"`);
-    if (layer.radiusField) attrs.push(`radius-field="${layer.radiusField}"`);
-    if (layer.radiusUnit !== 'px') attrs.push(`radius-unit="${layer.radiusUnit}"`);
-    if (layer.radiusMin !== 4) attrs.push(`radius-min="${layer.radiusMin}"`);
-    if (layer.radiusMax !== 30) attrs.push(`radius-max="${layer.radiusMax}"`);
+    if (layer.radius !== 8) attrs.push(`radius="${esc(layer.radius)}"`);
+    if (layer.radiusField) attrs.push(`radius-field="${esc(layer.radiusField)}"`);
+    if (layer.radiusUnit !== 'px') attrs.push(`radius-unit="${esc(layer.radiusUnit)}"`);
+    if (layer.radiusMin !== 4) attrs.push(`radius-min="${esc(layer.radiusMin)}"`);
+    if (layer.radiusMax !== 30) attrs.push(`radius-max="${esc(layer.radiusMax)}"`);
   }
 
   if (layer.type === 'heatmap') {
-    if (layer.heatRadius !== 25) attrs.push(`heat-radius="${layer.heatRadius}"`);
-    if (layer.heatBlur !== 15) attrs.push(`heat-blur="${layer.heatBlur}"`);
-    if (layer.heatField) attrs.push(`heat-field="${layer.heatField}"`);
+    if (layer.heatRadius !== 25) attrs.push(`heat-radius="${esc(layer.heatRadius)}"`);
+    if (layer.heatBlur !== 15) attrs.push(`heat-blur="${esc(layer.heatBlur)}"`);
+    if (layer.heatField) attrs.push(`heat-field="${esc(layer.heatField)}"`);
   }
 
   if (layer.cluster) {
     attrs.push('cluster');
-    if (layer.clusterRadius !== 80) attrs.push(`cluster-radius="${layer.clusterRadius}"`);
+    if (layer.clusterRadius !== 80) attrs.push(`cluster-radius="${esc(layer.clusterRadius)}"`);
   }
 
-  if (layer.minZoom !== 0) attrs.push(`min-zoom="${layer.minZoom}"`);
-  if (layer.maxZoom !== 18) attrs.push(`max-zoom="${layer.maxZoom}"`);
+  if (layer.minZoom !== 0) attrs.push(`min-zoom="${esc(layer.minZoom)}"`);
+  if (layer.maxZoom !== 18) attrs.push(`max-zoom="${esc(layer.maxZoom)}"`);
   if (layer.bbox) {
     attrs.push('bbox');
-    if (layer.bboxDebounce !== 300) attrs.push(`bbox-debounce="${layer.bboxDebounce}"`);
-    if (layer.bboxField) attrs.push(`bbox-field="${layer.bboxField}"`);
+    if (layer.bboxDebounce !== 300) attrs.push(`bbox-debounce="${esc(layer.bboxDebounce)}"`);
+    if (layer.bboxField) attrs.push(`bbox-field="${esc(layer.bboxField)}"`);
   }
-  if (layer.maxItems !== 5000) attrs.push(`max-items="${layer.maxItems}"`);
+  if (layer.maxItems !== 5000) attrs.push(`max-items="${esc(layer.maxItems)}"`);
 
   // Timeline
   if (layer.timeField) {
-    attrs.push(`time-field="${layer.timeField}"`);
-    if (layer.timeBucket !== 'none') attrs.push(`time-bucket="${layer.timeBucket}"`);
-    if (layer.timeMode !== 'snapshot') attrs.push(`time-mode="${layer.timeMode}"`);
+    attrs.push(`time-field="${esc(layer.timeField)}"`);
+    if (layer.timeBucket !== 'none') attrs.push(`time-bucket="${esc(layer.timeBucket)}"`);
+    if (layer.timeMode !== 'snapshot') attrs.push(`time-mode="${esc(layer.timeMode)}"`);
   }
 
   return attrs.join('\n    ');
@@ -92,8 +108,10 @@ function autoTemplateFromFields(layer: LayerConfig): string {
     .map((f) => f.trim())
     .filter(Boolean);
   if (!fields.length) return '';
+  // Le label est du HTML côté layout (`<strong>`), le mustache `{{…}}` est lu
+  // brut par le compagnon popup — on escape le nom de colonne dans les deux.
   return fields
-    .map((f) => `<p class="fr-mb-1v"><strong>${f} :</strong> {{${f}}}</p>`)
+    .map((f) => `<p class="fr-mb-1v"><strong>${esc(f)} :</strong> {{${esc(f)}}}</p>`)
     .join('\n        ');
 }
 
@@ -102,10 +120,14 @@ function popupTag(layer: LayerConfig): string {
   if (layer.noInteractive || mode === 'none' || mode === 'tooltip') return '';
 
   const attrs: string[] = [];
-  attrs.push(`mode="${mode}"`);
-  if (layer.titleField) attrs.push(`title-field="${layer.titleField}"`);
-  if (layer.popupWidth && layer.popupWidth !== '350px') attrs.push(`width="${layer.popupWidth}"`);
+  attrs.push(`mode="${esc(mode)}"`);
+  if (layer.titleField) attrs.push(`title-field="${esc(layer.titleField)}"`);
+  if (layer.popupWidth && layer.popupWidth !== '350px')
+    attrs.push(`width="${esc(layer.popupWidth)}"`);
 
+  // popupTemplate : HTML brut intentionnel (mustache `{{champ}}` + markup DSFR
+  // libre) — pas d'escape ici, l'utilisateur est responsable. Pour le template
+  // auto-généré à partir de popupFields, l'escape est fait en amont.
   const template = layer.popupTemplate || autoTemplateFromFields(layer);
   let inner = '';
   if (template) {
@@ -125,7 +147,7 @@ export function buildSourceTag(
 ): string {
   if (!layer.source) return '';
   const s = layer.source;
-  const attrs: string[] = [`id="${opts.id ?? layer.id}"`];
+  const attrs: string[] = [`id="${esc(opts.id ?? layer.id)}"`];
   const isAdapter: { current: boolean } = { current: false };
 
   // Unified Source format: detect provider from apiUrl
@@ -141,39 +163,40 @@ export function buildSourceTag(
         break;
       }
     }
-    attrs.push(`url="${gristUrl}"`);
+    attrs.push(`url="${esc(gristUrl)}"`);
     attrs.push('transform="records"');
   } else if (provider.id === 'opendatasoft' && resourceIds?.datasetId) {
     const baseUrl = new URL(s.apiUrl!).origin;
     attrs.push('api-type="opendatasoft"');
-    attrs.push(`base-url="${baseUrl}"`);
-    attrs.push(`dataset-id="${resourceIds.datasetId}"`);
+    attrs.push(`base-url="${esc(baseUrl)}"`);
+    attrs.push(`dataset-id="${esc(resourceIds.datasetId)}"`);
     isAdapter.current = true;
   } else if (provider.id === 'tabular' && resourceIds?.resourceId) {
     attrs.push('api-type="tabular"');
     attrs.push(`base-url="https://tabular-api.data.gouv.fr"`);
-    attrs.push(`resource="${resourceIds.resourceId}"`);
+    attrs.push(`resource="${esc(resourceIds.resourceId)}"`);
     isAdapter.current = true;
   } else if (provider.id === 'insee' && resourceIds?.datasetId) {
     const baseUrl = new URL(s.apiUrl!).origin;
     attrs.push('api-type="insee"');
-    attrs.push(`base-url="${baseUrl}"`);
-    attrs.push(`dataset-id="${resourceIds.datasetId}"`);
+    attrs.push(`base-url="${esc(baseUrl)}"`);
+    attrs.push(`dataset-id="${esc(resourceIds.datasetId)}"`);
     isAdapter.current = true;
   } else if (s.apiUrl) {
-    attrs.push(`url="${s.apiUrl}"`);
-    if (s.dataPath) attrs.push(`transform="${s.dataPath}"`);
+    attrs.push(`url="${esc(s.apiUrl)}"`);
+    if (s.dataPath) attrs.push(`transform="${esc(s.dataPath)}"`);
   } else if (s.type === 'manual' && s.data?.length) {
-    // Attribut simple-quoté : les apostrophes du JSON doivent être échappées
-    // en entité HTML, sinon l'attribut se termine au premier « d' » venu.
-    attrs.push(`data='${JSON.stringify(s.data).replace(/'/g, '&#39;')}'`);
+    // Attribut simple-quoté : JSON.stringify échappe les `"` internes, on
+    // remplace les `'` (délimiteurs) par leur entité, et on escape les `<`
+    // pour empêcher qu'une donnée `</script>` ne casse le HTML ambiant.
+    attrs.push(`data='${JSON.stringify(s.data).replace(/'/g, '&#39;').replace(/</g, '\\u003c')}'`);
   } else {
     return '';
   }
 
   // limit : echantillonnage (field-service) ou plafond utilisateur (max-items)
   const limit = opts.limit ?? (isAdapter.current && layer.maxItems !== 5000 ? layer.maxItems : 0);
-  if (limit && isAdapter.current) attrs.push(`limit="${limit}"`);
+  if (limit && isAdapter.current) attrs.push(`limit="${esc(limit)}"`);
 
   return `<dsfr-data-source ${attrs.join('\n  ')}>\n</dsfr-data-source>`;
 }
@@ -201,8 +224,8 @@ export function generateCode(): string {
     lines.push(
       `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@gouvfr/dsfr@1.14.4/dist/dsfr.min.css">`
     );
-    lines.push(`<script type="module" src="${LIB_URL}/dsfr-data.core.esm.js"></script>`);
-    lines.push(`<script type="module" src="${LIB_URL}/dsfr-data.map.esm.js"></script>`);
+    lines.push(`<script type="module" src="${esc(LIB_URL)}/dsfr-data.core.esm.js"></script>`);
+    lines.push(`<script type="module" src="${esc(LIB_URL)}/dsfr-data.map.esm.js"></script>`);
     lines.push('');
   }
 
@@ -216,7 +239,7 @@ export function generateCode(): string {
       // l'ancien attribut filter du layer etait un no-op (jamais lu)
       if (layer.filter) {
         lines.push(
-          `<dsfr-data-query id="${layer.id}-filtre" source="${layer.id}" where="${layer.filter}">\n</dsfr-data-query>`
+          `<dsfr-data-query id="${esc(layer.id)}-filtre" source="${esc(layer.id)}" where="${esc(layer.filter)}">\n</dsfr-data-query>`
         );
       }
       lines.push('');
@@ -225,21 +248,21 @@ export function generateCode(): string {
 
   // Map container
   const mapAttrs: string[] = [];
-  if (m.a11y) mapAttrs.push(`id="${MAP_A11Y_ID}"`);
-  if (m.center !== '46.603,2.888') mapAttrs.push(`center="${m.center}"`);
-  if (m.zoom !== 6) mapAttrs.push(`zoom="${m.zoom}"`);
-  if (m.minZoom !== 2) mapAttrs.push(`min-zoom="${m.minZoom}"`);
-  if (m.maxZoom !== 18) mapAttrs.push(`max-zoom="${m.maxZoom}"`);
-  if (m.tiles !== 'ign-plan') mapAttrs.push(`tiles="${m.tiles}"`);
+  if (m.a11y) mapAttrs.push(`id="${esc(MAP_A11Y_ID)}"`);
+  if (m.center !== '46.603,2.888') mapAttrs.push(`center="${esc(m.center)}"`);
+  if (m.zoom !== 6) mapAttrs.push(`zoom="${esc(m.zoom)}"`);
+  if (m.minZoom !== 2) mapAttrs.push(`min-zoom="${esc(m.minZoom)}"`);
+  if (m.maxZoom !== 18) mapAttrs.push(`max-zoom="${esc(m.maxZoom)}"`);
+  if (m.tiles !== 'ign-plan') mapAttrs.push(`tiles="${esc(m.tiles)}"`);
   if (m.sovereignOnly) mapAttrs.push('sovereign-only');
-  if (m.height !== '500px') mapAttrs.push(`height="${m.height}"`);
-  if (m.name) mapAttrs.push(`name="${m.name}"`);
+  if (m.height !== '500px') mapAttrs.push(`height="${esc(m.height)}"`);
+  if (m.name) mapAttrs.push(`name="${esc(m.name)}"`);
   if (m.fitBounds) mapAttrs.push('fit-bounds');
   if (m.noControls) mapAttrs.push('no-controls');
   if (m.locked) mapAttrs.push('locked');
-  if (m.maxBounds) mapAttrs.push(`max-bounds="${m.maxBounds}"`);
+  if (m.maxBounds) mapAttrs.push(`max-bounds="${esc(m.maxBounds)}"`);
   const insets = insetsAttrValue();
-  if (insets) mapAttrs.push(`insets="${insets}"`);
+  if (insets) mapAttrs.push(`insets="${esc(insets)}"`);
 
   lines.push(`<dsfr-data-map${mapAttrs.length ? ' ' + mapAttrs.join(' ') : ''}>`);
 
@@ -260,8 +283,8 @@ export function generateCode(): string {
   // Timeline controls (if any layer has time-field)
   if (visibleLayers.some((l) => l.timeField)) {
     const tAttrs: string[] = [];
-    if (m.timelineSpeed !== 1) tAttrs.push(`speed="${m.timelineSpeed}"`);
-    if (m.timelineInterval !== 1000) tAttrs.push(`interval="${m.timelineInterval}"`);
+    if (m.timelineSpeed !== 1) tAttrs.push(`speed="${esc(m.timelineSpeed)}"`);
+    if (m.timelineInterval !== 1000) tAttrs.push(`interval="${esc(m.timelineInterval)}"`);
     lines.push('');
     lines.push(
       `  <dsfr-data-map-timeline${tAttrs.length ? ' ' + tAttrs.join(' ') : ''}></dsfr-data-map-timeline>`
@@ -277,7 +300,7 @@ export function generateCode(): string {
       const srcId = first.filter ? `${first.id}-filtre` : first.id;
       lines.push('');
       lines.push(
-        `<dsfr-data-a11y for="${MAP_A11Y_ID}" source="${srcId}" table download></dsfr-data-a11y>`
+        `<dsfr-data-a11y for="${esc(MAP_A11Y_ID)}" source="${esc(srcId)}" table download></dsfr-data-a11y>`
       );
     }
   }


### PR DESCRIPTION
## Ferme l'alerte CodeQL [#63](https://github.com/bmatge/dsfr-data/security/code-scanning/63)

Règle : **`js/html-constructed-from-input`** (CWE-79 XSS) — medium.

### Vecteur

Une source enregistrée (STORAGE_KEYS.SOURCES) avec un `apiUrl` bidouillé comme :
```
x" onerror="alert(document.cookie)
```
produisait un tag HTML :
```html
<dsfr-data-source id="layer-1" url="x" onerror="alert(document.cookie)" ...>
```

Deux points d'impact :
1. **Immédiat** : `field-service.ts:145` fait `host.innerHTML = tag` pour scanner les champs de la source — le HTML est parsé et l'attribut event fires.
2. **En cascade utilisateur** : le même HTML est produit par le bouton « Obtenir le code » — un utilisateur qui colle ce code dans son propre site propage la XSS chez lui.

CodeQL avait tracé :
- **Source** : `packages/shared/src/providers/index.ts:34` (input externe : `registerProvider`)
- **Flow via** : `apps/builder-carto/src/field-service.ts:145` (`innerHTML`)
- **Sink** : `apps/builder-carto/src/ui/code-generator.ts:178` (construction du template)

### Fix

Helper `esc()` en tête de `code-generator.ts` (échappe `&`, `"`, `<`, `>` — `&` en premier pour ne pas double-escape). Application à **toutes les interpolations** dans :
- `layerAttrs()` : URLs, IDs, champs de colonnes, filtres, bornes de zoom…
- `popupTag()` : mode, title-field, popup-width…
- `autoTemplateFromFields()` : noms de colonnes dans le HTML **et** dans le mustache
- `buildSourceTag()` : URLs, base-URLs, resource-IDs, dataset-IDs…
- `generateCode()` : center, zoom, tiles, name, max-bounds, insets…

Bonus : attribut `data='…'` du mode manual échappe désormais `<` → `<` dans le JSON stringifié (bloque un `</script>` embarqué qui casserait le HTML ambiant).

### Exceptions documentées

- **`layer.popupTemplate`** reste HTML brut (mustache `{{champ}}` + markup DSFR libre, intentionnel — documenté dans le code).
- L'attribut `data='…'` reste en single-quoted car `JSON.stringify` produit des `"` internes.

### Tests

- [x] `npm run test:run` : **3699/3699 verts**
- [x] `npm run typecheck` : OK
- [x] `npx prettier --check` sur le fichier modifié : OK
- [x] CI verte
- [x] Après merge : re-scan CodeQL → alerte #63 fermée automatiquement

### Refs

- Rapport de recette #482 (bugs post-refonte builder-carto — celui-ci est le seul XSS remonté par CodeQL)
- CodeQL rule docs : https://codeql.github.com/codeql-query-help/javascript/js-html-constructed-from-input/

🤖 Generated with [Claude Code](https://claude.com/claude-code)